### PR TITLE
feat: Add PipelineRun server endpoints with relational persistence

### DIFF
--- a/server/src/main/kotlin/com/orchestradashboard/server/controller/PipelineController.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/controller/PipelineController.kt
@@ -4,6 +4,7 @@ import com.orchestradashboard.server.model.CreatePipelineRunRequest
 import com.orchestradashboard.server.model.PipelineRunResponse
 import com.orchestradashboard.server.model.UpdateStatusRequest
 import com.orchestradashboard.server.service.PipelineService
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -28,20 +29,21 @@ class PipelineController(
         @RequestParam status: String?,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "20") size: Int,
-    ): ResponseEntity<List<PipelineRunResponse>> {
-        val pageable = PageRequest.of(page, size.coerceAtMost(100))
-        return ResponseEntity.ok(pipelineService.getAllPipelineRuns(agentId, status, pageable))
+    ): ResponseEntity<Page<PipelineRunResponse>> {
+        val clampedSize = size.coerceIn(1, 100)
+        val pageable = PageRequest.of(page, clampedSize)
+        return ResponseEntity.ok(pipelineService.getPipelines(agentId, status, pageable))
     }
 
     @GetMapping("/{id}")
     fun getPipeline(
         @PathVariable id: String,
-    ): ResponseEntity<PipelineRunResponse> = ResponseEntity.ok(pipelineService.getPipelineRun(id))
+    ): ResponseEntity<PipelineRunResponse> = ResponseEntity.ok(pipelineService.getPipeline(id))
 
     @PostMapping
     fun createPipeline(
         @RequestBody request: CreatePipelineRunRequest,
-    ): ResponseEntity<PipelineRunResponse> = ResponseEntity.status(HttpStatus.CREATED).body(pipelineService.createPipelineRun(request))
+    ): ResponseEntity<PipelineRunResponse> = ResponseEntity.status(HttpStatus.CREATED).body(pipelineService.createPipeline(request))
 
     @PutMapping("/{id}/status")
     fun updateStatus(

--- a/server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunEntity.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunEntity.kt
@@ -27,7 +27,7 @@ data class PipelineRunEntity(
     val startedAt: Long = 0L,
     @Column(name = "finished_at")
     val finishedAt: Long? = null,
-    @Column(name = "trigger_info")
+    @Column(name = "trigger_info", columnDefinition = "TEXT")
     val triggerInfo: String = "",
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "agent_id", insertable = false, updatable = false)

--- a/server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunMapper.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunMapper.kt
@@ -1,12 +1,13 @@
 package com.orchestradashboard.server.model
 
 import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import org.springframework.stereotype.Component
 
 @Component
 class PipelineRunMapper {
-    private val objectMapper = jacksonObjectMapper()
+    private val objectMapper = ObjectMapper().registerModule(KotlinModule.Builder().build())
 
     fun toResponse(entity: PipelineRunEntity): PipelineRunResponse =
         PipelineRunResponse(
@@ -14,15 +15,13 @@ class PipelineRunMapper {
             agentId = entity.agentId,
             pipelineName = entity.pipelineName,
             status = entity.status,
-            steps = deserializeSteps(entity.steps),
+            steps = parseSteps(entity.steps),
             startedAt = entity.startedAt,
             finishedAt = entity.finishedAt,
             triggerInfo = entity.triggerInfo,
         )
 
-    fun toResponseList(entities: List<PipelineRunEntity>): List<PipelineRunResponse> = entities.map { toResponse(it) }
-
-    fun deserializeSteps(json: String): List<PipelineStepResponse> =
+    fun parseSteps(json: String): List<PipelineStepResponse> =
         if (json.isBlank()) {
             emptyList()
         } else {
@@ -33,5 +32,5 @@ class PipelineRunMapper {
             }
         }
 
-    fun serializeSteps(steps: List<PipelineStepResponse>): String = objectMapper.writeValueAsString(steps)
+    fun serializeSteps(steps: List<PipelineStepRequest>): String = objectMapper.writeValueAsString(steps)
 }

--- a/server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunResponse.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunResponse.kt
@@ -2,6 +2,13 @@ package com.orchestradashboard.server.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
+data class PipelineStepResponse(
+    val name: String,
+    val status: String,
+    val detail: String,
+    @JsonProperty("elapsed_ms") val elapsedMs: Long,
+)
+
 data class PipelineRunResponse(
     val id: String,
     @JsonProperty("agent_id") val agentId: String,
@@ -13,18 +20,21 @@ data class PipelineRunResponse(
     @JsonProperty("trigger_info") val triggerInfo: String,
 )
 
-data class PipelineStepResponse(
-    val name: String,
-    val status: String,
-    val detail: String,
-    @JsonProperty("elapsed_ms") val elapsedMs: Long,
-)
-
 data class CreatePipelineRunRequest(
+    val id: String? = null,
     @JsonProperty("agent_id") val agentId: String,
     @JsonProperty("pipeline_name") val pipelineName: String,
-    val steps: List<PipelineStepResponse> = emptyList(),
     @JsonProperty("trigger_info") val triggerInfo: String = "",
+    val steps: List<PipelineStepRequest> = emptyList(),
 )
 
-data class UpdateStatusRequest(val status: String)
+data class PipelineStepRequest(
+    val name: String,
+    val status: String = "PENDING",
+    val detail: String = "",
+    @JsonProperty("elapsed_ms") val elapsedMs: Long = 0L,
+)
+
+data class UpdateStatusRequest(
+    val status: String,
+)

--- a/server/src/main/kotlin/com/orchestradashboard/server/service/PipelineService.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/service/PipelineService.kt
@@ -6,6 +6,7 @@ import com.orchestradashboard.server.model.PipelineRunMapper
 import com.orchestradashboard.server.model.PipelineRunResponse
 import com.orchestradashboard.server.repository.AgentJpaRepository
 import com.orchestradashboard.server.repository.PipelineRunJpaRepository
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import java.util.UUID
@@ -16,15 +17,11 @@ class PipelineService(
     private val agentRepository: AgentJpaRepository,
     private val mapper: PipelineRunMapper,
 ) {
-    companion object {
-        private val TERMINAL_STATUSES = setOf("PASSED", "FAILED", "CANCELLED")
-    }
-
-    fun getAllPipelineRuns(
+    fun getPipelines(
         agentId: String?,
         status: String?,
         pageable: Pageable,
-    ): List<PipelineRunResponse> {
+    ): Page<PipelineRunResponse> {
         val page =
             when {
                 agentId != null && status != null -> pipelineRepository.findByAgentIdAndStatus(agentId, status, pageable)
@@ -32,23 +29,22 @@ class PipelineService(
                 status != null -> pipelineRepository.findByStatus(status, pageable)
                 else -> pipelineRepository.findAll(pageable)
             }
-        return mapper.toResponseList(page.content)
+        return page.map { mapper.toResponse(it) }
     }
 
-    fun getPipelineRun(id: String): PipelineRunResponse {
+    fun getPipeline(id: String): PipelineRunResponse {
         val entity =
             pipelineRepository.findById(id)
-                .orElseThrow { NoSuchElementException("PipelineRun with id '$id' not found") }
+                .orElseThrow { NoSuchElementException("Pipeline run with id '$id' not found") }
         return mapper.toResponse(entity)
     }
 
-    fun createPipelineRun(request: CreatePipelineRunRequest): PipelineRunResponse {
-        if (!agentRepository.existsById(request.agentId)) {
-            throw NoSuchElementException("Agent with id '${request.agentId}' not found")
-        }
+    fun createPipeline(request: CreatePipelineRunRequest): PipelineRunResponse {
+        agentRepository.findById(request.agentId)
+            .orElseThrow { NoSuchElementException("Agent with id '${request.agentId}' not found") }
         val entity =
             PipelineRunEntity(
-                id = UUID.randomUUID().toString(),
+                id = request.id ?: UUID.randomUUID().toString(),
                 agentId = request.agentId,
                 pipelineName = request.pipelineName,
                 status = "QUEUED",
@@ -65,8 +61,9 @@ class PipelineService(
     ): PipelineRunResponse {
         val existing =
             pipelineRepository.findById(id)
-                .orElseThrow { NoSuchElementException("PipelineRun with id '$id' not found") }
-        val finishedAt = if (status in TERMINAL_STATUSES) System.currentTimeMillis() else existing.finishedAt
+                .orElseThrow { NoSuchElementException("Pipeline run with id '$id' not found") }
+        val terminalStatuses = setOf("PASSED", "FAILED", "CANCELLED")
+        val finishedAt = if (status in terminalStatuses) System.currentTimeMillis() else existing.finishedAt
         val updated = existing.copy(status = status, finishedAt = finishedAt)
         return mapper.toResponse(pipelineRepository.save(updated))
     }

--- a/server/src/test/kotlin/com/orchestradashboard/server/controller/PipelineControllerTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/controller/PipelineControllerTest.kt
@@ -10,10 +10,13 @@ import com.orchestradashboard.server.service.PipelineService
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
@@ -35,11 +38,14 @@ class PipelineControllerTest {
 
     private val sampleResponse =
         PipelineRunResponse(
-            id = "run-1",
+            id = "pipe-1",
             agentId = "agent-1",
-            pipelineName = "CI Pipeline",
+            pipelineName = "build-deploy",
             status = "RUNNING",
-            steps = listOf(PipelineStepResponse(name = "Build", status = "PASSED", detail = "OK", elapsedMs = 1200L)),
+            steps =
+                listOf(
+                    PipelineStepResponse(name = "build", status = "PASSED", detail = "ok", elapsedMs = 100L),
+                ),
             startedAt = 1700000000L,
             finishedAt = null,
             triggerInfo = "manual",
@@ -47,74 +53,86 @@ class PipelineControllerTest {
 
     @Test
     fun `GET api-v1-pipelines returns 200 with pipeline list`() {
-        whenever(pipelineService.getAllPipelineRuns(eq(null), eq(null), any())).thenReturn(listOf(sampleResponse))
+        val pageable = PageRequest.of(0, 20)
+        whenever(pipelineService.getPipelines(null, null, pageable)).thenReturn(PageImpl(listOf(sampleResponse), pageable, 1))
 
         mockMvc.get("/api/v1/pipelines")
             .andExpect {
                 status { isOk() }
                 content { contentType(MediaType.APPLICATION_JSON) }
-                jsonPath("$[0].id") { value("run-1") }
-                jsonPath("$[0].status") { value("RUNNING") }
+                jsonPath("$.content[0].id") { value("pipe-1") }
+                jsonPath("$.content[0].status") { value("RUNNING") }
             }
     }
 
     @Test
-    fun `GET api-v1-pipelines with agentId param returns filtered list`() {
-        whenever(pipelineService.getAllPipelineRuns(eq("agent-1"), eq(null), any())).thenReturn(listOf(sampleResponse))
+    fun `GET api-v1-pipelines with agentId filter returns filtered results`() {
+        val pageable = PageRequest.of(0, 20)
+        whenever(pipelineService.getPipelines(eq("agent-1"), eq(null), any())).thenReturn(PageImpl(listOf(sampleResponse), pageable, 1))
 
         mockMvc.get("/api/v1/pipelines?agentId=agent-1")
             .andExpect {
                 status { isOk() }
-                jsonPath("$[0].agent_id") { value("agent-1") }
+                jsonPath("$.content[0].agent_id") { value("agent-1") }
             }
     }
 
     @Test
-    fun `GET api-v1-pipelines with status param returns filtered list`() {
-        whenever(pipelineService.getAllPipelineRuns(eq(null), eq("RUNNING"), any())).thenReturn(listOf(sampleResponse))
+    fun `GET api-v1-pipelines with status filter returns filtered results`() {
+        val pageable = PageRequest.of(0, 20)
+        whenever(pipelineService.getPipelines(eq(null), eq("RUNNING"), any())).thenReturn(PageImpl(listOf(sampleResponse), pageable, 1))
 
         mockMvc.get("/api/v1/pipelines?status=RUNNING")
             .andExpect {
                 status { isOk() }
-                jsonPath("$[0].status") { value("RUNNING") }
+                jsonPath("$.content[0].status") { value("RUNNING") }
             }
     }
 
     @Test
-    fun `GET api-v1-pipelines with both params returns combined filter`() {
-        whenever(pipelineService.getAllPipelineRuns(eq("agent-1"), eq("RUNNING"), any())).thenReturn(listOf(sampleResponse))
+    fun `GET api-v1-pipelines with both filters returns filtered results`() {
+        val pageable = PageRequest.of(0, 20)
+        whenever(
+            pipelineService.getPipelines(eq("agent-1"), eq("RUNNING"), any()),
+        ).thenReturn(PageImpl(listOf(sampleResponse), pageable, 1))
 
         mockMvc.get("/api/v1/pipelines?agentId=agent-1&status=RUNNING")
             .andExpect {
                 status { isOk() }
-                jsonPath("$[0].id") { value("run-1") }
+                jsonPath("$.content[0].id") { value("pipe-1") }
             }
     }
 
     @Test
-    fun `GET api-v1-pipelines supports pagination params`() {
-        whenever(pipelineService.getAllPipelineRuns(eq(null), eq(null), any())).thenReturn(emptyList())
+    fun `GET api-v1-pipelines with size over 100 clamps to 100`() {
+        val clampedPageable = PageRequest.of(0, 100)
+        whenever(
+            pipelineService.getPipelines(eq(null), eq(null), eq(clampedPageable)),
+        ).thenReturn(PageImpl(emptyList(), clampedPageable, 0))
 
-        mockMvc.get("/api/v1/pipelines?page=1&size=10")
+        mockMvc.get("/api/v1/pipelines?size=200")
             .andExpect {
                 status { isOk() }
             }
+
+        verify(pipelineService).getPipelines(null, null, clampedPageable)
     }
 
     @Test
-    fun `GET api-v1-pipelines-id returns 200 when found`() {
-        whenever(pipelineService.getPipelineRun("run-1")).thenReturn(sampleResponse)
+    fun `GET api-v1-pipelines-id returns 200 with pipeline run`() {
+        whenever(pipelineService.getPipeline("pipe-1")).thenReturn(sampleResponse)
 
-        mockMvc.get("/api/v1/pipelines/run-1")
+        mockMvc.get("/api/v1/pipelines/pipe-1")
             .andExpect {
                 status { isOk() }
-                jsonPath("$.pipeline_name") { value("CI Pipeline") }
+                jsonPath("$.pipeline_name") { value("build-deploy") }
+                jsonPath("$.steps[0].name") { value("build") }
             }
     }
 
     @Test
     fun `GET api-v1-pipelines-id returns 404 when not found`() {
-        whenever(pipelineService.getPipelineRun("missing")).thenThrow(NoSuchElementException("Not found"))
+        whenever(pipelineService.getPipeline("missing")).thenThrow(NoSuchElementException("Pipeline not found"))
 
         mockMvc.get("/api/v1/pipelines/missing")
             .andExpect {
@@ -124,37 +142,36 @@ class PipelineControllerTest {
 
     @Test
     fun `POST api-v1-pipelines returns 201 on creation`() {
-        val request = CreatePipelineRunRequest(agentId = "agent-1", pipelineName = "CI Pipeline", triggerInfo = "manual")
-        whenever(pipelineService.createPipelineRun(request)).thenReturn(sampleResponse)
+        val request = CreatePipelineRunRequest(agentId = "agent-1", pipelineName = "build-deploy")
+        whenever(pipelineService.createPipeline(any())).thenReturn(sampleResponse.copy(status = "QUEUED"))
 
         mockMvc.post("/api/v1/pipelines") {
             contentType = MediaType.APPLICATION_JSON
             content = objectMapper.writeValueAsString(request)
         }.andExpect {
             status { isCreated() }
-            jsonPath("$.id") { value("run-1") }
+            jsonPath("$.id") { value("pipe-1") }
+            jsonPath("$.status") { value("QUEUED") }
         }
     }
 
     @Test
     fun `POST api-v1-pipelines returns 404 when agent not found`() {
-        val request = CreatePipelineRunRequest(agentId = "missing", pipelineName = "Pipeline")
-        whenever(pipelineService.createPipelineRun(request)).thenThrow(NoSuchElementException("Agent not found"))
+        whenever(pipelineService.createPipeline(any())).thenThrow(NoSuchElementException("Agent not found"))
 
         mockMvc.post("/api/v1/pipelines") {
             contentType = MediaType.APPLICATION_JSON
-            content = objectMapper.writeValueAsString(request)
+            content = objectMapper.writeValueAsString(CreatePipelineRunRequest(agentId = "missing", pipelineName = "build"))
         }.andExpect {
             status { isNotFound() }
         }
     }
 
     @Test
-    fun `PUT api-v1-pipelines-id-status returns 200`() {
-        val updated = sampleResponse.copy(status = "PASSED", finishedAt = 1700001000L)
-        whenever(pipelineService.updateStatus("run-1", "PASSED")).thenReturn(updated)
+    fun `PUT api-v1-pipelines-id-status returns 200 on status update`() {
+        whenever(pipelineService.updateStatus("pipe-1", "PASSED")).thenReturn(sampleResponse.copy(status = "PASSED"))
 
-        mockMvc.put("/api/v1/pipelines/run-1/status") {
+        mockMvc.put("/api/v1/pipelines/pipe-1/status") {
             contentType = MediaType.APPLICATION_JSON
             content = objectMapper.writeValueAsString(UpdateStatusRequest(status = "PASSED"))
         }.andExpect {
@@ -164,12 +181,12 @@ class PipelineControllerTest {
     }
 
     @Test
-    fun `PUT api-v1-pipelines-id-status returns 404 when not found`() {
-        whenever(pipelineService.updateStatus("missing", "PASSED")).thenThrow(NoSuchElementException("Not found"))
+    fun `PUT api-v1-pipelines-id-status returns 404 when pipeline not found`() {
+        whenever(pipelineService.updateStatus("missing", "RUNNING")).thenThrow(NoSuchElementException("Pipeline not found"))
 
         mockMvc.put("/api/v1/pipelines/missing/status") {
             contentType = MediaType.APPLICATION_JSON
-            content = objectMapper.writeValueAsString(UpdateStatusRequest(status = "PASSED"))
+            content = objectMapper.writeValueAsString(UpdateStatusRequest(status = "RUNNING"))
         }.andExpect {
             status { isNotFound() }
         }

--- a/server/src/test/kotlin/com/orchestradashboard/server/repository/PipelineRunJpaRepositoryTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/repository/PipelineRunJpaRepositoryTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.data.domain.PageRequest
@@ -20,6 +21,8 @@ class PipelineRunJpaRepositoryTest {
 
     @BeforeEach
     fun setUp() {
+        pipelineRepository.deleteAll()
+        agentRepository.deleteAll()
         agentRepository.save(AgentEntity(id = "agent-1", name = "Alpha", type = "WORKER", status = "RUNNING", lastHeartbeat = 100L))
         agentRepository.save(AgentEntity(id = "agent-2", name = "Beta", type = "PLANNER", status = "IDLE", lastHeartbeat = 200L))
     }
@@ -28,110 +31,121 @@ class PipelineRunJpaRepositoryTest {
     fun `save and findById round-trips a pipeline run`() {
         val entity =
             PipelineRunEntity(
-                id = "run-1",
+                id = "pipe-1",
                 agentId = "agent-1",
-                pipelineName = "CI Pipeline",
+                pipelineName = "build-deploy",
                 status = "RUNNING",
-                steps = """[{"name":"Build","status":"PASSED","detail":"OK","elapsed_ms":1200}]""",
                 startedAt = 1700000000L,
-                finishedAt = null,
                 triggerInfo = "manual",
             )
 
         pipelineRepository.save(entity)
-        val found = pipelineRepository.findById("run-1")
+        val found = pipelineRepository.findById("pipe-1")
 
         assertTrue(found.isPresent)
-        assertEquals("CI Pipeline", found.get().pipelineName)
+        assertEquals("build-deploy", found.get().pipelineName)
         assertEquals("RUNNING", found.get().status)
         assertEquals("agent-1", found.get().agentId)
+        assertEquals(1700000000L, found.get().startedAt)
+        assertEquals("manual", found.get().triggerInfo)
     }
 
     @Test
-    fun `steps column persists JSON correctly`() {
-        val stepsJson = """[{"name":"Build","status":"PASSED","detail":"OK","elapsed_ms":500}]"""
+    fun `steps column persists and retrieves JSON correctly`() {
+        val stepsJson = """[{"name":"build","status":"PASSED","detail":"ok","elapsed_ms":100}]"""
         pipelineRepository.save(
-            PipelineRunEntity(id = "run-1", agentId = "agent-1", pipelineName = "P", steps = stepsJson, startedAt = 100L),
+            PipelineRunEntity(
+                id = "pipe-1",
+                agentId = "agent-1",
+                pipelineName = "build",
+                status = "RUNNING",
+                steps = stepsJson,
+                startedAt = 100L,
+            ),
         )
 
-        val found = pipelineRepository.findById("run-1")
+        val found = pipelineRepository.findById("pipe-1")
 
         assertTrue(found.isPresent)
         assertEquals(stepsJson, found.get().steps)
     }
 
     @Test
-    fun `findByAgentId returns matching runs only`() {
-        pipelineRepository.save(PipelineRunEntity(id = "r1", agentId = "agent-1", pipelineName = "P1", startedAt = 100L))
-        pipelineRepository.save(PipelineRunEntity(id = "r2", agentId = "agent-1", pipelineName = "P2", startedAt = 200L))
-        pipelineRepository.save(PipelineRunEntity(id = "r3", agentId = "agent-2", pipelineName = "P3", startedAt = 300L))
-
-        val page = pipelineRepository.findByAgentId("agent-1", PageRequest.of(0, 20))
-
-        assertEquals(2, page.content.size)
-        assertTrue(page.content.all { it.agentId == "agent-1" })
-    }
-
-    @Test
-    fun `findByAgentId supports pagination`() {
-        pipelineRepository.save(PipelineRunEntity(id = "r1", agentId = "agent-1", pipelineName = "P1", startedAt = 100L))
-        pipelineRepository.save(PipelineRunEntity(id = "r2", agentId = "agent-1", pipelineName = "P2", startedAt = 200L))
-        pipelineRepository.save(PipelineRunEntity(id = "r3", agentId = "agent-1", pipelineName = "P3", startedAt = 300L))
-
-        val page = pipelineRepository.findByAgentId("agent-1", PageRequest.of(0, 2))
-
-        assertEquals(2, page.content.size)
-        assertEquals(3, page.totalElements)
-    }
-
-    @Test
-    fun `findByStatus returns matching runs only`() {
+    fun `findByAgentId returns matching pipelines only`() {
         pipelineRepository.save(
-            PipelineRunEntity(id = "r1", agentId = "agent-1", pipelineName = "P1", status = "RUNNING", startedAt = 100L),
+            PipelineRunEntity(id = "p1", agentId = "agent-1", pipelineName = "build", status = "RUNNING", startedAt = 100L),
         )
-        pipelineRepository.save(PipelineRunEntity(id = "r2", agentId = "agent-1", pipelineName = "P2", status = "PASSED", startedAt = 200L))
         pipelineRepository.save(
-            PipelineRunEntity(id = "r3", agentId = "agent-2", pipelineName = "P3", status = "RUNNING", startedAt = 300L),
+            PipelineRunEntity(id = "p2", agentId = "agent-1", pipelineName = "test", status = "QUEUED", startedAt = 200L),
+        )
+        pipelineRepository.save(
+            PipelineRunEntity(id = "p3", agentId = "agent-2", pipelineName = "deploy", status = "RUNNING", startedAt = 300L),
         )
 
-        val page = pipelineRepository.findByStatus("RUNNING", PageRequest.of(0, 20))
+        val result = pipelineRepository.findByAgentId("agent-1", PageRequest.of(0, 20))
 
-        assertEquals(2, page.content.size)
-        assertTrue(page.content.all { it.status == "RUNNING" })
+        assertEquals(2, result.totalElements)
+        assertTrue(result.content.all { it.agentId == "agent-1" })
     }
 
     @Test
-    fun `findByAgentIdAndStatus returns intersection`() {
+    fun `findByStatus returns matching pipelines only`() {
         pipelineRepository.save(
-            PipelineRunEntity(id = "r1", agentId = "agent-1", pipelineName = "P1", status = "RUNNING", startedAt = 100L),
+            PipelineRunEntity(id = "p1", agentId = "agent-1", pipelineName = "build", status = "RUNNING", startedAt = 100L),
         )
-        pipelineRepository.save(PipelineRunEntity(id = "r2", agentId = "agent-1", pipelineName = "P2", status = "PASSED", startedAt = 200L))
         pipelineRepository.save(
-            PipelineRunEntity(id = "r3", agentId = "agent-2", pipelineName = "P3", status = "RUNNING", startedAt = 300L),
+            PipelineRunEntity(id = "p2", agentId = "agent-1", pipelineName = "test", status = "QUEUED", startedAt = 200L),
+        )
+        pipelineRepository.save(
+            PipelineRunEntity(id = "p3", agentId = "agent-2", pipelineName = "deploy", status = "RUNNING", startedAt = 300L),
         )
 
-        val page = pipelineRepository.findByAgentIdAndStatus("agent-1", "RUNNING", PageRequest.of(0, 20))
+        val result = pipelineRepository.findByStatus("RUNNING", PageRequest.of(0, 20))
 
-        assertEquals(1, page.content.size)
-        assertEquals("r1", page.content[0].id)
+        assertEquals(2, result.totalElements)
+        assertTrue(result.content.all { it.status == "RUNNING" })
     }
 
     @Test
-    fun `findByAgentId returns empty page for unknown agent`() {
-        val page = pipelineRepository.findByAgentId("unknown", PageRequest.of(0, 20))
+    fun `findByAgentIdAndStatus returns matching pipelines only`() {
+        pipelineRepository.save(
+            PipelineRunEntity(id = "p1", agentId = "agent-1", pipelineName = "build", status = "RUNNING", startedAt = 100L),
+        )
+        pipelineRepository.save(
+            PipelineRunEntity(id = "p2", agentId = "agent-1", pipelineName = "test", status = "QUEUED", startedAt = 200L),
+        )
+        pipelineRepository.save(
+            PipelineRunEntity(id = "p3", agentId = "agent-2", pipelineName = "deploy", status = "RUNNING", startedAt = 300L),
+        )
 
-        assertTrue(page.content.isEmpty())
+        val result = pipelineRepository.findByAgentIdAndStatus("agent-1", "RUNNING", PageRequest.of(0, 20))
+
+        assertEquals(1, result.totalElements)
+        assertEquals("p1", result.content[0].id)
     }
 
     @Test
-    fun `findAll with Pageable returns correct page`() {
-        pipelineRepository.save(PipelineRunEntity(id = "r1", agentId = "agent-1", pipelineName = "P1", startedAt = 100L))
-        pipelineRepository.save(PipelineRunEntity(id = "r2", agentId = "agent-1", pipelineName = "P2", startedAt = 200L))
-        pipelineRepository.save(PipelineRunEntity(id = "r3", agentId = "agent-2", pipelineName = "P3", startedAt = 300L))
+    fun `foreign key enforced - save fails with invalid agentId`() {
+        val entity = PipelineRunEntity(id = "p1", agentId = "nonexistent", pipelineName = "build", status = "RUNNING", startedAt = 100L)
+        pipelineRepository.save(entity)
 
-        val page = pipelineRepository.findAll(PageRequest.of(0, 2))
+        assertThrows<Exception> {
+            pipelineRepository.flush()
+        }
+    }
 
-        assertEquals(2, page.content.size)
-        assertEquals(3, page.totalElements)
+    @Test
+    fun `pagination works correctly`() {
+        for (i in 1..5) {
+            pipelineRepository.save(
+                PipelineRunEntity(id = "p$i", agentId = "agent-1", pipelineName = "build-$i", status = "RUNNING", startedAt = i.toLong()),
+            )
+        }
+
+        val page = pipelineRepository.findAll(PageRequest.of(0, 3))
+
+        assertEquals(3, page.content.size)
+        assertEquals(5, page.totalElements)
+        assertEquals(2, page.totalPages)
     }
 }

--- a/server/src/test/kotlin/com/orchestradashboard/server/service/PipelineServiceTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/service/PipelineServiceTest.kt
@@ -1,14 +1,13 @@
 package com.orchestradashboard.server.service
 
+import com.orchestradashboard.server.model.AgentEntity
 import com.orchestradashboard.server.model.CreatePipelineRunRequest
 import com.orchestradashboard.server.model.PipelineRunEntity
 import com.orchestradashboard.server.model.PipelineRunMapper
-import com.orchestradashboard.server.model.PipelineStepResponse
 import com.orchestradashboard.server.repository.AgentJpaRepository
 import com.orchestradashboard.server.repository.PipelineRunJpaRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -27,118 +26,120 @@ class PipelineServiceTest {
     private val mapper = PipelineRunMapper()
     private val service = PipelineService(pipelineRepository, agentRepository, mapper)
 
-    private val defaultEntity =
+    private val sampleEntity =
         PipelineRunEntity(
-            id = "run-1",
+            id = "pipe-1",
             agentId = "agent-1",
-            pipelineName = "CI Pipeline",
+            pipelineName = "build-deploy",
             status = "RUNNING",
             steps = "[]",
             startedAt = 1700000000L,
+            triggerInfo = "manual",
         )
 
     @Test
-    fun `getAllPipelineRuns returns mapped responses`() {
+    fun `getAllPipelines returns paginated results`() {
         val pageable = PageRequest.of(0, 20)
-        whenever(pipelineRepository.findAll(pageable)).thenReturn(PageImpl(listOf(defaultEntity)))
+        whenever(pipelineRepository.findAll(pageable)).thenReturn(PageImpl(listOf(sampleEntity), pageable, 1))
 
-        val result = service.getAllPipelineRuns(null, null, pageable)
+        val result = service.getPipelines(null, null, pageable)
 
-        assertEquals(1, result.size)
-        assertEquals("run-1", result[0].id)
+        assertEquals(1, result.totalElements)
+        assertEquals("pipe-1", result.content[0].id)
+        verify(pipelineRepository).findAll(pageable)
     }
 
     @Test
-    fun `getAllPipelineRuns returns empty list when none exist`() {
+    fun `getPipelinesByAgentId returns filtered results`() {
         val pageable = PageRequest.of(0, 20)
-        whenever(pipelineRepository.findAll(pageable)).thenReturn(PageImpl(emptyList()))
+        whenever(pipelineRepository.findByAgentId("agent-1", pageable)).thenReturn(PageImpl(listOf(sampleEntity), pageable, 1))
 
-        val result = service.getAllPipelineRuns(null, null, pageable)
+        val result = service.getPipelines("agent-1", null, pageable)
 
-        assertTrue(result.isEmpty())
-    }
-
-    @Test
-    fun `getPipelineRun returns response when found`() {
-        whenever(pipelineRepository.findById("run-1")).thenReturn(Optional.of(defaultEntity))
-
-        val result = service.getPipelineRun("run-1")
-
-        assertEquals("run-1", result.id)
-        assertEquals("CI Pipeline", result.pipelineName)
-    }
-
-    @Test
-    fun `getPipelineRun throws NoSuchElementException when not found`() {
-        whenever(pipelineRepository.findById("missing")).thenReturn(Optional.empty())
-
-        assertThrows<NoSuchElementException> {
-            service.getPipelineRun("missing")
-        }
-    }
-
-    @Test
-    fun `getPipelineRunsByAgentId delegates to repository with pagination`() {
-        val pageable = PageRequest.of(0, 20)
-        whenever(pipelineRepository.findByAgentId("agent-1", pageable)).thenReturn(PageImpl(listOf(defaultEntity)))
-
-        val result = service.getAllPipelineRuns("agent-1", null, pageable)
-
-        assertEquals(1, result.size)
+        assertEquals(1, result.totalElements)
         verify(pipelineRepository).findByAgentId("agent-1", pageable)
     }
 
     @Test
-    fun `getPipelineRunsByStatus delegates to repository with pagination`() {
+    fun `getPipelinesByStatus returns filtered results`() {
         val pageable = PageRequest.of(0, 20)
-        whenever(pipelineRepository.findByStatus("RUNNING", pageable)).thenReturn(PageImpl(listOf(defaultEntity)))
+        whenever(pipelineRepository.findByStatus("RUNNING", pageable)).thenReturn(PageImpl(listOf(sampleEntity), pageable, 1))
 
-        val result = service.getAllPipelineRuns(null, "RUNNING", pageable)
+        val result = service.getPipelines(null, "RUNNING", pageable)
 
-        assertEquals(1, result.size)
+        assertEquals(1, result.totalElements)
         verify(pipelineRepository).findByStatus("RUNNING", pageable)
     }
 
     @Test
-    fun `getPipelineRunsByAgentIdAndStatus delegates to repository with pagination`() {
+    fun `getPipelinesByAgentIdAndStatus returns filtered results`() {
         val pageable = PageRequest.of(0, 20)
-        whenever(pipelineRepository.findByAgentIdAndStatus("agent-1", "RUNNING", pageable)).thenReturn(PageImpl(listOf(defaultEntity)))
+        whenever(
+            pipelineRepository.findByAgentIdAndStatus("agent-1", "RUNNING", pageable),
+        ).thenReturn(PageImpl(listOf(sampleEntity), pageable, 1))
 
-        val result = service.getAllPipelineRuns("agent-1", "RUNNING", pageable)
+        val result = service.getPipelines("agent-1", "RUNNING", pageable)
 
-        assertEquals(1, result.size)
+        assertEquals(1, result.totalElements)
         verify(pipelineRepository).findByAgentIdAndStatus("agent-1", "RUNNING", pageable)
     }
 
     @Test
-    fun `createPipelineRun saves entity and returns response`() {
-        val request =
-            CreatePipelineRunRequest(
-                agentId = "agent-1",
-                pipelineName = "CI Pipeline",
-                steps = listOf(PipelineStepResponse(name = "Build", status = "PENDING", detail = "", elapsedMs = 0L)),
-                triggerInfo = "manual",
-            )
-        whenever(agentRepository.existsById("agent-1")).thenReturn(true)
-        whenever(pipelineRepository.save(any<PipelineRunEntity>())).thenAnswer { it.arguments[0] as PipelineRunEntity }
+    fun `getPipeline returns pipeline when found`() {
+        whenever(pipelineRepository.findById("pipe-1")).thenReturn(Optional.of(sampleEntity))
 
-        val result = service.createPipelineRun(request)
+        val result = service.getPipeline("pipe-1")
 
-        assertEquals("agent-1", result.agentId)
-        assertEquals("CI Pipeline", result.pipelineName)
-        assertEquals("QUEUED", result.status)
-        assertEquals(1, result.steps.size)
-        assertEquals("manual", result.triggerInfo)
+        assertEquals("pipe-1", result.id)
+        assertEquals("build-deploy", result.pipelineName)
     }
 
     @Test
-    fun `createPipelineRun auto-assigns UUID`() {
-        val request = CreatePipelineRunRequest(agentId = "agent-1", pipelineName = "Pipeline")
-        whenever(agentRepository.existsById("agent-1")).thenReturn(true)
-        val captor = argumentCaptor<PipelineRunEntity>()
+    fun `getPipeline throws when not found`() {
+        whenever(pipelineRepository.findById("missing")).thenReturn(Optional.empty())
+
+        assertThrows<NoSuchElementException> {
+            service.getPipeline("missing")
+        }
+    }
+
+    @Test
+    fun `createPipeline creates with valid agentId`() {
+        val agent = AgentEntity(id = "agent-1", name = "Alpha", type = "WORKER", status = "RUNNING", lastHeartbeat = 100L)
+        whenever(agentRepository.findById("agent-1")).thenReturn(Optional.of(agent))
         whenever(pipelineRepository.save(any<PipelineRunEntity>())).thenAnswer { it.arguments[0] as PipelineRunEntity }
 
-        service.createPipelineRun(request)
+        val request = CreatePipelineRunRequest(id = "pipe-1", agentId = "agent-1", pipelineName = "build-deploy")
+        val result = service.createPipeline(request)
+
+        assertEquals("pipe-1", result.id)
+        assertEquals("QUEUED", result.status)
+        assertTrue(result.startedAt > 0)
+    }
+
+    @Test
+    fun `createPipeline throws when agent not found`() {
+        whenever(agentRepository.findById("missing")).thenReturn(Optional.empty())
+
+        val request = CreatePipelineRunRequest(agentId = "missing", pipelineName = "build")
+
+        val ex =
+            assertThrows<NoSuchElementException> {
+                service.createPipeline(request)
+            }
+        assertTrue(ex.message!!.contains("Agent"))
+    }
+
+    @Test
+    fun `createPipeline auto-assigns UUID when id not provided`() {
+        val agent = AgentEntity(id = "agent-1", name = "Alpha", type = "WORKER", status = "RUNNING", lastHeartbeat = 100L)
+        whenever(agentRepository.findById("agent-1")).thenReturn(Optional.of(agent))
+        whenever(pipelineRepository.save(any<PipelineRunEntity>())).thenAnswer { it.arguments[0] as PipelineRunEntity }
+
+        val request = CreatePipelineRunRequest(agentId = "agent-1", pipelineName = "build")
+        val captor = argumentCaptor<PipelineRunEntity>()
+
+        service.createPipeline(request)
 
         verify(pipelineRepository).save(captor.capture())
         assertNotNull(captor.firstValue.id)
@@ -146,55 +147,33 @@ class PipelineServiceTest {
     }
 
     @Test
-    fun `createPipelineRun validates agent exists`() {
-        val request = CreatePipelineRunRequest(agentId = "missing", pipelineName = "Pipeline")
-        whenever(agentRepository.existsById("missing")).thenReturn(false)
-
-        assertThrows<NoSuchElementException> {
-            service.createPipelineRun(request)
-        }
-    }
-
-    @Test
-    fun `updateStatus updates status field`() {
-        whenever(pipelineRepository.findById("run-1")).thenReturn(Optional.of(defaultEntity))
+    fun `updateStatus updates pipeline status`() {
+        whenever(pipelineRepository.findById("pipe-1")).thenReturn(Optional.of(sampleEntity))
         whenever(pipelineRepository.save(any<PipelineRunEntity>())).thenAnswer { it.arguments[0] as PipelineRunEntity }
 
-        val result = service.updateStatus("run-1", "RUNNING")
+        val result = service.updateStatus("pipe-1", "RUNNING")
 
         assertEquals("RUNNING", result.status)
     }
 
     @Test
     fun `updateStatus sets finishedAt for terminal statuses`() {
-        whenever(pipelineRepository.findById("run-1")).thenReturn(Optional.of(defaultEntity))
-        val captor = argumentCaptor<PipelineRunEntity>()
+        val entity = sampleEntity.copy(status = "RUNNING", finishedAt = null)
+        whenever(pipelineRepository.findById("pipe-1")).thenReturn(Optional.of(entity))
         whenever(pipelineRepository.save(any<PipelineRunEntity>())).thenAnswer { it.arguments[0] as PipelineRunEntity }
 
-        service.updateStatus("run-1", "PASSED")
+        val result = service.updateStatus("pipe-1", "PASSED")
 
-        verify(pipelineRepository).save(captor.capture())
-        assertNotNull(captor.firstValue.finishedAt)
+        assertEquals("PASSED", result.status)
+        assertNotNull(result.finishedAt)
     }
 
     @Test
-    fun `updateStatus preserves null finishedAt for non-terminal statuses`() {
-        whenever(pipelineRepository.findById("run-1")).thenReturn(Optional.of(defaultEntity))
-        val captor = argumentCaptor<PipelineRunEntity>()
-        whenever(pipelineRepository.save(any<PipelineRunEntity>())).thenAnswer { it.arguments[0] as PipelineRunEntity }
-
-        service.updateStatus("run-1", "RUNNING")
-
-        verify(pipelineRepository).save(captor.capture())
-        assertNull(captor.firstValue.finishedAt)
-    }
-
-    @Test
-    fun `updateStatus throws for non-existent run`() {
+    fun `updateStatus throws when pipeline not found`() {
         whenever(pipelineRepository.findById("missing")).thenReturn(Optional.empty())
 
         assertThrows<NoSuchElementException> {
-            service.updateStatus("missing", "PASSED")
+            service.updateStatus("missing", "RUNNING")
         }
     }
 }


### PR DESCRIPTION
Closes #16

## Design
# Design Document: PipelineRun Server Endpoints (Issue #16)

## 1. Files to Create/Modify

### New Files (8 total)

| File | Purpose |
|------|---------|
| `server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunEntity.kt` | JPA entity with JSON steps column |
| `server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunResponse.kt` | Response DTO + request DTOs |
| `server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunMapper.kt` | Entity ↔ Response mapping |
| `server/src/main/kotlin/com/orchestradashboard/server/repository/PipelineRunJpaRepository.kt` | JPA repository with custom finders |
| `server/src/main/kotlin/com/orchestradashboard/server/service/PipelineService.kt` | Business logic + validation |
| `server/src/main/kotlin/com/orchestradashboard/server/controller/PipelineController.kt` | REST endpoints at `/api/v1/pipelines` |
| **Tests (written FIRST):** | |
| `server/src/test/kotlin/com/orchestradashboard/server/controller/PipelineControllerTest.kt` | `@WebMvcTest` — all endpoints |
| `server/src/test/kotlin/com/orchestradashboard/server/service/PipelineServiceTest.kt` | Unit tests with mocks |
| `server/src/test/kotlin/com/orchestradashboard/server/repository/PipelineRunJpaRepositoryTest.kt` | `@DataJpaTest` — custom queries + JSON column |

### No Modifications Needed
The existing Agent code and build config already have all required dependencies (JPA, Jackson, H2, mockito-kotlin, etc.).

---

## 2. TDD Test Plan (Write 

_(truncated)_

## Changed Files (9)
- `server/src/main/kotlin/com/orchestradashboard/server/controller/PipelineController.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunEntity.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunMapper.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/model/PipelineRunResponse.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/repository/PipelineRunJpaRepository.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/service/PipelineService.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/controller/PipelineControllerTest.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/repository/PipelineRunJpaRepositoryTest.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/service/PipelineServiceTest.kt`

## Review
The implementation is a solid, by-the-book execution of the design document. The Test-Driven Development (TDD) approach has resulted in a well-tested and robust feature.

### 1. Business Logic Correctness
- **PASS**: The logic is sound. The service layer correctly validates agent existence on pipeline creation (`createPipeline`), preventing orphaned records. The status update logic (`updateStatus`) correctly identifies terminal states ("PASSED", "FAILED", "CANCELLED") and sets the `finishedAt` timestamp only for those transitions, which is the desired behavior.

### 2. Edge Cases and Error Handling
- **PASS**: The implementation handles edge cases gracefully.
    - **Not Found**: `NoSuchElementException` is consistently thrown for missing entities, which the `PipelineController`'s `@Except

_(truncated)_

## AI Audit: PASS
[AUDIT: PASS]

The implementation aligns well with the original intent, handles edge cases, follows security best practices, and adheres to guidelines. The comments are minimal but appropriate, and the code is self-documenting. No critical or major issues were found.