### PR TITLE
feat: Implement shared repository interfaces and use cases

### DIFF
--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/AgentRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/AgentRepositoryImpl.kt
@@ -3,8 +3,10 @@ package com.orchestradashboard.shared.data.repository
 import com.orchestradashboard.shared.data.mapper.AgentMapper
 import com.orchestradashboard.shared.data.network.DashboardApiClient
 import com.orchestradashboard.shared.domain.model.Agent
+import com.orchestradashboard.shared.domain.model.Agent.AgentStatus
 import com.orchestradashboard.shared.domain.repository.AgentRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
 /**
@@ -26,6 +28,11 @@ class AgentRepositoryImpl(
         return apiClient.fetchAgent(agentId)
             .mapCatching { dto -> agentMapper.toDomain(dto) }
     }
+
+    override suspend fun getAgentsByStatus(status: AgentStatus): Result<List<Agent>> =
+        runCatching {
+            observeAgents().first().filter { it.status == status }
+        }
 
     override suspend fun registerAgent(agent: Agent): Result<Agent> {
         return apiClient.registerAgent(agent)

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/AgentRepository.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/AgentRepository.kt
@@ -1,6 +1,7 @@
 package com.orchestradashboard.shared.domain.repository
 
 import com.orchestradashboard.shared.domain.model.Agent
+import com.orchestradashboard.shared.domain.model.Agent.AgentStatus
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -22,6 +23,14 @@ interface AgentRepository {
      * @return [Result] containing the agent on success, or an exception on failure
      */
     suspend fun getAgent(agentId: String): Result<Agent>
+
+    /**
+     * Retrieves agents filtered by their operational status.
+     *
+     * @param status The status to filter by
+     * @return [Result] containing the matching agents on success
+     */
+    suspend fun getAgentsByStatus(status: AgentStatus): Result<List<Agent>>
 
     /**
      * Registers a new agent with the monitoring system.

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/EventRepository.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/EventRepository.kt
@@ -1,0 +1,26 @@
+package com.orchestradashboard.shared.domain.repository
+
+import com.orchestradashboard.shared.domain.model.AgentEvent
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Repository interface for accessing and observing agent events.
+ * Streaming operations return [Flow]; one-shot operations return [Result].
+ */
+interface EventRepository {
+    /**
+     * Observes events for a specific agent in real-time.
+     *
+     * @param agentId The agent whose events to observe
+     * @return [Flow] of event lists, updated on changes
+     */
+    fun observeEvents(agentId: String): Flow<List<AgentEvent>>
+
+    /**
+     * Retrieves the most recent events across all agents.
+     *
+     * @param limit Maximum number of events to return
+     * @return [Result] containing the events on success, or an exception on failure
+     */
+    suspend fun getRecentEvents(limit: Int): Result<List<AgentEvent>>
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/PipelineRepository.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/PipelineRepository.kt
@@ -1,0 +1,33 @@
+package com.orchestradashboard.shared.domain.repository
+
+import com.orchestradashboard.shared.domain.model.PipelineRun
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Repository interface for accessing and observing pipeline runs.
+ * Streaming operations return [Flow]; one-shot operations return [Result].
+ */
+interface PipelineRepository {
+    /**
+     * Observes pipeline runs for a specific agent.
+     *
+     * @param agentId The agent whose pipeline runs to observe
+     * @return [Flow] of pipeline run lists, updated on changes
+     */
+    fun observePipelineRuns(agentId: String): Flow<List<PipelineRun>>
+
+    /**
+     * Retrieves a specific pipeline run by its unique identifier.
+     *
+     * @param runId Unique pipeline run identifier
+     * @return [Result] containing the pipeline run on success, or an exception on failure
+     */
+    suspend fun getPipelineRun(runId: String): Result<PipelineRun>
+
+    /**
+     * Observes all currently active (running or queued) pipelines.
+     *
+     * @return [Flow] of active pipeline run lists, updated on changes
+     */
+    fun observeActivePipelines(): Flow<List<PipelineRun>>
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/GetPipelineRunUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/GetPipelineRunUseCase.kt
@@ -1,0 +1,21 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.PipelineRun
+import com.orchestradashboard.shared.domain.repository.PipelineRepository
+
+/**
+ * Retrieves a single pipeline run by ID.
+ *
+ * @param pipelineRepository Data source for pipeline information
+ */
+class GetPipelineRunUseCase(
+    private val pipelineRepository: PipelineRepository,
+) {
+    /**
+     * Invokes the use case.
+     *
+     * @param runId Unique pipeline run identifier
+     * @return [Result] containing the pipeline run on success, or an exception on failure
+     */
+    suspend operator fun invoke(runId: String): Result<PipelineRun> = pipelineRepository.getPipelineRun(runId)
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveActivePipelinesUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveActivePipelinesUseCase.kt
@@ -1,0 +1,21 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.PipelineRun
+import com.orchestradashboard.shared.domain.repository.PipelineRepository
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Observes all currently active pipeline runs.
+ *
+ * @param pipelineRepository Data source for pipeline information
+ */
+class ObserveActivePipelinesUseCase(
+    private val pipelineRepository: PipelineRepository,
+) {
+    /**
+     * Invokes the use case.
+     *
+     * @return [Flow] emitting updated lists of active pipeline runs
+     */
+    operator fun invoke(): Flow<List<PipelineRun>> = pipelineRepository.observeActivePipelines()
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveEventsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveEventsUseCase.kt
@@ -1,0 +1,22 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.AgentEvent
+import com.orchestradashboard.shared.domain.repository.EventRepository
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Observes events for a specific agent in real-time.
+ *
+ * @param eventRepository Data source for event information
+ */
+class ObserveEventsUseCase(
+    private val eventRepository: EventRepository,
+) {
+    /**
+     * Invokes the use case.
+     *
+     * @param agentId The agent whose events to observe
+     * @return [Flow] emitting updated event lists for the specified agent
+     */
+    operator fun invoke(agentId: String): Flow<List<AgentEvent>> = eventRepository.observeEvents(agentId)
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/FakeAgentRepository.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/FakeAgentRepository.kt
@@ -1,0 +1,24 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.Agent
+import com.orchestradashboard.shared.domain.repository.AgentRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class FakeAgentRepository(
+    private val agents: List<Agent> = emptyList(),
+) : AgentRepository {
+    override fun observeAgents(): Flow<List<Agent>> = flowOf(agents)
+
+    override suspend fun getAgent(agentId: String): Result<Agent> =
+        agents.find { it.id == agentId }
+            ?.let { Result.success(it) }
+            ?: Result.failure(NoSuchElementException("Agent $agentId not found"))
+
+    override suspend fun getAgentsByStatus(status: Agent.AgentStatus): Result<List<Agent>> =
+        Result.success(agents.filter { it.status == status })
+
+    override suspend fun registerAgent(agent: Agent): Result<Agent> = Result.success(agent)
+
+    override suspend fun deregisterAgent(agentId: String): Result<Unit> = Result.success(Unit)
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/FakeEventRepository.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/FakeEventRepository.kt
@@ -1,0 +1,15 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.AgentEvent
+import com.orchestradashboard.shared.domain.repository.EventRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class FakeEventRepository(
+    private val events: List<AgentEvent> = emptyList(),
+) : EventRepository {
+    override fun observeEvents(agentId: String): Flow<List<AgentEvent>> = flowOf(events.filter { it.agentId == agentId })
+
+    override suspend fun getRecentEvents(limit: Int): Result<List<AgentEvent>> =
+        Result.success(events.sortedByDescending { it.timestamp }.take(limit))
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/FakePipelineRepository.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/FakePipelineRepository.kt
@@ -1,0 +1,25 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.PipelineRun
+import com.orchestradashboard.shared.domain.model.PipelineRunStatus
+import com.orchestradashboard.shared.domain.repository.PipelineRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class FakePipelineRepository(
+    private val pipelineRuns: List<PipelineRun> = emptyList(),
+) : PipelineRepository {
+    override fun observePipelineRuns(agentId: String): Flow<List<PipelineRun>> = flowOf(pipelineRuns.filter { it.agentId == agentId })
+
+    override suspend fun getPipelineRun(runId: String): Result<PipelineRun> =
+        pipelineRuns.find { it.id == runId }
+            ?.let { Result.success(it) }
+            ?: Result.failure(NoSuchElementException("PipelineRun $runId not found"))
+
+    override fun observeActivePipelines(): Flow<List<PipelineRun>> =
+        flowOf(
+            pipelineRuns.filter {
+                it.status == PipelineRunStatus.RUNNING || it.status == PipelineRunStatus.QUEUED
+            },
+        )
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/GetAgentUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/GetAgentUseCaseTest.kt
@@ -1,0 +1,35 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.Agent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GetAgentUseCaseTest {
+    private val agents =
+        listOf(
+            Agent("1", "Alpha", Agent.AgentType.WORKER, Agent.AgentStatus.RUNNING, 100L),
+            Agent("2", "Beta", Agent.AgentType.PLANNER, Agent.AgentStatus.IDLE, 200L),
+        )
+    private val repository = FakeAgentRepository(agents)
+    private val useCase = GetAgentUseCase(repository)
+
+    @Test
+    fun `invoke returns success result for existing agent`() =
+        runTest {
+            val result = useCase("1")
+
+            assertTrue(result.isSuccess)
+            assertEquals(agents[0], result.getOrNull())
+        }
+
+    @Test
+    fun `invoke returns failure result for non-existent agent`() =
+        runTest {
+            val result = useCase("nonexistent")
+
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull() is NoSuchElementException)
+        }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveActivePipelinesUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveActivePipelinesUseCaseTest.kt
@@ -1,0 +1,70 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.PipelineRun
+import com.orchestradashboard.shared.domain.model.PipelineRunStatus
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ObserveActivePipelinesUseCaseTest {
+    private val runningPipeline =
+        PipelineRun(
+            id = "run-1",
+            agentId = "agent-1",
+            pipelineName = "Build",
+            status = PipelineRunStatus.RUNNING,
+            steps = emptyList(),
+            startedAt = 1000L,
+            finishedAt = null,
+            triggerInfo = "manual",
+        )
+    private val queuedPipeline =
+        PipelineRun(
+            id = "run-2",
+            agentId = "agent-2",
+            pipelineName = "Deploy",
+            status = PipelineRunStatus.QUEUED,
+            steps = emptyList(),
+            startedAt = 2000L,
+            finishedAt = null,
+            triggerInfo = "auto",
+        )
+    private val passedPipeline =
+        PipelineRun(
+            id = "run-3",
+            agentId = "agent-1",
+            pipelineName = "Test",
+            status = PipelineRunStatus.PASSED,
+            steps = emptyList(),
+            startedAt = 500L,
+            finishedAt = 900L,
+            triggerInfo = "commit",
+        )
+
+    @Test
+    fun `invoke returns only active pipelines`() =
+        runTest {
+            val repository =
+                FakePipelineRepository(listOf(runningPipeline, queuedPipeline, passedPipeline))
+            val useCase = ObserveActivePipelinesUseCase(repository)
+
+            val result = useCase().first()
+
+            assertEquals(2, result.size)
+            assertTrue(result.contains(runningPipeline))
+            assertTrue(result.contains(queuedPipeline))
+        }
+
+    @Test
+    fun `invoke returns empty list when no active pipelines`() =
+        runTest {
+            val repository = FakePipelineRepository(listOf(passedPipeline))
+            val useCase = ObserveActivePipelinesUseCase(repository)
+
+            val result = useCase().first()
+
+            assertTrue(result.isEmpty())
+        }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveAgentsUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveAgentsUseCaseTest.kt
@@ -1,40 +1,13 @@
 package com.orchestradashboard.shared.domain.usecase
 
 import com.orchestradashboard.shared.domain.model.Agent
-import com.orchestradashboard.shared.domain.repository.AgentRepository
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class ObserveAgentsUseCaseTest {
-    // ─── Fake implementation ───────────────────────────────────
-
-    private class FakeAgentRepository(
-        private val agents: List<Agent> = emptyList(),
-        private val error: Throwable? = null,
-    ) : AgentRepository {
-        override fun observeAgents(): Flow<List<Agent>> {
-            if (error != null) throw error
-            return flowOf(agents)
-        }
-
-        override suspend fun getAgent(agentId: String): Result<Agent> {
-            return agents.find { it.id == agentId }
-                ?.let { Result.success(it) }
-                ?: Result.failure(NoSuchElementException("Agent $agentId not found"))
-        }
-
-        override suspend fun registerAgent(agent: Agent): Result<Agent> = Result.success(agent)
-
-        override suspend fun deregisterAgent(agentId: String): Result<Unit> = Result.success(Unit)
-    }
-
-    // ─── Tests ─────────────────────────────────────────────────
-
     @Test
     fun `invoke returns flow emitting the agent list`() =
         runTest {

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveEventsUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveEventsUseCaseTest.kt
@@ -1,0 +1,41 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.AgentEvent
+import com.orchestradashboard.shared.domain.model.EventType
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ObserveEventsUseCaseTest {
+    private val events =
+        listOf(
+            AgentEvent("e1", "agent-1", EventType.HEARTBEAT, "{}", 1000L),
+            AgentEvent("e2", "agent-1", EventType.STATUS_CHANGE, "{\"status\":\"RUNNING\"}", 2000L),
+            AgentEvent("e3", "agent-2", EventType.ERROR, "{\"msg\":\"timeout\"}", 3000L),
+        )
+
+    @Test
+    fun `invoke returns events filtered by agent ID`() =
+        runTest {
+            val repository = FakeEventRepository(events)
+            val useCase = ObserveEventsUseCase(repository)
+
+            val result = useCase("agent-1").first()
+
+            assertEquals(2, result.size)
+            assertTrue(result.all { it.agentId == "agent-1" })
+        }
+
+    @Test
+    fun `invoke returns empty list for agent with no events`() =
+        runTest {
+            val repository = FakeEventRepository(events)
+            val useCase = ObserveEventsUseCase(repository)
+
+            val result = useCase("agent-999").first()
+
+            assertTrue(result.isEmpty())
+        }
+}


### PR DESCRIPTION
Closes #3

## Design
### Implementation Design

#### 1. Files to Modify/Create

**New Files to Create:**

- **Repositories:**
  - `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/AgentRepository.kt`
  - `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/PipelineRepository.kt`
  - `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/EventRepository.kt`

- **Use Cases:**
  - `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveAgentsUseCase.kt`
  - `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/GetAgentUseCase.kt`
  - `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveActivePipelinesUseCase.kt`
  - `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/GetPipelineRunUseCase.kt`
  - `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveEventsUseCase.kt`

- **Tests:**
  - `shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/FakeAgentRepository.kt`
  - `shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/FakePipelineRepository.kt`
  - `shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveAgentsUseCaseTest.kt`
  - `shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/GetAgentUseCaseTest.kt`
  - `shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveActivePipelinesUseCaseT

_(truncated)_

## Changed Files (14)
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/AgentRepositoryImpl.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/AgentRepository.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/EventRepository.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/PipelineRepository.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/GetPipelineRunUseCase.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveActivePipelinesUseCase.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveEventsUseCase.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/FakeAgentRepository.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/FakeEventRepository.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/FakePipelineRepository.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/GetAgentUseCaseTest.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveActivePipelinesUseCaseTest.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveAgentsUseCaseTest.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveEventsUseCaseTest.kt`

## Review
Now I have a complete picture. Here's my review:

## Code Review — Issue #3: Repository Interfaces and Use Cases

### Checklist against Issue Requirements

**Repository Interfaces:**
- `AgentRepository` — `getAgentsByStatus()` added correctly. `observeAgents()` and `getAgent()` pre-existed.
- `PipelineRepository` — All 3 methods present and correct.
- `EventRepository` — Both methods present and correct.
- All interfaces use only `Flow`, `Result`, and domain types — no framework leakage.

**Use Cases:**
- `ObserveAgentsUseCase` — pre-existed, correct.
- `GetAgentUseCase` — correct `suspend operator fun invoke()`.
- `ObserveActivePipelinesUseCase` — correct.
- `GetPipelineRunUseCase` — correct.
- `ObserveEventsUseCase` — correct.
- All use cases follow single-responsibility with `operator f

_(truncated)_

## AI Audit: PASS
[AUDIT: PASS]