### PR TITLE
feat: Implement API client and repository implementations with Ktor HTTP client

### DIFF
--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/PipelineRunDto.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/PipelineRunDto.kt
@@ -26,4 +26,5 @@ data class PipelineRunDto(
 @Serializable
 data class PipelineRunPageDto(
     val content: List<PipelineRunDto>,
+    val totalElements: Int = 0,
 )

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/network/DashboardApi.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/network/DashboardApi.kt
@@ -3,8 +3,14 @@ package com.orchestradashboard.shared.data.network
 import com.orchestradashboard.shared.data.dto.AgentDto
 import com.orchestradashboard.shared.data.dto.AgentEventDto
 import com.orchestradashboard.shared.data.dto.PipelineRunDto
+import kotlinx.coroutines.flow.Flow
 
+/**
+ * Contract for the Dashboard API surface consumed by repository implementations.
+ */
 interface DashboardApi {
+    fun observeAgents(): Flow<List<AgentDto>>
+
     suspend fun getAgents(): List<AgentDto>
 
     suspend fun getAgent(agentId: String): AgentDto
@@ -17,6 +23,10 @@ interface DashboardApi {
         agentId: String? = null,
         limit: Int = 50,
     ): List<AgentEventDto>
+
+    fun observePipelineRuns(agentId: String? = null): Flow<List<PipelineRunDto>>
+
+    fun observeEvents(agentId: String): Flow<List<AgentEventDto>>
 
     suspend fun registerAgent(agent: AgentDto): AgentDto
 

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/network/DashboardApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/network/DashboardApiClient.kt
@@ -13,11 +13,23 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 class DashboardApiClient(
     private val httpClient: HttpClient,
     private val baseUrl: String,
+    private val pollingIntervalMs: Long = 5000L,
 ) : DashboardApi {
+    override fun observeAgents(): Flow<List<AgentDto>> =
+        flow {
+            while (true) {
+                emit(getAgents())
+                delay(pollingIntervalMs)
+            }
+        }
+
     override suspend fun getAgents(): List<AgentDto> {
         return httpClient.get("$baseUrl/api/v1/agents").body()
     }
@@ -47,6 +59,22 @@ class DashboardApiClient(
             parameter("limit", limit)
         }.body()
     }
+
+    override fun observePipelineRuns(agentId: String?): Flow<List<PipelineRunDto>> =
+        flow {
+            while (true) {
+                emit(getPipelineRuns(agentId))
+                delay(pollingIntervalMs)
+            }
+        }
+
+    override fun observeEvents(agentId: String): Flow<List<AgentEventDto>> =
+        flow {
+            while (true) {
+                emit(getRecentEvents(agentId = agentId))
+                delay(pollingIntervalMs)
+            }
+        }
 
     override suspend fun registerAgent(agent: AgentDto): AgentDto {
         return httpClient.post("$baseUrl/api/v1/agents") {

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/AgentRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/AgentRepositoryImpl.kt
@@ -6,24 +6,17 @@ import com.orchestradashboard.shared.data.network.DashboardApi
 import com.orchestradashboard.shared.domain.model.Agent
 import com.orchestradashboard.shared.domain.model.Agent.AgentStatus
 import com.orchestradashboard.shared.domain.repository.AgentRepository
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 
 class AgentRepositoryImpl(
     private val api: DashboardApi,
     private val agentMapper: AgentMapper,
-    private val pollingIntervalMs: Long = 5_000L,
 ) : AgentRepository {
     override fun observeAgents(): Flow<List<Agent>> =
-        flow {
-            while (true) {
-                val agents = api.getAgents()
-                emit(agentMapper.toDomain(agents))
-                delay(pollingIntervalMs)
-            }
-        }
+        api.observeAgents()
+            .map { dtos -> agentMapper.toDomain(dtos) }
 
     override suspend fun getAgent(agentId: String): Result<Agent> =
         runCatching {

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/EventRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/EventRepositoryImpl.kt
@@ -4,23 +4,16 @@ import com.orchestradashboard.shared.data.mapper.AgentEventMapper
 import com.orchestradashboard.shared.data.network.DashboardApi
 import com.orchestradashboard.shared.domain.model.AgentEvent
 import com.orchestradashboard.shared.domain.repository.EventRepository
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 
 class EventRepositoryImpl(
     private val api: DashboardApi,
     private val mapper: AgentEventMapper,
-    private val pollingIntervalMs: Long = 5_000L,
 ) : EventRepository {
     override fun observeEvents(agentId: String): Flow<List<AgentEvent>> =
-        flow {
-            while (true) {
-                val events = api.getRecentEvents(agentId = agentId)
-                emit(mapper.toDomain(events))
-                delay(pollingIntervalMs)
-            }
-        }
+        api.observeEvents(agentId)
+            .map { dtos -> mapper.toDomain(dtos) }
 
     override suspend fun getRecentEvents(limit: Int): Result<List<AgentEvent>> =
         runCatching {

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/PipelineRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/PipelineRepositoryImpl.kt
@@ -3,24 +3,18 @@ package com.orchestradashboard.shared.data.repository
 import com.orchestradashboard.shared.data.mapper.PipelineRunMapper
 import com.orchestradashboard.shared.data.network.DashboardApi
 import com.orchestradashboard.shared.domain.model.PipelineRun
+import com.orchestradashboard.shared.domain.model.PipelineRunStatus
 import com.orchestradashboard.shared.domain.repository.PipelineRepository
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 
 class PipelineRepositoryImpl(
     private val api: DashboardApi,
     private val mapper: PipelineRunMapper,
-    private val pollingIntervalMs: Long = 5_000L,
 ) : PipelineRepository {
     override fun observePipelineRuns(agentId: String): Flow<List<PipelineRun>> =
-        flow {
-            while (true) {
-                val runs = api.getPipelineRuns(agentId)
-                emit(mapper.toDomain(runs))
-                delay(pollingIntervalMs)
-            }
-        }
+        api.observePipelineRuns(agentId)
+            .map { dtos -> mapper.toDomain(dtos) }
 
     override suspend fun getPipelineRun(runId: String): Result<PipelineRun> =
         runCatching {
@@ -28,16 +22,10 @@ class PipelineRepositoryImpl(
         }
 
     override fun observeActivePipelines(): Flow<List<PipelineRun>> =
-        flow {
-            while (true) {
-                val runs = api.getPipelineRuns(agentId = null)
-                val active =
-                    runs.filter {
-                        it.status.equals("RUNNING", ignoreCase = true) ||
-                            it.status.equals("QUEUED", ignoreCase = true)
-                    }
-                emit(mapper.toDomain(active))
-                delay(pollingIntervalMs)
+        api.observePipelineRuns()
+            .map { dtos ->
+                mapper.toDomain(dtos).filter {
+                    it.status == PipelineRunStatus.RUNNING || it.status == PipelineRunStatus.QUEUED
+                }
             }
-        }
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/network/FakeDashboardApiClient.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/network/FakeDashboardApiClient.kt
@@ -3,6 +3,9 @@ package com.orchestradashboard.shared.data.network
 import com.orchestradashboard.shared.data.dto.AgentDto
 import com.orchestradashboard.shared.data.dto.AgentEventDto
 import com.orchestradashboard.shared.data.dto.PipelineRunDto
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 class FakeDashboardApiClient : DashboardApi {
     var agentsResponse: List<AgentDto> = emptyList()
@@ -28,6 +31,15 @@ class FakeDashboardApiClient : DashboardApi {
     private fun maybeThrow() {
         errorToThrow?.let { throw it }
     }
+
+    override fun observeAgents(): Flow<List<AgentDto>> =
+        flow {
+            while (true) {
+                maybeThrow()
+                emit(getAgents())
+                delay(50L)
+            }
+        }
 
     override suspend fun getAgents(): List<AgentDto> {
         getAgentsCallCount++
@@ -71,6 +83,24 @@ class FakeDashboardApiClient : DashboardApi {
             }
         return filtered.take(limit)
     }
+
+    override fun observePipelineRuns(agentId: String?): Flow<List<PipelineRunDto>> =
+        flow {
+            while (true) {
+                maybeThrow()
+                emit(getPipelineRuns(agentId))
+                delay(50L)
+            }
+        }
+
+    override fun observeEvents(agentId: String): Flow<List<AgentEventDto>> =
+        flow {
+            while (true) {
+                maybeThrow()
+                emit(getRecentEvents(agentId = agentId))
+                delay(50L)
+            }
+        }
 
     override suspend fun registerAgent(agent: AgentDto): AgentDto {
         maybeThrow()

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/AgentRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/AgentRepositoryImplTest.kt
@@ -2,86 +2,118 @@ package com.orchestradashboard.shared.data.repository
 
 import com.orchestradashboard.shared.data.dto.AgentDto
 import com.orchestradashboard.shared.data.mapper.AgentMapper
-import com.orchestradashboard.shared.data.network.FakeDashboardApiClient
 import com.orchestradashboard.shared.domain.model.Agent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class AgentRepositoryImplTest {
-    private val fakeApi = FakeDashboardApiClient()
-    private val mapper = AgentMapper()
-    private val repository = AgentRepositoryImpl(fakeApi, mapper, pollingIntervalMs = 50L)
+    private val agentMapper = AgentMapper()
+
+    private fun createFakeClient() = FakeDashboardApiClient(pollingIntervalMs = 5000L)
 
     private val sampleAgentDto =
         AgentDto(
             id = "agent-1",
-            name = "Worker One",
+            name = "Alpha",
             type = "WORKER",
             status = "RUNNING",
-            lastHeartbeat = 1700000000L,
+            lastHeartbeat = 1000L,
+            metadata = mapOf("version" to "1.0"),
         )
 
     @Test
-    fun `getAgent returns Result success with mapped domain model on success`() =
+    fun `getAgent returns success with mapped domain model`() =
         runTest {
-            fakeApi.agentResponse = sampleAgentDto
+            val fakeClient = createFakeClient()
+            fakeClient.agents = listOf(sampleAgentDto)
+            val repo = AgentRepositoryImpl(fakeClient, agentMapper)
 
-            val result = repository.getAgent("agent-1")
+            val result = repo.getAgent("agent-1")
 
             assertTrue(result.isSuccess)
-            assertEquals("agent-1", result.getOrThrow().id)
-            assertEquals("Worker One", result.getOrThrow().name)
-            assertEquals(Agent.AgentType.WORKER, result.getOrThrow().type)
+            val agent = result.getOrThrow()
+            assertEquals("agent-1", agent.id)
+            assertEquals("Alpha", agent.name)
+            assertEquals(Agent.AgentType.WORKER, agent.type)
+            assertEquals(Agent.AgentStatus.RUNNING, agent.status)
         }
 
     @Test
-    fun `getAgent returns Result failure on network error`() =
+    fun `getAgent returns failure on network error`() =
         runTest {
-            fakeApi.errorToThrow = RuntimeException("Network error")
+            val fakeClient = createFakeClient()
+            fakeClient.shouldFail = true
+            val repo = AgentRepositoryImpl(fakeClient, agentMapper)
 
-            val result = repository.getAgent("agent-1")
+            val result = repo.getAgent("agent-1")
 
             assertTrue(result.isFailure)
-            assertEquals("Network error", result.exceptionOrNull()?.message)
         }
 
     @Test
-    fun `observeAgents emits agent list from API`() =
+    fun `observeAgents emits agent list`() =
         runTest {
-            fakeApi.agentsResponse = listOf(sampleAgentDto)
+            val fakeClient = createFakeClient()
+            fakeClient.agents = listOf(sampleAgentDto)
+            val repo = AgentRepositoryImpl(fakeClient, agentMapper)
 
-            val agents = repository.observeAgents().first()
+            val result = repo.observeAgents().first()
 
-            assertEquals(1, agents.size)
-            assertEquals("agent-1", agents[0].id)
+            assertEquals(1, result.size)
+            assertEquals("agent-1", result[0].id)
         }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `observeAgents emits periodically`() =
         runTest {
-            fakeApi.agentsResponse = listOf(sampleAgentDto)
+            val fakeClient = FakeDashboardApiClient(pollingIntervalMs = 1000L)
+            fakeClient.agents = listOf(sampleAgentDto)
+            val repo = AgentRepositoryImpl(fakeClient, agentMapper)
 
-            val emissions = repository.observeAgents().take(3).toList()
+            val emissions = mutableListOf<List<Agent>>()
+            val job =
+                launch {
+                    repo.observeAgents().take(3).toList(emissions)
+                }
+            advanceTimeBy(3000L)
+            job.join()
 
             assertEquals(3, emissions.size)
-            assertTrue(fakeApi.getAgentsCallCount >= 3)
         }
 
     @Test
-    fun `getAgentsByStatus filters correctly from API`() =
+    fun `observeAgents emits empty list when no agents`() =
         runTest {
-            fakeApi.agentsResponse =
+            val fakeClient = createFakeClient()
+            fakeClient.agents = emptyList()
+            val repo = AgentRepositoryImpl(fakeClient, agentMapper)
+
+            val result = repo.observeAgents().first()
+
+            assertTrue(result.isEmpty())
+        }
+
+    @Test
+    fun `getAgentsByStatus filters correctly`() =
+        runTest {
+            val fakeClient = createFakeClient()
+            fakeClient.agents =
                 listOf(
                     sampleAgentDto,
                     AgentDto("agent-2", "Idle Agent", "WORKER", "IDLE", 0L),
                 )
+            val repo = AgentRepositoryImpl(fakeClient, agentMapper)
 
-            val result = repository.getAgentsByStatus(Agent.AgentStatus.RUNNING)
+            val result = repo.getAgentsByStatus(Agent.AgentStatus.RUNNING)
 
             assertTrue(result.isSuccess)
             assertEquals(1, result.getOrThrow().size)
@@ -89,59 +121,66 @@ class AgentRepositoryImplTest {
         }
 
     @Test
-    fun `registerAgent returns Result success with mapped domain model`() =
+    fun `registerAgent returns success with mapped domain model`() =
         runTest {
-            fakeApi.registerResponse = sampleAgentDto
+            val fakeClient = createFakeClient()
+            val repo = AgentRepositoryImpl(fakeClient, agentMapper)
             val agent =
                 Agent(
                     id = "agent-1",
-                    name = "Worker One",
+                    name = "Alpha",
                     type = Agent.AgentType.WORKER,
                     status = Agent.AgentStatus.RUNNING,
-                    lastHeartbeat = 1700000000L,
+                    lastHeartbeat = 1000L,
+                    metadata = mapOf("version" to "1.0"),
                 )
 
-            val result = repository.registerAgent(agent)
+            val result = repo.registerAgent(agent)
 
             assertTrue(result.isSuccess)
             assertEquals("agent-1", result.getOrThrow().id)
         }
 
     @Test
-    fun `registerAgent returns Result failure on network error`() =
+    fun `registerAgent returns failure on network error`() =
         runTest {
-            fakeApi.errorToThrow = RuntimeException("Network error")
+            val fakeClient = createFakeClient()
+            fakeClient.shouldFail = true
+            val repo = AgentRepositoryImpl(fakeClient, agentMapper)
             val agent =
                 Agent(
                     id = "agent-1",
-                    name = "Worker One",
+                    name = "Alpha",
                     type = Agent.AgentType.WORKER,
                     status = Agent.AgentStatus.RUNNING,
                     lastHeartbeat = 0L,
                 )
 
-            val result = repository.registerAgent(agent)
+            val result = repo.registerAgent(agent)
 
             assertTrue(result.isFailure)
-            assertEquals("Network error", result.exceptionOrNull()?.message)
         }
 
     @Test
-    fun `deregisterAgent returns Result success`() =
+    fun `deregisterAgent returns success`() =
         runTest {
-            val result = repository.deregisterAgent("agent-1")
+            val fakeClient = createFakeClient()
+            val repo = AgentRepositoryImpl(fakeClient, agentMapper)
+
+            val result = repo.deregisterAgent("agent-1")
 
             assertTrue(result.isSuccess)
         }
 
     @Test
-    fun `deregisterAgent returns Result failure on network error`() =
+    fun `deregisterAgent returns failure on network error`() =
         runTest {
-            fakeApi.errorToThrow = RuntimeException("Network error")
+            val fakeClient = createFakeClient()
+            fakeClient.shouldFail = true
+            val repo = AgentRepositoryImpl(fakeClient, agentMapper)
 
-            val result = repository.deregisterAgent("agent-1")
+            val result = repo.deregisterAgent("agent-1")
 
             assertTrue(result.isFailure)
-            assertEquals("Network error", result.exceptionOrNull()?.message)
         }
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/EventRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/EventRepositoryImplTest.kt
@@ -2,76 +2,76 @@ package com.orchestradashboard.shared.data.repository
 
 import com.orchestradashboard.shared.data.dto.AgentEventDto
 import com.orchestradashboard.shared.data.mapper.AgentEventMapper
-import com.orchestradashboard.shared.data.network.FakeDashboardApiClient
 import com.orchestradashboard.shared.domain.model.EventType
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class EventRepositoryImplTest {
-    private val fakeApi = FakeDashboardApiClient()
     private val mapper = AgentEventMapper()
-    private val repository = EventRepositoryImpl(fakeApi, mapper, pollingIntervalMs = 50L)
+
+    private fun createFakeClient() = FakeDashboardApiClient(pollingIntervalMs = 5000L)
 
     private val sampleEventDto =
         AgentEventDto(
             id = "evt-1",
             agentId = "agent-1",
             type = "STATUS_CHANGE",
+            payload = JsonObject(mapOf("old" to JsonPrimitive("IDLE"), "new" to JsonPrimitive("RUNNING"))),
             timestamp = 1700000000L,
         )
 
-    @Test
-    fun `getRecentEvents returns Result success with mapped events`() =
-        runTest {
-            fakeApi.eventsResponse = listOf(sampleEventDto)
+    private val otherAgentEvent =
+        AgentEventDto(
+            id = "evt-2",
+            agentId = "agent-2",
+            type = "HEARTBEAT",
+            timestamp = 2000L,
+        )
 
-            val result = repository.getRecentEvents(50)
+    @Test
+    fun `getRecentEvents returns mapped events`() =
+        runTest {
+            val fakeClient = createFakeClient()
+            fakeClient.events = listOf(sampleEventDto, otherAgentEvent)
+            val repo = EventRepositoryImpl(fakeClient, mapper)
+
+            val result = repo.getRecentEvents(50)
 
             assertTrue(result.isSuccess)
-            assertEquals(1, result.getOrThrow().size)
-            assertEquals("evt-1", result.getOrThrow()[0].id)
-            assertEquals(EventType.STATUS_CHANGE, result.getOrThrow()[0].type)
+            val events = result.getOrThrow()
+            assertEquals(2, events.size)
+            assertEquals("evt-1", events[0].id)
+            assertEquals(EventType.STATUS_CHANGE, events[0].type)
         }
 
     @Test
-    fun `getRecentEvents returns Result failure on network error`() =
+    fun `getRecentEvents returns failure on error`() =
         runTest {
-            fakeApi.errorToThrow = RuntimeException("Network error")
+            val fakeClient = createFakeClient()
+            fakeClient.shouldFail = true
+            val repo = EventRepositoryImpl(fakeClient, mapper)
 
-            val result = repository.getRecentEvents(50)
+            val result = repo.getRecentEvents(50)
 
             assertTrue(result.isFailure)
-            assertEquals("Network error", result.exceptionOrNull()?.message)
         }
 
     @Test
-    fun `observeEvents emits events for given agentId`() =
+    fun `observeEvents emits for given agentId`() =
         runTest {
-            fakeApi.eventsResponse =
-                listOf(
-                    sampleEventDto,
-                    AgentEventDto("evt-2", "agent-2", "HEARTBEAT", emptyMap(), 200L),
-                )
+            val fakeClient = createFakeClient()
+            fakeClient.events = listOf(sampleEventDto, otherAgentEvent)
+            val repo = EventRepositoryImpl(fakeClient, mapper)
 
-            val events = repository.observeEvents("agent-1").first()
+            val result = repo.observeEvents("agent-1").first()
 
-            assertEquals(1, events.size)
-            assertEquals("evt-1", events[0].id)
-        }
-
-    @Test
-    fun `observeEvents emits periodically`() =
-        runTest {
-            fakeApi.eventsResponse = listOf(sampleEventDto)
-
-            val emissions = repository.observeEvents("agent-1").take(3).toList()
-
-            assertEquals(3, emissions.size)
-            assertTrue(fakeApi.getRecentEventsCallCount >= 3)
+            assertEquals(1, result.size)
+            assertEquals("agent-1", result[0].agentId)
+            assertEquals(EventType.STATUS_CHANGE, result[0].type)
         }
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/FakeDashboardApiClient.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/FakeDashboardApiClient.kt
@@ -1,0 +1,92 @@
+package com.orchestradashboard.shared.data.repository
+
+import com.orchestradashboard.shared.data.dto.AgentDto
+import com.orchestradashboard.shared.data.dto.AgentEventDto
+import com.orchestradashboard.shared.data.dto.PipelineRunDto
+import com.orchestradashboard.shared.data.network.DashboardApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class FakeDashboardApiClient(
+    private val pollingIntervalMs: Long = 5000L,
+) : DashboardApi {
+    var agents: List<AgentDto> = emptyList()
+    var pipelineRuns: List<PipelineRunDto> = emptyList()
+    var events: List<AgentEventDto> = emptyList()
+    var shouldFail: Boolean = false
+
+    override fun observeAgents(): Flow<List<AgentDto>> =
+        flow {
+            while (true) {
+                if (shouldFail) throw RuntimeException("Network error")
+                emit(agents)
+                delay(pollingIntervalMs)
+            }
+        }
+
+    override suspend fun getAgents(): List<AgentDto> {
+        if (shouldFail) throw RuntimeException("Network error")
+        return agents
+    }
+
+    override suspend fun getAgent(agentId: String): AgentDto {
+        if (shouldFail) throw RuntimeException("Network error")
+        return agents.first { it.id == agentId }
+    }
+
+    override suspend fun getPipelineRuns(agentId: String?): List<PipelineRunDto> {
+        if (shouldFail) throw RuntimeException("Network error")
+        return if (agentId != null) {
+            pipelineRuns.filter { it.agentId == agentId }
+        } else {
+            pipelineRuns
+        }
+    }
+
+    override suspend fun getPipelineRun(id: String): PipelineRunDto {
+        if (shouldFail) throw RuntimeException("Network error")
+        return pipelineRuns.first { it.id == id }
+    }
+
+    override suspend fun getRecentEvents(
+        agentId: String?,
+        limit: Int,
+    ): List<AgentEventDto> {
+        if (shouldFail) throw RuntimeException("Network error")
+        val filtered =
+            if (agentId != null) {
+                events.filter { it.agentId == agentId }
+            } else {
+                events
+            }
+        return filtered.take(limit)
+    }
+
+    override fun observePipelineRuns(agentId: String?): Flow<List<PipelineRunDto>> =
+        flow {
+            while (true) {
+                if (shouldFail) throw RuntimeException("Network error")
+                emit(getPipelineRuns(agentId))
+                delay(pollingIntervalMs)
+            }
+        }
+
+    override fun observeEvents(agentId: String): Flow<List<AgentEventDto>> =
+        flow {
+            while (true) {
+                if (shouldFail) throw RuntimeException("Network error")
+                emit(getRecentEvents(agentId = agentId))
+                delay(pollingIntervalMs)
+            }
+        }
+
+    override suspend fun registerAgent(agent: AgentDto): AgentDto {
+        if (shouldFail) throw RuntimeException("Network error")
+        return agent
+    }
+
+    override suspend fun deregisterAgent(agentId: String) {
+        if (shouldFail) throw RuntimeException("Network error")
+    }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/PipelineRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/PipelineRepositoryImplTest.kt
@@ -3,95 +3,118 @@ package com.orchestradashboard.shared.data.repository
 import com.orchestradashboard.shared.data.dto.PipelineRunDto
 import com.orchestradashboard.shared.data.dto.PipelineStepDto
 import com.orchestradashboard.shared.data.mapper.PipelineRunMapper
-import com.orchestradashboard.shared.data.network.FakeDashboardApiClient
 import com.orchestradashboard.shared.domain.model.PipelineRunStatus
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class PipelineRepositoryImplTest {
-    private val fakeApi = FakeDashboardApiClient()
     private val mapper = PipelineRunMapper()
-    private val repository = PipelineRepositoryImpl(fakeApi, mapper, pollingIntervalMs = 50L)
+
+    private fun createFakeClient() = FakeDashboardApiClient(pollingIntervalMs = 5000L)
 
     private val sampleRunDto =
         PipelineRunDto(
             id = "run-1",
             agentId = "agent-1",
-            pipelineName = "Build",
+            pipelineName = "build-pipeline",
             status = "RUNNING",
-            steps = listOf(PipelineStepDto("Compile", "PASSED", "OK", 1000L)),
-            startedAt = 1700000000L,
+            steps =
+                listOf(
+                    PipelineStepDto(
+                        name = "compile",
+                        status = "PASSED",
+                        detail = "Compiled successfully",
+                        elapsedMs = 1200L,
+                    ),
+                ),
+            startedAt = 1000L,
+            finishedAt = null,
+            triggerInfo = "manual",
+        )
+
+    private val queuedRunDto =
+        PipelineRunDto(
+            id = "run-2",
+            agentId = "agent-2",
+            pipelineName = "test-pipeline",
+            status = "QUEUED",
+            steps = emptyList(),
+            startedAt = 2000L,
+            finishedAt = null,
+            triggerInfo = "scheduled",
+        )
+
+    private val passedRunDto =
+        PipelineRunDto(
+            id = "run-3",
+            agentId = "agent-1",
+            pipelineName = "deploy-pipeline",
+            status = "PASSED",
+            steps = emptyList(),
+            startedAt = 500L,
+            finishedAt = 1500L,
+            triggerInfo = "ci",
         )
 
     @Test
-    fun `getPipelineRun returns Result success with mapped domain model`() =
+    fun `observePipelineRuns emits runs for agent`() =
         runTest {
-            fakeApi.pipelineRunResponse = sampleRunDto
+            val fakeClient = createFakeClient()
+            fakeClient.pipelineRuns = listOf(sampleRunDto, queuedRunDto, passedRunDto)
+            val repo = PipelineRepositoryImpl(fakeClient, mapper)
 
-            val result = repository.getPipelineRun("run-1")
+            val result = repo.observePipelineRuns("agent-1").first()
+
+            assertEquals(2, result.size)
+            assertTrue(result.all { it.agentId == "agent-1" })
+        }
+
+    @Test
+    fun `getPipelineRun returns success`() =
+        runTest {
+            val fakeClient = createFakeClient()
+            fakeClient.pipelineRuns = listOf(sampleRunDto)
+            val repo = PipelineRepositoryImpl(fakeClient, mapper)
+
+            val result = repo.getPipelineRun("run-1")
 
             assertTrue(result.isSuccess)
-            assertEquals("run-1", result.getOrThrow().id)
-            assertEquals(PipelineRunStatus.RUNNING, result.getOrThrow().status)
-            assertEquals(1, result.getOrThrow().steps.size)
+            val run = result.getOrThrow()
+            assertEquals("run-1", run.id)
+            assertEquals("build-pipeline", run.pipelineName)
+            assertEquals(PipelineRunStatus.RUNNING, run.status)
+            assertEquals(1, run.steps.size)
         }
 
     @Test
-    fun `getPipelineRun returns Result failure on network error`() =
+    fun `getPipelineRun returns failure on network error`() =
         runTest {
-            fakeApi.errorToThrow = RuntimeException("Network error")
+            val fakeClient = createFakeClient()
+            fakeClient.shouldFail = true
+            val repo = PipelineRepositoryImpl(fakeClient, mapper)
 
-            val result = repository.getPipelineRun("run-1")
+            val result = repo.getPipelineRun("run-1")
 
             assertTrue(result.isFailure)
-            assertEquals("Network error", result.exceptionOrNull()?.message)
         }
 
     @Test
-    fun `observePipelineRuns emits pipeline list for given agentId`() =
+    fun `observeActivePipelines filters RUNNING and QUEUED`() =
         runTest {
-            fakeApi.pipelineRunsResponse =
-                listOf(
-                    sampleRunDto,
-                    PipelineRunDto("run-2", "agent-2", "Deploy", "PASSED", emptyList(), 100L, 200L),
-                )
+            val fakeClient = createFakeClient()
+            fakeClient.pipelineRuns = listOf(sampleRunDto, queuedRunDto, passedRunDto)
+            val repo = PipelineRepositoryImpl(fakeClient, mapper)
 
-            val runs = repository.observePipelineRuns("agent-1").first()
+            val result = repo.observeActivePipelines().first()
 
-            assertEquals(1, runs.size)
-            assertEquals("run-1", runs[0].id)
-        }
-
-    @Test
-    fun `observeActivePipelines emits only active pipelines`() =
-        runTest {
-            fakeApi.pipelineRunsResponse =
-                listOf(
-                    // RUNNING
-                    sampleRunDto,
-                    PipelineRunDto("run-2", "agent-2", "Deploy", "PASSED", emptyList(), 100L, 200L),
-                    PipelineRunDto("run-3", "agent-3", "Test", "QUEUED", emptyList(), 300L),
-                )
-
-            val active = repository.observeActivePipelines().first()
-
-            assertEquals(2, active.size)
-            assertTrue(active.all { it.status == PipelineRunStatus.RUNNING || it.status == PipelineRunStatus.QUEUED })
-        }
-
-    @Test
-    fun `observePipelineRuns emits periodically`() =
-        runTest {
-            fakeApi.pipelineRunsResponse = listOf(sampleRunDto)
-
-            val emissions = repository.observePipelineRuns("agent-1").take(3).toList()
-
-            assertEquals(3, emissions.size)
-            assertTrue(fakeApi.getPipelineRunsCallCount >= 3)
+            assertEquals(2, result.size)
+            assertTrue(
+                result.all {
+                    it.status == PipelineRunStatus.RUNNING || it.status == PipelineRunStatus.QUEUED
+                },
+            )
         }
 }


### PR DESCRIPTION
Closes #23

## Design
Now I have complete understanding. Let me produce the design document.

---

# Design Document: Issue #23 — API Client & Repository Implementations

## 1. Files to Create/Modify

### New Files (8)

| # | Path | Purpose |
|---|------|---------|
| 1 | `shared/src/commonMain/.../data/dto/PipelineRunDto.kt` | DTO for pipeline runs + steps |
| 2 | `shared/src/commonMain/.../data/mapper/PipelineRunMapper.kt` | PipelineRunDto → PipelineRun |
| 3 | `shared/src/commonMain/.../data/mapper/AgentEventMapper.kt` | AgentEventDto → AgentEvent |
| 4 | `shared/src/commonMain/.../data/repository/PipelineRepositoryImpl.kt` | Implements PipelineRepository |
| 5 | `shared/src/commonMain/.../data/repository/EventRepositoryImpl.kt` | Implements EventRepository |
| 6 | `shared/src/commonTest/.../data/repository/FakeDashboardApiClient.kt` | Fake API client for tests |
| 7 | `shared/src/commonTest/.../data/repository/AgentRepositoryImplTest.kt` | Tests for AgentRepositoryImpl |
| 8 | `shared/src/commonTest/.../data/repository/PipelineRepositoryImplTest.kt` | Tests for PipelineRepositoryImpl |

*(Note: `EventRepositoryImplTest.kt` can be added if time allows but the issue only explicitly requires `AgentRepositoryImplTest.kt` and `FakeDashboardApiClient`.)*

### Modified Files (3)

| # | Path | Change |
|---|------|--------|
| 1 | `shared/src/commonMain/.../data/dto/MetricDto.kt` | Add `id` field to `AgentEventDto` (server returns it, domain model needs it) |
| 2 | `shared/src/commonMain/.../data/networ

_(truncated)_

## Changed Files (15)
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/MetricDto.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/PipelineRunDto.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/mapper/AgentEventMapper.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/mapper/PipelineRunMapper.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/network/DashboardApi.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/network/DashboardApiClient.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/AgentRepositoryImpl.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/EventRepositoryImpl.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/PipelineRepositoryImpl.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/mapper/AgentEventMapperTest.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/mapper/PipelineRunMapperTest.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/AgentRepositoryImplTest.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/EventRepositoryImplTest.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/FakeDashboardApiClient.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/PipelineRepositoryImplTest.kt`

## Review
This implementation is of high quality and correctly addresses the requirements outlined in the GitHub issue and design document.

### 1. Business Logic Correctness
- **Polling Implementation:** The transition from a simple fetch to a polling `Flow` in `DashboardApiClient` (`observeAgents`, `observePipelineRuns`, `observeEvents`) is correctly implemented using a `while(true)` loop with a `delay`. This meets the core requirement for periodic updates.
- **Repository Logic:** All three repository implementations (`AgentRepositoryImpl`, `PipelineRepositoryImpl`, `EventRepositoryImpl`) correctly delegate to the new `DashboardApi` interface. They use `flow.map` to transform DTOs into domain models, which is the correct and idiomatic approach.
- **Filtering Logic:** `observeActivePipelines` corre

_(truncated)_

## AI Audit: PASS
[AUDIT: PASS]

The implementation aligns well with the original intent, handles most edge cases, and follows good security practices. While there are some minor issues with unnecessary comments and edge case handling, these do not significantly impact the functionality or security of the application. The code is clean, well-structured, and maintainable.