### PR TITLE
feat: Add PipelineRun and AgentEvent server endpoints with relational persistence

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -8,6 +8,8 @@ naming:
       - "**/*Screen*"
       - "**/*Component*"
       - "**/*Composable*"
+      - "**/test/**"
+      - "**/androidTest/**"
 
 style:
   MagicNumber:

--- a/server/src/main/kotlin/com/orchestradashboard/server/controller/EventController.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/controller/EventController.kt
@@ -1,0 +1,34 @@
+package com.orchestradashboard.server.controller
+
+import com.orchestradashboard.server.model.AgentEventResponse
+import com.orchestradashboard.server.model.CreateEventRequest
+import com.orchestradashboard.server.service.EventService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/events")
+class EventController(
+    private val eventService: EventService,
+) {
+    @GetMapping
+    fun getEvents(
+        @RequestParam agentId: String?,
+        @RequestParam(defaultValue = "50") limit: Int,
+    ): ResponseEntity<List<AgentEventResponse>> = ResponseEntity.ok(eventService.getRecentEvents(agentId, limit.coerceAtMost(100)))
+
+    @PostMapping
+    fun createEvent(
+        @RequestBody request: CreateEventRequest,
+    ): ResponseEntity<AgentEventResponse> = ResponseEntity.status(HttpStatus.CREATED).body(eventService.createEvent(request))
+
+    @ExceptionHandler(NoSuchElementException::class)
+    fun handleNotFound(ex: NoSuchElementException): ResponseEntity<Void> = ResponseEntity.notFound().build()
+}

--- a/server/src/main/kotlin/com/orchestradashboard/server/controller/PipelineController.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/controller/PipelineController.kt
@@ -1,0 +1,54 @@
+package com.orchestradashboard.server.controller
+
+import com.orchestradashboard.server.model.CreatePipelineRunRequest
+import com.orchestradashboard.server.model.PipelineRunResponse
+import com.orchestradashboard.server.model.UpdateStatusRequest
+import com.orchestradashboard.server.service.PipelineService
+import org.springframework.data.domain.PageRequest
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/pipelines")
+class PipelineController(
+    private val pipelineService: PipelineService,
+) {
+    @GetMapping
+    fun getPipelines(
+        @RequestParam agentId: String?,
+        @RequestParam status: String?,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int,
+    ): ResponseEntity<List<PipelineRunResponse>> {
+        val pageable = PageRequest.of(page, size.coerceAtMost(100))
+        return ResponseEntity.ok(pipelineService.getAllPipelineRuns(agentId, status, pageable))
+    }
+
+    @GetMapping("/{id}")
+    fun getPipeline(
+        @PathVariable id: String,
+    ): ResponseEntity<PipelineRunResponse> = ResponseEntity.ok(pipelineService.getPipelineRun(id))
+
+    @PostMapping
+    fun createPipeline(
+        @RequestBody request: CreatePipelineRunRequest,
+    ): ResponseEntity<PipelineRunResponse> = ResponseEntity.status(HttpStatus.CREATED).body(pipelineService.createPipelineRun(request))
+
+    @PutMapping("/{id}/status")
+    fun updateStatus(
+        @PathVariable id: String,
+        @RequestBody request: UpdateStatusRequest,
+    ): ResponseEntity<PipelineRunResponse> = ResponseEntity.ok(pipelineService.updateStatus(id, request.status))
+
+    @ExceptionHandler(NoSuchElementException::class)
+    fun handleNotFound(ex: NoSuchElementException): ResponseEntity<Void> = ResponseEntity.notFound().build()
+}

--- a/server/src/main/kotlin/com/orchestradashboard/server/model/AgentEventEntity.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/model/AgentEventEntity.kt
@@ -1,0 +1,29 @@
+package com.orchestradashboard.server.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity
+@Table(name = "agent_events")
+data class AgentEventEntity(
+    @Id
+    @Column(length = 36)
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "agent_id", nullable = false, length = 36)
+    val agentId: String = "",
+    @Column(nullable = false)
+    val type: String = "",
+    @Column(columnDefinition = "TEXT")
+    val payload: String = "",
+    @Column(nullable = false)
+    val timestamp: Long = 0L,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "agent_id", insertable = false, updatable = false)
+    val agent: AgentEntity? = null,
+)

--- a/server/src/main/kotlin/com/orchestradashboard/server/model/AgentEventMapper.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/model/AgentEventMapper.kt
@@ -1,0 +1,17 @@
+package com.orchestradashboard.server.model
+
+import org.springframework.stereotype.Component
+
+@Component
+class AgentEventMapper {
+    fun toResponse(entity: AgentEventEntity): AgentEventResponse =
+        AgentEventResponse(
+            id = entity.id,
+            agentId = entity.agentId,
+            type = entity.type,
+            payload = entity.payload,
+            timestamp = entity.timestamp,
+        )
+
+    fun toResponseList(entities: List<AgentEventEntity>): List<AgentEventResponse> = entities.map { toResponse(it) }
+}

--- a/server/src/main/kotlin/com/orchestradashboard/server/model/AgentEventResponse.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/model/AgentEventResponse.kt
@@ -1,0 +1,17 @@
+package com.orchestradashboard.server.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class AgentEventResponse(
+    val id: String,
+    @JsonProperty("agent_id") val agentId: String,
+    val type: String,
+    val payload: String,
+    val timestamp: Long,
+)
+
+data class CreateEventRequest(
+    @JsonProperty("agent_id") val agentId: String,
+    val type: String,
+    val payload: String = "",
+)

--- a/server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunEntity.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunEntity.kt
@@ -1,0 +1,35 @@
+package com.orchestradashboard.server.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity
+@Table(name = "pipeline_runs")
+data class PipelineRunEntity(
+    @Id
+    @Column(length = 36)
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "agent_id", nullable = false, length = 36)
+    val agentId: String = "",
+    @Column(name = "pipeline_name", nullable = false)
+    val pipelineName: String = "",
+    @Column(nullable = false)
+    val status: String = "QUEUED",
+    @Column(columnDefinition = "TEXT")
+    val steps: String = "[]",
+    @Column(name = "started_at", nullable = false)
+    val startedAt: Long = 0L,
+    @Column(name = "finished_at")
+    val finishedAt: Long? = null,
+    @Column(name = "trigger_info")
+    val triggerInfo: String = "",
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "agent_id", insertable = false, updatable = false)
+    val agent: AgentEntity? = null,
+)

--- a/server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunMapper.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunMapper.kt
@@ -1,0 +1,37 @@
+package com.orchestradashboard.server.model
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.springframework.stereotype.Component
+
+@Component
+class PipelineRunMapper {
+    private val objectMapper = jacksonObjectMapper()
+
+    fun toResponse(entity: PipelineRunEntity): PipelineRunResponse =
+        PipelineRunResponse(
+            id = entity.id,
+            agentId = entity.agentId,
+            pipelineName = entity.pipelineName,
+            status = entity.status,
+            steps = deserializeSteps(entity.steps),
+            startedAt = entity.startedAt,
+            finishedAt = entity.finishedAt,
+            triggerInfo = entity.triggerInfo,
+        )
+
+    fun toResponseList(entities: List<PipelineRunEntity>): List<PipelineRunResponse> = entities.map { toResponse(it) }
+
+    fun deserializeSteps(json: String): List<PipelineStepResponse> =
+        if (json.isBlank()) {
+            emptyList()
+        } else {
+            try {
+                objectMapper.readValue(json, object : TypeReference<List<PipelineStepResponse>>() {})
+            } catch (_: Exception) {
+                emptyList()
+            }
+        }
+
+    fun serializeSteps(steps: List<PipelineStepResponse>): String = objectMapper.writeValueAsString(steps)
+}

--- a/server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunResponse.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunResponse.kt
@@ -1,0 +1,30 @@
+package com.orchestradashboard.server.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class PipelineRunResponse(
+    val id: String,
+    @JsonProperty("agent_id") val agentId: String,
+    @JsonProperty("pipeline_name") val pipelineName: String,
+    val status: String,
+    val steps: List<PipelineStepResponse>,
+    @JsonProperty("started_at") val startedAt: Long,
+    @JsonProperty("finished_at") val finishedAt: Long?,
+    @JsonProperty("trigger_info") val triggerInfo: String,
+)
+
+data class PipelineStepResponse(
+    val name: String,
+    val status: String,
+    val detail: String,
+    @JsonProperty("elapsed_ms") val elapsedMs: Long,
+)
+
+data class CreatePipelineRunRequest(
+    @JsonProperty("agent_id") val agentId: String,
+    @JsonProperty("pipeline_name") val pipelineName: String,
+    val steps: List<PipelineStepResponse> = emptyList(),
+    @JsonProperty("trigger_info") val triggerInfo: String = "",
+)
+
+data class UpdateStatusRequest(val status: String)

--- a/server/src/main/kotlin/com/orchestradashboard/server/repository/AgentEventJpaRepository.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/repository/AgentEventJpaRepository.kt
@@ -1,0 +1,12 @@
+package com.orchestradashboard.server.repository
+
+import com.orchestradashboard.server.model.AgentEventEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface AgentEventJpaRepository : JpaRepository<AgentEventEntity, String> {
+    fun findByAgentIdOrderByTimestampDesc(agentId: String): List<AgentEventEntity>
+
+    fun findTop50ByOrderByTimestampDesc(): List<AgentEventEntity>
+}

--- a/server/src/main/kotlin/com/orchestradashboard/server/repository/PipelineRunJpaRepository.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/repository/PipelineRunJpaRepository.kt
@@ -1,0 +1,26 @@
+package com.orchestradashboard.server.repository
+
+import com.orchestradashboard.server.model.PipelineRunEntity
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PipelineRunJpaRepository : JpaRepository<PipelineRunEntity, String> {
+    fun findByAgentId(
+        agentId: String,
+        pageable: Pageable,
+    ): Page<PipelineRunEntity>
+
+    fun findByStatus(
+        status: String,
+        pageable: Pageable,
+    ): Page<PipelineRunEntity>
+
+    fun findByAgentIdAndStatus(
+        agentId: String,
+        status: String,
+        pageable: Pageable,
+    ): Page<PipelineRunEntity>
+}

--- a/server/src/main/kotlin/com/orchestradashboard/server/service/EventService.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/service/EventService.kt
@@ -1,0 +1,46 @@
+package com.orchestradashboard.server.service
+
+import com.orchestradashboard.server.model.AgentEventEntity
+import com.orchestradashboard.server.model.AgentEventMapper
+import com.orchestradashboard.server.model.AgentEventResponse
+import com.orchestradashboard.server.model.CreateEventRequest
+import com.orchestradashboard.server.repository.AgentEventJpaRepository
+import com.orchestradashboard.server.repository.AgentJpaRepository
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class EventService(
+    private val eventRepository: AgentEventJpaRepository,
+    private val agentRepository: AgentJpaRepository,
+    private val mapper: AgentEventMapper,
+) {
+    fun getRecentEvents(
+        agentId: String?,
+        limit: Int,
+    ): List<AgentEventResponse> {
+        val clamped = limit.coerceAtMost(100)
+        val entities =
+            if (agentId != null) {
+                eventRepository.findByAgentIdOrderByTimestampDesc(agentId)
+            } else {
+                eventRepository.findTop50ByOrderByTimestampDesc()
+            }
+        return mapper.toResponseList(entities.take(clamped))
+    }
+
+    fun createEvent(request: CreateEventRequest): AgentEventResponse {
+        if (!agentRepository.existsById(request.agentId)) {
+            throw NoSuchElementException("Agent with id '${request.agentId}' not found")
+        }
+        val entity =
+            AgentEventEntity(
+                id = UUID.randomUUID().toString(),
+                agentId = request.agentId,
+                type = request.type,
+                payload = request.payload,
+                timestamp = System.currentTimeMillis(),
+            )
+        return mapper.toResponse(eventRepository.save(entity))
+    }
+}

--- a/server/src/main/kotlin/com/orchestradashboard/server/service/PipelineService.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/service/PipelineService.kt
@@ -1,0 +1,73 @@
+package com.orchestradashboard.server.service
+
+import com.orchestradashboard.server.model.CreatePipelineRunRequest
+import com.orchestradashboard.server.model.PipelineRunEntity
+import com.orchestradashboard.server.model.PipelineRunMapper
+import com.orchestradashboard.server.model.PipelineRunResponse
+import com.orchestradashboard.server.repository.AgentJpaRepository
+import com.orchestradashboard.server.repository.PipelineRunJpaRepository
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class PipelineService(
+    private val pipelineRepository: PipelineRunJpaRepository,
+    private val agentRepository: AgentJpaRepository,
+    private val mapper: PipelineRunMapper,
+) {
+    companion object {
+        private val TERMINAL_STATUSES = setOf("PASSED", "FAILED", "CANCELLED")
+    }
+
+    fun getAllPipelineRuns(
+        agentId: String?,
+        status: String?,
+        pageable: Pageable,
+    ): List<PipelineRunResponse> {
+        val page =
+            when {
+                agentId != null && status != null -> pipelineRepository.findByAgentIdAndStatus(agentId, status, pageable)
+                agentId != null -> pipelineRepository.findByAgentId(agentId, pageable)
+                status != null -> pipelineRepository.findByStatus(status, pageable)
+                else -> pipelineRepository.findAll(pageable)
+            }
+        return mapper.toResponseList(page.content)
+    }
+
+    fun getPipelineRun(id: String): PipelineRunResponse {
+        val entity =
+            pipelineRepository.findById(id)
+                .orElseThrow { NoSuchElementException("PipelineRun with id '$id' not found") }
+        return mapper.toResponse(entity)
+    }
+
+    fun createPipelineRun(request: CreatePipelineRunRequest): PipelineRunResponse {
+        if (!agentRepository.existsById(request.agentId)) {
+            throw NoSuchElementException("Agent with id '${request.agentId}' not found")
+        }
+        val entity =
+            PipelineRunEntity(
+                id = UUID.randomUUID().toString(),
+                agentId = request.agentId,
+                pipelineName = request.pipelineName,
+                status = "QUEUED",
+                steps = mapper.serializeSteps(request.steps),
+                startedAt = System.currentTimeMillis(),
+                triggerInfo = request.triggerInfo,
+            )
+        return mapper.toResponse(pipelineRepository.save(entity))
+    }
+
+    fun updateStatus(
+        id: String,
+        status: String,
+    ): PipelineRunResponse {
+        val existing =
+            pipelineRepository.findById(id)
+                .orElseThrow { NoSuchElementException("PipelineRun with id '$id' not found") }
+        val finishedAt = if (status in TERMINAL_STATUSES) System.currentTimeMillis() else existing.finishedAt
+        val updated = existing.copy(status = status, finishedAt = finishedAt)
+        return mapper.toResponse(pipelineRepository.save(updated))
+    }
+}

--- a/server/src/test/kotlin/com/orchestradashboard/server/controller/EventControllerTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/controller/EventControllerTest.kt
@@ -1,0 +1,100 @@
+package com.orchestradashboard.server.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.orchestradashboard.server.config.SecurityConfig
+import com.orchestradashboard.server.model.AgentEventResponse
+import com.orchestradashboard.server.model.CreateEventRequest
+import com.orchestradashboard.server.service.EventService
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import org.mockito.Mockito.`when` as whenever
+
+@WebMvcTest(EventController::class)
+@Import(SecurityConfig::class)
+class EventControllerTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @MockBean
+    lateinit var eventService: EventService
+
+    private val sampleResponse =
+        AgentEventResponse(
+            id = "evt-1",
+            agentId = "agent-1",
+            type = "STATUS_CHANGE",
+            payload = """{"from":"IDLE","to":"RUNNING"}""",
+            timestamp = 1700000000L,
+        )
+
+    @Test
+    fun `GET api-v1-events returns 200 with event list`() {
+        whenever(eventService.getRecentEvents(null, 50)).thenReturn(listOf(sampleResponse))
+
+        mockMvc.get("/api/v1/events")
+            .andExpect {
+                status { isOk() }
+                content { contentType(MediaType.APPLICATION_JSON) }
+                jsonPath("$[0].id") { value("evt-1") }
+                jsonPath("$[0].type") { value("STATUS_CHANGE") }
+            }
+    }
+
+    @Test
+    fun `GET api-v1-events with agentId param returns filtered list`() {
+        whenever(eventService.getRecentEvents("agent-1", 50)).thenReturn(listOf(sampleResponse))
+
+        mockMvc.get("/api/v1/events?agentId=agent-1")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$[0].agent_id") { value("agent-1") }
+            }
+    }
+
+    @Test
+    fun `GET api-v1-events with limit param respects limit`() {
+        whenever(eventService.getRecentEvents(null, 10)).thenReturn(listOf(sampleResponse))
+
+        mockMvc.get("/api/v1/events?limit=10")
+            .andExpect {
+                status { isOk() }
+            }
+    }
+
+    @Test
+    fun `POST api-v1-events returns 201 on creation`() {
+        val request = CreateEventRequest(agentId = "agent-1", type = "STATUS_CHANGE", payload = "{}")
+        whenever(eventService.createEvent(request)).thenReturn(sampleResponse)
+
+        mockMvc.post("/api/v1/events") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(request)
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.id") { value("evt-1") }
+        }
+    }
+
+    @Test
+    fun `POST api-v1-events returns 404 when agent not found`() {
+        val request = CreateEventRequest(agentId = "missing", type = "ERROR")
+        whenever(eventService.createEvent(request)).thenThrow(NoSuchElementException("Agent not found"))
+
+        mockMvc.post("/api/v1/events") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(request)
+        }.andExpect {
+            status { isNotFound() }
+        }
+    }
+}

--- a/server/src/test/kotlin/com/orchestradashboard/server/controller/PipelineControllerTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/controller/PipelineControllerTest.kt
@@ -1,0 +1,177 @@
+package com.orchestradashboard.server.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.orchestradashboard.server.config.SecurityConfig
+import com.orchestradashboard.server.model.CreatePipelineRunRequest
+import com.orchestradashboard.server.model.PipelineRunResponse
+import com.orchestradashboard.server.model.PipelineStepResponse
+import com.orchestradashboard.server.model.UpdateStatusRequest
+import com.orchestradashboard.server.service.PipelineService
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.put
+import org.mockito.Mockito.`when` as whenever
+
+@WebMvcTest(PipelineController::class)
+@Import(SecurityConfig::class)
+class PipelineControllerTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @MockBean
+    lateinit var pipelineService: PipelineService
+
+    private val sampleResponse =
+        PipelineRunResponse(
+            id = "run-1",
+            agentId = "agent-1",
+            pipelineName = "CI Pipeline",
+            status = "RUNNING",
+            steps = listOf(PipelineStepResponse(name = "Build", status = "PASSED", detail = "OK", elapsedMs = 1200L)),
+            startedAt = 1700000000L,
+            finishedAt = null,
+            triggerInfo = "manual",
+        )
+
+    @Test
+    fun `GET api-v1-pipelines returns 200 with pipeline list`() {
+        whenever(pipelineService.getAllPipelineRuns(eq(null), eq(null), any())).thenReturn(listOf(sampleResponse))
+
+        mockMvc.get("/api/v1/pipelines")
+            .andExpect {
+                status { isOk() }
+                content { contentType(MediaType.APPLICATION_JSON) }
+                jsonPath("$[0].id") { value("run-1") }
+                jsonPath("$[0].status") { value("RUNNING") }
+            }
+    }
+
+    @Test
+    fun `GET api-v1-pipelines with agentId param returns filtered list`() {
+        whenever(pipelineService.getAllPipelineRuns(eq("agent-1"), eq(null), any())).thenReturn(listOf(sampleResponse))
+
+        mockMvc.get("/api/v1/pipelines?agentId=agent-1")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$[0].agent_id") { value("agent-1") }
+            }
+    }
+
+    @Test
+    fun `GET api-v1-pipelines with status param returns filtered list`() {
+        whenever(pipelineService.getAllPipelineRuns(eq(null), eq("RUNNING"), any())).thenReturn(listOf(sampleResponse))
+
+        mockMvc.get("/api/v1/pipelines?status=RUNNING")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$[0].status") { value("RUNNING") }
+            }
+    }
+
+    @Test
+    fun `GET api-v1-pipelines with both params returns combined filter`() {
+        whenever(pipelineService.getAllPipelineRuns(eq("agent-1"), eq("RUNNING"), any())).thenReturn(listOf(sampleResponse))
+
+        mockMvc.get("/api/v1/pipelines?agentId=agent-1&status=RUNNING")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$[0].id") { value("run-1") }
+            }
+    }
+
+    @Test
+    fun `GET api-v1-pipelines supports pagination params`() {
+        whenever(pipelineService.getAllPipelineRuns(eq(null), eq(null), any())).thenReturn(emptyList())
+
+        mockMvc.get("/api/v1/pipelines?page=1&size=10")
+            .andExpect {
+                status { isOk() }
+            }
+    }
+
+    @Test
+    fun `GET api-v1-pipelines-id returns 200 when found`() {
+        whenever(pipelineService.getPipelineRun("run-1")).thenReturn(sampleResponse)
+
+        mockMvc.get("/api/v1/pipelines/run-1")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.pipeline_name") { value("CI Pipeline") }
+            }
+    }
+
+    @Test
+    fun `GET api-v1-pipelines-id returns 404 when not found`() {
+        whenever(pipelineService.getPipelineRun("missing")).thenThrow(NoSuchElementException("Not found"))
+
+        mockMvc.get("/api/v1/pipelines/missing")
+            .andExpect {
+                status { isNotFound() }
+            }
+    }
+
+    @Test
+    fun `POST api-v1-pipelines returns 201 on creation`() {
+        val request = CreatePipelineRunRequest(agentId = "agent-1", pipelineName = "CI Pipeline", triggerInfo = "manual")
+        whenever(pipelineService.createPipelineRun(request)).thenReturn(sampleResponse)
+
+        mockMvc.post("/api/v1/pipelines") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(request)
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.id") { value("run-1") }
+        }
+    }
+
+    @Test
+    fun `POST api-v1-pipelines returns 404 when agent not found`() {
+        val request = CreatePipelineRunRequest(agentId = "missing", pipelineName = "Pipeline")
+        whenever(pipelineService.createPipelineRun(request)).thenThrow(NoSuchElementException("Agent not found"))
+
+        mockMvc.post("/api/v1/pipelines") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(request)
+        }.andExpect {
+            status { isNotFound() }
+        }
+    }
+
+    @Test
+    fun `PUT api-v1-pipelines-id-status returns 200`() {
+        val updated = sampleResponse.copy(status = "PASSED", finishedAt = 1700001000L)
+        whenever(pipelineService.updateStatus("run-1", "PASSED")).thenReturn(updated)
+
+        mockMvc.put("/api/v1/pipelines/run-1/status") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(UpdateStatusRequest(status = "PASSED"))
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.status") { value("PASSED") }
+        }
+    }
+
+    @Test
+    fun `PUT api-v1-pipelines-id-status returns 404 when not found`() {
+        whenever(pipelineService.updateStatus("missing", "PASSED")).thenThrow(NoSuchElementException("Not found"))
+
+        mockMvc.put("/api/v1/pipelines/missing/status") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(UpdateStatusRequest(status = "PASSED"))
+        }.andExpect {
+            status { isNotFound() }
+        }
+    }
+}

--- a/server/src/test/kotlin/com/orchestradashboard/server/model/AgentEventMapperTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/model/AgentEventMapperTest.kt
@@ -1,0 +1,43 @@
+package com.orchestradashboard.server.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AgentEventMapperTest {
+    private val mapper = AgentEventMapper()
+
+    @Test
+    fun `toResponse maps all entity fields correctly`() {
+        val entity =
+            AgentEventEntity(
+                id = "evt-1",
+                agentId = "agent-1",
+                type = "STATUS_CHANGE",
+                payload = """{"from":"IDLE","to":"RUNNING"}""",
+                timestamp = 1700000000L,
+            )
+
+        val response = mapper.toResponse(entity)
+
+        assertEquals("evt-1", response.id)
+        assertEquals("agent-1", response.agentId)
+        assertEquals("STATUS_CHANGE", response.type)
+        assertEquals("""{"from":"IDLE","to":"RUNNING"}""", response.payload)
+        assertEquals(1700000000L, response.timestamp)
+    }
+
+    @Test
+    fun `toResponseList maps list of entities`() {
+        val entities =
+            listOf(
+                AgentEventEntity(id = "e1", agentId = "a1", type = "HEARTBEAT", payload = "", timestamp = 100L),
+                AgentEventEntity(id = "e2", agentId = "a2", type = "ERROR", payload = "fail", timestamp = 200L),
+            )
+
+        val responses = mapper.toResponseList(entities)
+
+        assertEquals(2, responses.size)
+        assertEquals("e1", responses[0].id)
+        assertEquals("e2", responses[1].id)
+    }
+}

--- a/server/src/test/kotlin/com/orchestradashboard/server/model/PipelineRunMapperTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/model/PipelineRunMapperTest.kt
@@ -1,0 +1,122 @@
+package com.orchestradashboard.server.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PipelineRunMapperTest {
+    private val mapper = PipelineRunMapper()
+
+    @Test
+    fun `toResponse maps all entity fields correctly`() {
+        val stepsJson = """[{"name":"Build","status":"PASSED","detail":"OK","elapsed_ms":1200}]"""
+        val entity =
+            PipelineRunEntity(
+                id = "run-1",
+                agentId = "agent-1",
+                pipelineName = "CI Pipeline",
+                status = "RUNNING",
+                steps = stepsJson,
+                startedAt = 1700000000L,
+                finishedAt = 1700001000L,
+                triggerInfo = "manual",
+            )
+
+        val response = mapper.toResponse(entity)
+
+        assertEquals("run-1", response.id)
+        assertEquals("agent-1", response.agentId)
+        assertEquals("CI Pipeline", response.pipelineName)
+        assertEquals("RUNNING", response.status)
+        assertEquals(1, response.steps.size)
+        assertEquals("Build", response.steps[0].name)
+        assertEquals("PASSED", response.steps[0].status)
+        assertEquals("OK", response.steps[0].detail)
+        assertEquals(1200L, response.steps[0].elapsedMs)
+        assertEquals(1700000000L, response.startedAt)
+        assertEquals(1700001000L, response.finishedAt)
+        assertEquals("manual", response.triggerInfo)
+    }
+
+    @Test
+    fun `toResponse handles empty steps JSON`() {
+        val entity =
+            PipelineRunEntity(
+                id = "run-1",
+                agentId = "agent-1",
+                pipelineName = "Pipeline",
+                status = "QUEUED",
+                steps = "[]",
+                startedAt = 100L,
+            )
+
+        val response = mapper.toResponse(entity)
+
+        assertTrue(response.steps.isEmpty())
+    }
+
+    @Test
+    fun `toResponse handles null finishedAt`() {
+        val entity =
+            PipelineRunEntity(
+                id = "run-1",
+                agentId = "agent-1",
+                pipelineName = "Pipeline",
+                status = "RUNNING",
+                steps = "[]",
+                startedAt = 100L,
+                finishedAt = null,
+            )
+
+        val response = mapper.toResponse(entity)
+
+        assertNull(response.finishedAt)
+    }
+
+    @Test
+    fun `toResponseList maps list of entities`() {
+        val entities =
+            listOf(
+                PipelineRunEntity(id = "r1", agentId = "a1", pipelineName = "P1", startedAt = 100L),
+                PipelineRunEntity(id = "r2", agentId = "a2", pipelineName = "P2", startedAt = 200L),
+            )
+
+        val responses = mapper.toResponseList(entities)
+
+        assertEquals(2, responses.size)
+        assertEquals("r1", responses[0].id)
+        assertEquals("r2", responses[1].id)
+    }
+
+    @Test
+    fun `serializeSteps round-trips through deserializeSteps`() {
+        val steps =
+            listOf(
+                PipelineStepResponse(name = "Build", status = "PASSED", detail = "OK", elapsedMs = 500L),
+                PipelineStepResponse(name = "Test", status = "RUNNING", detail = "", elapsedMs = 0L),
+            )
+
+        val json = mapper.serializeSteps(steps)
+        val result = mapper.deserializeSteps(json)
+
+        assertEquals(2, result.size)
+        assertEquals("Build", result[0].name)
+        assertEquals("PASSED", result[0].status)
+        assertEquals("Test", result[1].name)
+    }
+
+    @Test
+    fun `deserializeSteps handles malformed JSON gracefully`() {
+        val result = mapper.deserializeSteps("{not valid json")
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `deserializeSteps handles blank string`() {
+        val result = mapper.deserializeSteps("")
+
+        assertTrue(result.isEmpty())
+    }
+}

--- a/server/src/test/kotlin/com/orchestradashboard/server/repository/PipelineRunJpaRepositoryTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/repository/PipelineRunJpaRepositoryTest.kt
@@ -1,0 +1,137 @@
+package com.orchestradashboard.server.repository
+
+import com.orchestradashboard.server.model.AgentEntity
+import com.orchestradashboard.server.model.PipelineRunEntity
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.data.domain.PageRequest
+
+@DataJpaTest
+class PipelineRunJpaRepositoryTest {
+    @Autowired
+    lateinit var pipelineRepository: PipelineRunJpaRepository
+
+    @Autowired
+    lateinit var agentRepository: AgentJpaRepository
+
+    @BeforeEach
+    fun setUp() {
+        agentRepository.save(AgentEntity(id = "agent-1", name = "Alpha", type = "WORKER", status = "RUNNING", lastHeartbeat = 100L))
+        agentRepository.save(AgentEntity(id = "agent-2", name = "Beta", type = "PLANNER", status = "IDLE", lastHeartbeat = 200L))
+    }
+
+    @Test
+    fun `save and findById round-trips a pipeline run`() {
+        val entity =
+            PipelineRunEntity(
+                id = "run-1",
+                agentId = "agent-1",
+                pipelineName = "CI Pipeline",
+                status = "RUNNING",
+                steps = """[{"name":"Build","status":"PASSED","detail":"OK","elapsed_ms":1200}]""",
+                startedAt = 1700000000L,
+                finishedAt = null,
+                triggerInfo = "manual",
+            )
+
+        pipelineRepository.save(entity)
+        val found = pipelineRepository.findById("run-1")
+
+        assertTrue(found.isPresent)
+        assertEquals("CI Pipeline", found.get().pipelineName)
+        assertEquals("RUNNING", found.get().status)
+        assertEquals("agent-1", found.get().agentId)
+    }
+
+    @Test
+    fun `steps column persists JSON correctly`() {
+        val stepsJson = """[{"name":"Build","status":"PASSED","detail":"OK","elapsed_ms":500}]"""
+        pipelineRepository.save(
+            PipelineRunEntity(id = "run-1", agentId = "agent-1", pipelineName = "P", steps = stepsJson, startedAt = 100L),
+        )
+
+        val found = pipelineRepository.findById("run-1")
+
+        assertTrue(found.isPresent)
+        assertEquals(stepsJson, found.get().steps)
+    }
+
+    @Test
+    fun `findByAgentId returns matching runs only`() {
+        pipelineRepository.save(PipelineRunEntity(id = "r1", agentId = "agent-1", pipelineName = "P1", startedAt = 100L))
+        pipelineRepository.save(PipelineRunEntity(id = "r2", agentId = "agent-1", pipelineName = "P2", startedAt = 200L))
+        pipelineRepository.save(PipelineRunEntity(id = "r3", agentId = "agent-2", pipelineName = "P3", startedAt = 300L))
+
+        val page = pipelineRepository.findByAgentId("agent-1", PageRequest.of(0, 20))
+
+        assertEquals(2, page.content.size)
+        assertTrue(page.content.all { it.agentId == "agent-1" })
+    }
+
+    @Test
+    fun `findByAgentId supports pagination`() {
+        pipelineRepository.save(PipelineRunEntity(id = "r1", agentId = "agent-1", pipelineName = "P1", startedAt = 100L))
+        pipelineRepository.save(PipelineRunEntity(id = "r2", agentId = "agent-1", pipelineName = "P2", startedAt = 200L))
+        pipelineRepository.save(PipelineRunEntity(id = "r3", agentId = "agent-1", pipelineName = "P3", startedAt = 300L))
+
+        val page = pipelineRepository.findByAgentId("agent-1", PageRequest.of(0, 2))
+
+        assertEquals(2, page.content.size)
+        assertEquals(3, page.totalElements)
+    }
+
+    @Test
+    fun `findByStatus returns matching runs only`() {
+        pipelineRepository.save(
+            PipelineRunEntity(id = "r1", agentId = "agent-1", pipelineName = "P1", status = "RUNNING", startedAt = 100L),
+        )
+        pipelineRepository.save(PipelineRunEntity(id = "r2", agentId = "agent-1", pipelineName = "P2", status = "PASSED", startedAt = 200L))
+        pipelineRepository.save(
+            PipelineRunEntity(id = "r3", agentId = "agent-2", pipelineName = "P3", status = "RUNNING", startedAt = 300L),
+        )
+
+        val page = pipelineRepository.findByStatus("RUNNING", PageRequest.of(0, 20))
+
+        assertEquals(2, page.content.size)
+        assertTrue(page.content.all { it.status == "RUNNING" })
+    }
+
+    @Test
+    fun `findByAgentIdAndStatus returns intersection`() {
+        pipelineRepository.save(
+            PipelineRunEntity(id = "r1", agentId = "agent-1", pipelineName = "P1", status = "RUNNING", startedAt = 100L),
+        )
+        pipelineRepository.save(PipelineRunEntity(id = "r2", agentId = "agent-1", pipelineName = "P2", status = "PASSED", startedAt = 200L))
+        pipelineRepository.save(
+            PipelineRunEntity(id = "r3", agentId = "agent-2", pipelineName = "P3", status = "RUNNING", startedAt = 300L),
+        )
+
+        val page = pipelineRepository.findByAgentIdAndStatus("agent-1", "RUNNING", PageRequest.of(0, 20))
+
+        assertEquals(1, page.content.size)
+        assertEquals("r1", page.content[0].id)
+    }
+
+    @Test
+    fun `findByAgentId returns empty page for unknown agent`() {
+        val page = pipelineRepository.findByAgentId("unknown", PageRequest.of(0, 20))
+
+        assertTrue(page.content.isEmpty())
+    }
+
+    @Test
+    fun `findAll with Pageable returns correct page`() {
+        pipelineRepository.save(PipelineRunEntity(id = "r1", agentId = "agent-1", pipelineName = "P1", startedAt = 100L))
+        pipelineRepository.save(PipelineRunEntity(id = "r2", agentId = "agent-1", pipelineName = "P2", startedAt = 200L))
+        pipelineRepository.save(PipelineRunEntity(id = "r3", agentId = "agent-2", pipelineName = "P3", startedAt = 300L))
+
+        val page = pipelineRepository.findAll(PageRequest.of(0, 2))
+
+        assertEquals(2, page.content.size)
+        assertEquals(3, page.totalElements)
+    }
+}

--- a/server/src/test/kotlin/com/orchestradashboard/server/service/EventServiceTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/service/EventServiceTest.kt
@@ -1,0 +1,104 @@
+package com.orchestradashboard.server.service
+
+import com.orchestradashboard.server.model.AgentEventEntity
+import com.orchestradashboard.server.model.AgentEventMapper
+import com.orchestradashboard.server.model.CreateEventRequest
+import com.orchestradashboard.server.repository.AgentEventJpaRepository
+import com.orchestradashboard.server.repository.AgentJpaRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class EventServiceTest {
+    private val eventRepository: AgentEventJpaRepository = mock()
+    private val agentRepository: AgentJpaRepository = mock()
+    private val mapper = AgentEventMapper()
+    private val service = EventService(eventRepository, agentRepository, mapper)
+
+    private val defaultEntity =
+        AgentEventEntity(
+            id = "evt-1",
+            agentId = "agent-1",
+            type = "STATUS_CHANGE",
+            payload = "{}",
+            timestamp = 1700000000L,
+        )
+
+    @Test
+    fun `getRecentEvents returns mapped responses`() {
+        whenever(eventRepository.findTop50ByOrderByTimestampDesc()).thenReturn(listOf(defaultEntity))
+
+        val result = service.getRecentEvents(null, 50)
+
+        assertEquals(1, result.size)
+        assertEquals("evt-1", result[0].id)
+    }
+
+    @Test
+    fun `getRecentEvents respects limit parameter`() {
+        val entities =
+            (1..10).map {
+                AgentEventEntity(id = "evt-$it", agentId = "agent-1", type = "HEARTBEAT", payload = "", timestamp = it.toLong())
+            }
+        whenever(eventRepository.findTop50ByOrderByTimestampDesc()).thenReturn(entities)
+
+        val result = service.getRecentEvents(null, 3)
+
+        assertEquals(3, result.size)
+    }
+
+    @Test
+    fun `getEventsByAgentId returns filtered events`() {
+        whenever(eventRepository.findByAgentIdOrderByTimestampDesc("agent-1")).thenReturn(listOf(defaultEntity))
+
+        val result = service.getRecentEvents("agent-1", 50)
+
+        assertEquals(1, result.size)
+        verify(eventRepository).findByAgentIdOrderByTimestampDesc("agent-1")
+    }
+
+    @Test
+    fun `createEvent saves entity and returns response`() {
+        val request = CreateEventRequest(agentId = "agent-1", type = "STATUS_CHANGE", payload = "{}")
+        whenever(agentRepository.existsById("agent-1")).thenReturn(true)
+        whenever(eventRepository.save(any<AgentEventEntity>())).thenAnswer { it.arguments[0] as AgentEventEntity }
+
+        val result = service.createEvent(request)
+
+        assertEquals("agent-1", result.agentId)
+        assertEquals("STATUS_CHANGE", result.type)
+        assertEquals("{}", result.payload)
+    }
+
+    @Test
+    fun `createEvent validates agent exists`() {
+        val request = CreateEventRequest(agentId = "missing", type = "ERROR")
+        whenever(agentRepository.existsById("missing")).thenReturn(false)
+
+        assertThrows<NoSuchElementException> {
+            service.createEvent(request)
+        }
+    }
+
+    @Test
+    fun `createEvent auto-assigns UUID and timestamp`() {
+        val request = CreateEventRequest(agentId = "agent-1", type = "HEARTBEAT")
+        whenever(agentRepository.existsById("agent-1")).thenReturn(true)
+        val captor = argumentCaptor<AgentEventEntity>()
+        whenever(eventRepository.save(any<AgentEventEntity>())).thenAnswer { it.arguments[0] as AgentEventEntity }
+
+        service.createEvent(request)
+
+        verify(eventRepository).save(captor.capture())
+        assertNotNull(captor.firstValue.id)
+        assertTrue(captor.firstValue.id.isNotBlank())
+        assertTrue(captor.firstValue.timestamp > 0)
+    }
+}

--- a/server/src/test/kotlin/com/orchestradashboard/server/service/PipelineServiceTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/service/PipelineServiceTest.kt
@@ -1,0 +1,200 @@
+package com.orchestradashboard.server.service
+
+import com.orchestradashboard.server.model.CreatePipelineRunRequest
+import com.orchestradashboard.server.model.PipelineRunEntity
+import com.orchestradashboard.server.model.PipelineRunMapper
+import com.orchestradashboard.server.model.PipelineStepResponse
+import com.orchestradashboard.server.repository.AgentJpaRepository
+import com.orchestradashboard.server.repository.PipelineRunJpaRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.util.Optional
+
+class PipelineServiceTest {
+    private val pipelineRepository: PipelineRunJpaRepository = mock()
+    private val agentRepository: AgentJpaRepository = mock()
+    private val mapper = PipelineRunMapper()
+    private val service = PipelineService(pipelineRepository, agentRepository, mapper)
+
+    private val defaultEntity =
+        PipelineRunEntity(
+            id = "run-1",
+            agentId = "agent-1",
+            pipelineName = "CI Pipeline",
+            status = "RUNNING",
+            steps = "[]",
+            startedAt = 1700000000L,
+        )
+
+    @Test
+    fun `getAllPipelineRuns returns mapped responses`() {
+        val pageable = PageRequest.of(0, 20)
+        whenever(pipelineRepository.findAll(pageable)).thenReturn(PageImpl(listOf(defaultEntity)))
+
+        val result = service.getAllPipelineRuns(null, null, pageable)
+
+        assertEquals(1, result.size)
+        assertEquals("run-1", result[0].id)
+    }
+
+    @Test
+    fun `getAllPipelineRuns returns empty list when none exist`() {
+        val pageable = PageRequest.of(0, 20)
+        whenever(pipelineRepository.findAll(pageable)).thenReturn(PageImpl(emptyList()))
+
+        val result = service.getAllPipelineRuns(null, null, pageable)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `getPipelineRun returns response when found`() {
+        whenever(pipelineRepository.findById("run-1")).thenReturn(Optional.of(defaultEntity))
+
+        val result = service.getPipelineRun("run-1")
+
+        assertEquals("run-1", result.id)
+        assertEquals("CI Pipeline", result.pipelineName)
+    }
+
+    @Test
+    fun `getPipelineRun throws NoSuchElementException when not found`() {
+        whenever(pipelineRepository.findById("missing")).thenReturn(Optional.empty())
+
+        assertThrows<NoSuchElementException> {
+            service.getPipelineRun("missing")
+        }
+    }
+
+    @Test
+    fun `getPipelineRunsByAgentId delegates to repository with pagination`() {
+        val pageable = PageRequest.of(0, 20)
+        whenever(pipelineRepository.findByAgentId("agent-1", pageable)).thenReturn(PageImpl(listOf(defaultEntity)))
+
+        val result = service.getAllPipelineRuns("agent-1", null, pageable)
+
+        assertEquals(1, result.size)
+        verify(pipelineRepository).findByAgentId("agent-1", pageable)
+    }
+
+    @Test
+    fun `getPipelineRunsByStatus delegates to repository with pagination`() {
+        val pageable = PageRequest.of(0, 20)
+        whenever(pipelineRepository.findByStatus("RUNNING", pageable)).thenReturn(PageImpl(listOf(defaultEntity)))
+
+        val result = service.getAllPipelineRuns(null, "RUNNING", pageable)
+
+        assertEquals(1, result.size)
+        verify(pipelineRepository).findByStatus("RUNNING", pageable)
+    }
+
+    @Test
+    fun `getPipelineRunsByAgentIdAndStatus delegates to repository with pagination`() {
+        val pageable = PageRequest.of(0, 20)
+        whenever(pipelineRepository.findByAgentIdAndStatus("agent-1", "RUNNING", pageable)).thenReturn(PageImpl(listOf(defaultEntity)))
+
+        val result = service.getAllPipelineRuns("agent-1", "RUNNING", pageable)
+
+        assertEquals(1, result.size)
+        verify(pipelineRepository).findByAgentIdAndStatus("agent-1", "RUNNING", pageable)
+    }
+
+    @Test
+    fun `createPipelineRun saves entity and returns response`() {
+        val request =
+            CreatePipelineRunRequest(
+                agentId = "agent-1",
+                pipelineName = "CI Pipeline",
+                steps = listOf(PipelineStepResponse(name = "Build", status = "PENDING", detail = "", elapsedMs = 0L)),
+                triggerInfo = "manual",
+            )
+        whenever(agentRepository.existsById("agent-1")).thenReturn(true)
+        whenever(pipelineRepository.save(any<PipelineRunEntity>())).thenAnswer { it.arguments[0] as PipelineRunEntity }
+
+        val result = service.createPipelineRun(request)
+
+        assertEquals("agent-1", result.agentId)
+        assertEquals("CI Pipeline", result.pipelineName)
+        assertEquals("QUEUED", result.status)
+        assertEquals(1, result.steps.size)
+        assertEquals("manual", result.triggerInfo)
+    }
+
+    @Test
+    fun `createPipelineRun auto-assigns UUID`() {
+        val request = CreatePipelineRunRequest(agentId = "agent-1", pipelineName = "Pipeline")
+        whenever(agentRepository.existsById("agent-1")).thenReturn(true)
+        val captor = argumentCaptor<PipelineRunEntity>()
+        whenever(pipelineRepository.save(any<PipelineRunEntity>())).thenAnswer { it.arguments[0] as PipelineRunEntity }
+
+        service.createPipelineRun(request)
+
+        verify(pipelineRepository).save(captor.capture())
+        assertNotNull(captor.firstValue.id)
+        assertTrue(captor.firstValue.id.isNotBlank())
+    }
+
+    @Test
+    fun `createPipelineRun validates agent exists`() {
+        val request = CreatePipelineRunRequest(agentId = "missing", pipelineName = "Pipeline")
+        whenever(agentRepository.existsById("missing")).thenReturn(false)
+
+        assertThrows<NoSuchElementException> {
+            service.createPipelineRun(request)
+        }
+    }
+
+    @Test
+    fun `updateStatus updates status field`() {
+        whenever(pipelineRepository.findById("run-1")).thenReturn(Optional.of(defaultEntity))
+        whenever(pipelineRepository.save(any<PipelineRunEntity>())).thenAnswer { it.arguments[0] as PipelineRunEntity }
+
+        val result = service.updateStatus("run-1", "RUNNING")
+
+        assertEquals("RUNNING", result.status)
+    }
+
+    @Test
+    fun `updateStatus sets finishedAt for terminal statuses`() {
+        whenever(pipelineRepository.findById("run-1")).thenReturn(Optional.of(defaultEntity))
+        val captor = argumentCaptor<PipelineRunEntity>()
+        whenever(pipelineRepository.save(any<PipelineRunEntity>())).thenAnswer { it.arguments[0] as PipelineRunEntity }
+
+        service.updateStatus("run-1", "PASSED")
+
+        verify(pipelineRepository).save(captor.capture())
+        assertNotNull(captor.firstValue.finishedAt)
+    }
+
+    @Test
+    fun `updateStatus preserves null finishedAt for non-terminal statuses`() {
+        whenever(pipelineRepository.findById("run-1")).thenReturn(Optional.of(defaultEntity))
+        val captor = argumentCaptor<PipelineRunEntity>()
+        whenever(pipelineRepository.save(any<PipelineRunEntity>())).thenAnswer { it.arguments[0] as PipelineRunEntity }
+
+        service.updateStatus("run-1", "RUNNING")
+
+        verify(pipelineRepository).save(captor.capture())
+        assertNull(captor.firstValue.finishedAt)
+    }
+
+    @Test
+    fun `updateStatus throws for non-existent run`() {
+        whenever(pipelineRepository.findById("missing")).thenReturn(Optional.empty())
+
+        assertThrows<NoSuchElementException> {
+            service.updateStatus("missing", "PASSED")
+        }
+    }
+}


### PR DESCRIPTION
Closes #5

## Design
Here is the complete design document for Issue #5:

---

# Design: PipelineRun and AgentEvent Server Endpoints (Issue #5)

## Critical Note on Gemini Critique

The Gemini critique is **wrong**. This is a **Kotlin/Spring Boot 3** project (JDK 21, Gradle, JPA, H2/PostgreSQL). There is no Python anywhere. The design stays in the existing Kotlin stack, following the established `Agent` entity pattern exactly.

The shared module already defines domain models at:
- `shared/.../domain/model/PipelineRun.kt` — `PipelineRun`, `PipelineStep`, `PipelineRunStatus`, `StepStatus`
- `shared/.../domain/model/AgentEvent.kt` — `AgentEvent`, `EventType`

---

## 1. Files to Create (Exact Paths)

**Base:** `server/src/main/kotlin/com/orchestradashboard/server/`

| Layer | File | Purpose |
|-------|------|---------|
| Model | `model/PipelineRunEntity.kt` | JPA entity for `pipeline_runs` table |
| Model | `model/AgentEventEntity.kt` | JPA entity for `agent_events` table |
| Model | `model/PipelineRunResponse.kt` | Response DTO + create/update request DTOs |
| Model | `model/AgentEventResponse.kt` | Response DTO + create request DTO |
| Model | `model/PipelineRunMapper.kt` | Entity ↔ DTO mapping (JSON steps) |
| Model | `model/AgentEventMapper.kt` | Entity ↔ DTO mapping |
| Repository | `repository/PipelineRunJpaRepository.kt` | Spring Data JPA repo |
| Repository | `repository/AgentEventJpaRepository.kt` | Spring Data JPA repo |
| Service | `service/PipelineService.kt` | CRUD + status/step updates 

_(truncated)_

## Changed Files (20)
- `config/detekt/detekt.yml`
- `server/src/main/kotlin/com/orchestradashboard/server/controller/EventController.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/controller/PipelineController.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/model/AgentEventEntity.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/model/AgentEventMapper.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/model/AgentEventResponse.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunEntity.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunMapper.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunResponse.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/repository/AgentEventJpaRepository.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/repository/PipelineRunJpaRepository.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/service/EventService.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/service/PipelineService.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/controller/EventControllerTest.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/controller/PipelineControllerTest.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/model/AgentEventMapperTest.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/model/PipelineRunMapperTest.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/repository/PipelineRunJpaRepositoryTest.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/service/EventServiceTest.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/service/PipelineServiceTest.kt`

## Review
The implementation is thorough, with extensive test coverage that aligns well with the TDD-focused design document. The code quality is high, adhering to clean, idiomatic Kotlin and a clear separation of concerns. Error handling for non-existent entities and malformed data is robust. The correction of the event query limit from 50 to 100 in `AgentEventJpaRepository` was a good catch and improves the API's consistency.

However, a critical flaw exists in the implementation of the pipeline listing endpoint.

**Business Logic Correctness:**

The `PipelineService.getAllPipelineRuns` method fails to apply pagination when filters (`agentId` or `status`) are used. The custom finder methods in `PipelineRunJpaRepository` (`findByAgentId`, `findByStatus`, etc.) were defined to return a `List<Pipelin

_(truncated)_

## AI Audit: PASS
[AUDIT: PASS]

The implementation aligns well with the original intent and addresses all critical issues identified in the previous review. The code is secure, follows best practices, and has comprehensive test coverage. All comments are either absent or provide meaningful explanations, adhering to the guidelines.