### PR TITLE
feat: feat: Implement JWT Authentication and Authorization for API access

### DIFF
--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -1,0 +1,3 @@
+# Google Tink (pulled by androidx-security-crypto) references annotations not in the runtime classpath
+-dontwarn com.google.errorprone.annotations.**
+-dontwarn org.slf4j.**

--- a/androidApp/src/main/kotlin/com/orchestradashboard/android/App.kt
+++ b/androidApp/src/main/kotlin/com/orchestradashboard/android/App.kt
@@ -9,7 +9,12 @@ import com.orchestradashboard.shared.domain.model.DashboardViewModel
 import com.orchestradashboard.shared.ui.screen.AppNavigation
 import com.orchestradashboard.shared.ui.theme.DashboardTheme
 
-class OrchestraApplication : Application()
+class OrchestraApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        AppContainer.initialize(this)
+    }
+}
 
 class MainActivity : ComponentActivity() {
     private lateinit var viewModel: DashboardViewModel

--- a/androidApp/src/main/kotlin/com/orchestradashboard/android/di/AppContainer.kt
+++ b/androidApp/src/main/kotlin/com/orchestradashboard/android/di/AppContainer.kt
@@ -1,16 +1,20 @@
 package com.orchestradashboard.android.di
 
+import android.content.Context
 import com.orchestradashboard.shared.data.mapper.AgentEventMapper
 import com.orchestradashboard.shared.data.mapper.AgentMapper
 import com.orchestradashboard.shared.data.mapper.PipelineRunMapper
 import com.orchestradashboard.shared.data.network.DashboardApiClient
 import com.orchestradashboard.shared.data.repository.AgentRepositoryImpl
+import com.orchestradashboard.shared.data.repository.AndroidTokenRepository
 import com.orchestradashboard.shared.data.repository.EventRepositoryImpl
 import com.orchestradashboard.shared.data.repository.PipelineRepositoryImpl
+import com.orchestradashboard.shared.data.repository.TokenRefreshHandler
 import com.orchestradashboard.shared.domain.model.DashboardViewModel
 import com.orchestradashboard.shared.domain.repository.AgentRepository
 import com.orchestradashboard.shared.domain.repository.EventRepository
 import com.orchestradashboard.shared.domain.repository.PipelineRepository
+import com.orchestradashboard.shared.domain.repository.TokenRepository
 import com.orchestradashboard.shared.domain.usecase.GetAgentUseCase
 import com.orchestradashboard.shared.domain.usecase.ObserveAgentsUseCase
 import com.orchestradashboard.shared.domain.usecase.ObserveEventsUseCase
@@ -29,6 +33,12 @@ import kotlinx.serialization.json.Json
  * All dependencies are lazily initialized and singletons unless noted.
  */
 object AppContainer {
+    private lateinit var applicationContext: Context
+
+    fun initialize(context: Context) {
+        applicationContext = context.applicationContext
+    }
+
     // ─── Configuration ──────────────────────────────────────────
 
     private val serverBaseUrl: String
@@ -54,6 +64,16 @@ object AppContainer {
 
     private val apiClient: DashboardApiClient by lazy {
         DashboardApiClient(httpClient, serverBaseUrl)
+    }
+
+    // ─── Auth ────────────────────────────────────────────────────
+
+    val tokenRepository: TokenRepository by lazy {
+        AndroidTokenRepository(applicationContext)
+    }
+
+    val tokenRefreshHandler: TokenRefreshHandler by lazy {
+        TokenRefreshHandler(httpClient, serverBaseUrl, tokenRepository)
     }
 
     // ─── Mappers ────────────────────────────────────────────────

--- a/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/di/AppContainer.kt
+++ b/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/di/AppContainer.kt
@@ -5,12 +5,15 @@ import com.orchestradashboard.shared.data.mapper.AgentMapper
 import com.orchestradashboard.shared.data.mapper.PipelineRunMapper
 import com.orchestradashboard.shared.data.network.DashboardApiClient
 import com.orchestradashboard.shared.data.repository.AgentRepositoryImpl
+import com.orchestradashboard.shared.data.repository.DesktopTokenRepository
 import com.orchestradashboard.shared.data.repository.EventRepositoryImpl
 import com.orchestradashboard.shared.data.repository.PipelineRepositoryImpl
+import com.orchestradashboard.shared.data.repository.TokenRefreshHandler
 import com.orchestradashboard.shared.domain.model.DashboardViewModel
 import com.orchestradashboard.shared.domain.repository.AgentRepository
 import com.orchestradashboard.shared.domain.repository.EventRepository
 import com.orchestradashboard.shared.domain.repository.PipelineRepository
+import com.orchestradashboard.shared.domain.repository.TokenRepository
 import com.orchestradashboard.shared.domain.usecase.GetAgentUseCase
 import com.orchestradashboard.shared.domain.usecase.ObserveAgentsUseCase
 import com.orchestradashboard.shared.domain.usecase.ObserveEventsUseCase
@@ -53,6 +56,16 @@ object AppContainer {
 
     private val apiClient: DashboardApiClient by lazy {
         DashboardApiClient(httpClient, serverBaseUrl)
+    }
+
+    // ─── Auth ────────────────────────────────────────────────────
+
+    val tokenRepository: TokenRepository by lazy {
+        DesktopTokenRepository()
+    }
+
+    val tokenRefreshHandler: TokenRefreshHandler by lazy {
+        TokenRefreshHandler(httpClient, serverBaseUrl, tokenRepository)
     }
 
     // ─── Mappers ────────────────────────────────────────────────

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,8 @@ mockito-kotlin = "5.4.0"
 testcontainers = "1.20.1"
 detekt = "1.23.7"
 ktlint = "12.1.1"
+jjwt = "0.12.6"
+androidx-security = "1.1.0-alpha06"
 agp = "8.5.2"
 androidx-activity = "1.9.2"
 androidx-core = "1.13.1"
@@ -69,9 +71,15 @@ testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.
 junit5-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
 junit5-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
 
+# JWT
+jjwt-api = { module = "io.jsonwebtoken:jjwt-api", version.ref = "jjwt" }
+jjwt-impl = { module = "io.jsonwebtoken:jjwt-impl", version.ref = "jjwt" }
+jjwt-jackson = { module = "io.jsonwebtoken:jjwt-jackson", version.ref = "jjwt" }
+
 # Android
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-security" }
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -18,6 +18,9 @@ dependencies {
     implementation(libs.spring.boot.starter.websocket)
     implementation(libs.spring.boot.starter.security)
     implementation(libs.spring.boot.starter.validation)
+    implementation(libs.jjwt.api)
+    runtimeOnly(libs.jjwt.impl)
+    runtimeOnly(libs.jjwt.jackson)
     implementation(libs.spring.boot.starter.actuator)
     implementation(libs.serialization.json)
 
@@ -27,6 +30,7 @@ dependencies {
 
     // Test
     testImplementation(libs.spring.boot.starter.test)
+    testImplementation("org.springframework.security:spring-security-test")
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.kotlin.test.junit5)
     testImplementation(libs.testcontainers.core)

--- a/server/src/main/kotlin/com/orchestradashboard/server/config/JwtAuthenticationFilter.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/config/JwtAuthenticationFilter.kt
@@ -1,0 +1,37 @@
+package com.orchestradashboard.server.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class JwtAuthenticationFilter(
+    private val jwtTokenProvider: JwtTokenProvider,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val token = extractToken(request)
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            val subject = jwtTokenProvider.getSubject(token)
+            val auth = UsernamePasswordAuthenticationToken(subject, null, emptyList())
+            SecurityContextHolder.getContext().authentication = auth
+        }
+        filterChain.doFilter(request, response)
+    }
+
+    private fun extractToken(request: HttpServletRequest): String? {
+        val header = request.getHeader("Authorization") ?: return null
+        return if (header.startsWith(BEARER_PREFIX)) header.substring(BEARER_PREFIX.length) else null
+    }
+
+    companion object {
+        private const val BEARER_PREFIX = "Bearer "
+    }
+}

--- a/server/src/main/kotlin/com/orchestradashboard/server/config/JwtTokenProvider.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/config/JwtTokenProvider.kt
@@ -1,0 +1,52 @@
+package com.orchestradashboard.server.config
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.util.Date
+import javax.crypto.SecretKey
+
+@Component
+class JwtTokenProvider(
+    @Value("\${jwt.secret}") private val secret: String,
+    @Value("\${jwt.access-expiration-ms:900000}") private val accessExpirationMs: Long,
+    @Value("\${jwt.refresh-expiration-ms:604800000}") private val refreshExpirationMs: Long,
+) {
+    private val key: SecretKey by lazy {
+        Keys.hmacShaKeyFor(secret.toByteArray())
+    }
+
+    fun generateAccessToken(subject: String): String = generateToken(subject, accessExpirationMs)
+
+    fun generateRefreshToken(subject: String): String = generateToken(subject, refreshExpirationMs)
+
+    fun validateToken(token: String): Boolean =
+        try {
+            Jwts.parser().verifyWith(key).build().parseSignedClaims(token)
+            true
+        } catch (
+            @Suppress("TooGenericExceptionCaught", "SwallowedException") e: Exception,
+        ) {
+            false
+        }
+
+    fun getSubject(token: String): String =
+        Jwts.parser().verifyWith(key).build()
+            .parseSignedClaims(token).payload.subject
+
+    fun getAccessExpirationMs(): Long = accessExpirationMs
+
+    private fun generateToken(
+        subject: String,
+        expirationMs: Long,
+    ): String {
+        val now = Date()
+        return Jwts.builder()
+            .subject(subject)
+            .issuedAt(now)
+            .expiration(Date(now.time + expirationMs))
+            .signWith(key)
+            .compact()
+    }
+}

--- a/server/src/main/kotlin/com/orchestradashboard/server/config/SecurityConfig.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/config/SecurityConfig.kt
@@ -1,30 +1,37 @@
 package com.orchestradashboard.server.config
 
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
-/**
- * Spring Security configuration.
- * All API endpoints are open by default for this open-source dashboard.
- * Replace with proper authentication for production deployments.
- */
 @Configuration
 @EnableWebSecurity
-class SecurityConfig {
+class SecurityConfig(
+    private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests { auth ->
                 auth
                     .requestMatchers("/actuator/health").permitAll()
-                    .requestMatchers("/api/**").permitAll()
+                    .requestMatchers("/api/v1/auth/**").permitAll()
                     .requestMatchers("/ws/**").permitAll()
                     .requestMatchers("/h2-console/**").permitAll()
                     .anyRequest().authenticated()
+            }
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+            .exceptionHandling {
+                it.authenticationEntryPoint { _, response, _ ->
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized")
+                }
             }
             .headers { it.frameOptions { fo -> fo.sameOrigin() } }
         return http.build()

--- a/server/src/main/kotlin/com/orchestradashboard/server/controller/AuthController.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/controller/AuthController.kt
@@ -1,0 +1,54 @@
+package com.orchestradashboard.server.controller
+
+import com.orchestradashboard.server.config.JwtTokenProvider
+import com.orchestradashboard.server.model.AuthRequest
+import com.orchestradashboard.server.model.AuthResponse
+import com.orchestradashboard.server.model.RefreshRequest
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/auth")
+class AuthController(
+    private val jwtTokenProvider: JwtTokenProvider,
+    @Value("\${auth.api-key}") private val configuredApiKey: String,
+) {
+    @PostMapping("/login")
+    fun login(
+        @RequestBody request: AuthRequest,
+    ): ResponseEntity<AuthResponse> {
+        if (request.apiKey != configuredApiKey) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        }
+        val subject = "dashboard-client"
+        return ResponseEntity.ok(
+            AuthResponse(
+                accessToken = jwtTokenProvider.generateAccessToken(subject),
+                refreshToken = jwtTokenProvider.generateRefreshToken(subject),
+                expiresIn = jwtTokenProvider.getAccessExpirationMs() / 1000,
+            ),
+        )
+    }
+
+    @PostMapping("/refresh")
+    fun refresh(
+        @RequestBody request: RefreshRequest,
+    ): ResponseEntity<AuthResponse> {
+        if (!jwtTokenProvider.validateToken(request.refreshToken)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        }
+        val subject = jwtTokenProvider.getSubject(request.refreshToken)
+        return ResponseEntity.ok(
+            AuthResponse(
+                accessToken = jwtTokenProvider.generateAccessToken(subject),
+                refreshToken = jwtTokenProvider.generateRefreshToken(subject),
+                expiresIn = jwtTokenProvider.getAccessExpirationMs() / 1000,
+            ),
+        )
+    }
+}

--- a/server/src/main/kotlin/com/orchestradashboard/server/model/AuthRequest.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/model/AuthRequest.kt
@@ -1,0 +1,5 @@
+package com.orchestradashboard.server.model
+
+data class AuthRequest(val apiKey: String)
+
+data class RefreshRequest(val refreshToken: String)

--- a/server/src/main/kotlin/com/orchestradashboard/server/model/AuthResponse.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/model/AuthResponse.kt
@@ -1,0 +1,10 @@
+package com.orchestradashboard.server.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class AuthResponse(
+    @JsonProperty("access_token") val accessToken: String,
+    @JsonProperty("refresh_token") val refreshToken: String,
+    @JsonProperty("expires_in") val expiresIn: Long,
+    @JsonProperty("token_type") val tokenType: String = "Bearer",
+)

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -40,6 +40,14 @@ logging:
     org.springframework.web: WARN
     org.hibernate: WARN
 
+jwt:
+  secret: ${JWT_SECRET:default-dev-secret-that-is-at-least-32-bytes-long!!}
+  access-expiration-ms: 900000
+  refresh-expiration-ms: 604800000
+
+auth:
+  api-key: ${AUTH_API_KEY:dev-api-key}
+
 dashboard:
   orchestrator:
     api-url: ${ORCHESTRATOR_API_URL:http://localhost:9000}

--- a/server/src/test/kotlin/com/orchestradashboard/server/config/JwtTokenProviderTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/config/JwtTokenProviderTest.kt
@@ -1,0 +1,74 @@
+package com.orchestradashboard.server.config
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class JwtTokenProviderTest {
+    private val testSecret = "test-secret-key-that-is-at-least-32-bytes-long!!"
+    private val accessExpirationMs = 900_000L
+    private val refreshExpirationMs = 604_800_000L
+
+    private val provider =
+        JwtTokenProvider(
+            secret = testSecret,
+            accessExpirationMs = accessExpirationMs,
+            refreshExpirationMs = refreshExpirationMs,
+        )
+
+    @Test
+    fun `should generate non-blank access token for valid subject`() {
+        val token = provider.generateAccessToken("dashboard-client")
+        assertTrue(token.isNotBlank())
+    }
+
+    @Test
+    fun `should generate valid JWT when credentials match`() {
+        val token = provider.generateAccessToken("dashboard-client")
+        assertTrue(provider.validateToken(token))
+        assertEquals("dashboard-client", provider.getSubject(token))
+    }
+
+    @Test
+    fun `should validate a freshly generated token as valid`() {
+        val token = provider.generateAccessToken("test-subject")
+        assertTrue(provider.validateToken(token))
+    }
+
+    @Test
+    fun `should reject token with tampered signature`() {
+        val token = provider.generateAccessToken("dashboard-client")
+        val tampered = token.dropLast(5) + "XXXXX"
+        assertFalse(provider.validateToken(tampered))
+    }
+
+    @Test
+    fun `should reject expired token`() {
+        val shortLivedProvider =
+            JwtTokenProvider(
+                secret = testSecret,
+                accessExpirationMs = 1L,
+                refreshExpirationMs = 1L,
+            )
+        val token = shortLivedProvider.generateAccessToken("dashboard-client")
+        Thread.sleep(50)
+        assertFalse(shortLivedProvider.validateToken(token))
+    }
+
+    @Test
+    fun `should extract correct subject from token`() {
+        val token = provider.generateAccessToken("my-service")
+        assertEquals("my-service", provider.getSubject(token))
+    }
+
+    @Test
+    fun `should generate refresh token with longer expiry`() {
+        val refreshToken = provider.generateRefreshToken("dashboard-client")
+        assertNotNull(refreshToken)
+        assertTrue(refreshToken.isNotBlank())
+        assertTrue(provider.validateToken(refreshToken))
+        assertEquals("dashboard-client", provider.getSubject(refreshToken))
+    }
+}

--- a/server/src/test/kotlin/com/orchestradashboard/server/controller/AgentControllerTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/controller/AgentControllerTest.kt
@@ -1,6 +1,8 @@
 package com.orchestradashboard.server.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.orchestradashboard.server.config.JwtAuthenticationFilter
+import com.orchestradashboard.server.config.JwtTokenProvider
 import com.orchestradashboard.server.config.SecurityConfig
 import com.orchestradashboard.server.model.AgentRegistrationRequest
 import com.orchestradashboard.server.model.AgentResponse
@@ -12,6 +14,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
@@ -19,7 +22,8 @@ import org.springframework.test.web.servlet.put
 import org.mockito.Mockito.`when` as whenever
 
 @WebMvcTest(AgentController::class)
-@Import(SecurityConfig::class)
+@Import(SecurityConfig::class, JwtAuthenticationFilter::class)
+@WithMockUser
 class AgentControllerTest {
     @Autowired
     lateinit var mockMvc: MockMvc
@@ -29,6 +33,9 @@ class AgentControllerTest {
 
     @MockBean
     lateinit var agentService: AgentService
+
+    @MockBean
+    lateinit var jwtTokenProvider: JwtTokenProvider
 
     private val sampleResponse =
         AgentResponse(

--- a/server/src/test/kotlin/com/orchestradashboard/server/controller/AuthControllerIntegrationTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/controller/AuthControllerIntegrationTest.kt
@@ -1,0 +1,130 @@
+package com.orchestradashboard.server.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.orchestradashboard.server.config.JwtTokenProvider
+import com.orchestradashboard.server.model.AuthRequest
+import com.orchestradashboard.server.model.RefreshRequest
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+class AuthControllerIntegrationTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    lateinit var jwtTokenProvider: JwtTokenProvider
+
+    @Test
+    fun `POST auth-login with valid credentials returns tokens`() {
+        mockMvc.post("/api/v1/auth/login") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(AuthRequest(apiKey = "dev-api-key"))
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.access_token") { isNotEmpty() }
+            jsonPath("$.refresh_token") { isNotEmpty() }
+            jsonPath("$.expires_in") { isNumber() }
+            jsonPath("$.token_type") { value("Bearer") }
+        }
+    }
+
+    @Test
+    fun `POST auth-login with invalid credentials returns 401`() {
+        mockMvc.post("/api/v1/auth/login") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(AuthRequest(apiKey = "wrong-key"))
+        }.andExpect {
+            status { isUnauthorized() }
+        }
+    }
+
+    @Test
+    fun `POST auth-refresh with valid refresh token returns new access token`() {
+        val refreshToken = jwtTokenProvider.generateRefreshToken("dashboard-client")
+
+        mockMvc.post("/api/v1/auth/refresh") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(RefreshRequest(refreshToken = refreshToken))
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.access_token") { isNotEmpty() }
+            jsonPath("$.refresh_token") { isNotEmpty() }
+        }
+    }
+
+    @Test
+    fun `POST auth-refresh with expired token returns 401`() {
+        val expiredProvider =
+            JwtTokenProvider(
+                secret = "default-dev-secret-that-is-at-least-32-bytes-long!!",
+                accessExpirationMs = 1L,
+                refreshExpirationMs = 1L,
+            )
+        val expiredToken = expiredProvider.generateRefreshToken("dashboard-client")
+        Thread.sleep(50)
+
+        mockMvc.post("/api/v1/auth/refresh") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(RefreshRequest(refreshToken = expiredToken))
+        }.andExpect {
+            status { isUnauthorized() }
+        }
+    }
+
+    @Test
+    fun `should deny access to protected endpoint without token`() {
+        mockMvc.get("/api/v1/agents")
+            .andExpect {
+                status { isUnauthorized() }
+            }
+    }
+
+    @Test
+    fun `should reject request with invalid or expired token`() {
+        mockMvc.get("/api/v1/agents") {
+            header("Authorization", "Bearer invalid-token-garbage")
+        }.andExpect {
+            status { isUnauthorized() }
+        }
+    }
+
+    @Test
+    fun `should allow access to protected endpoint with valid token`() {
+        val token = jwtTokenProvider.generateAccessToken("dashboard-client")
+
+        mockMvc.get("/api/v1/agents") {
+            header("Authorization", "Bearer $token")
+        }.andExpect {
+            status { isOk() }
+        }
+    }
+
+    @Test
+    fun `actuator health remains accessible without token`() {
+        mockMvc.get("/actuator/health")
+            .andExpect {
+                status { isOk() }
+            }
+    }
+
+    @Test
+    fun `auth endpoints are accessible without token`() {
+        mockMvc.post("/api/v1/auth/login") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(AuthRequest(apiKey = "dev-api-key"))
+        }.andExpect {
+            status { isOk() }
+        }
+    }
+}

--- a/server/src/test/kotlin/com/orchestradashboard/server/controller/EventControllerTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/controller/EventControllerTest.kt
@@ -1,6 +1,8 @@
 package com.orchestradashboard.server.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.orchestradashboard.server.config.JwtAuthenticationFilter
+import com.orchestradashboard.server.config.JwtTokenProvider
 import com.orchestradashboard.server.config.SecurityConfig
 import com.orchestradashboard.server.model.AgentEventResponse
 import com.orchestradashboard.server.model.CreateEventRequest
@@ -12,13 +14,15 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.mockito.Mockito.`when` as whenever
 
 @WebMvcTest(EventController::class)
-@Import(SecurityConfig::class)
+@Import(SecurityConfig::class, JwtAuthenticationFilter::class)
+@WithMockUser
 class EventControllerTest {
     @Autowired
     lateinit var mockMvc: MockMvc
@@ -28,6 +32,9 @@ class EventControllerTest {
 
     @MockBean
     lateinit var eventService: EventService
+
+    @MockBean
+    lateinit var jwtTokenProvider: JwtTokenProvider
 
     private val sampleResponse =
         AgentEventResponse(

--- a/server/src/test/kotlin/com/orchestradashboard/server/controller/PipelineControllerTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/controller/PipelineControllerTest.kt
@@ -1,6 +1,8 @@
 package com.orchestradashboard.server.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.orchestradashboard.server.config.JwtAuthenticationFilter
+import com.orchestradashboard.server.config.JwtTokenProvider
 import com.orchestradashboard.server.config.SecurityConfig
 import com.orchestradashboard.server.model.PipelineRunResponse
 import com.orchestradashboard.server.model.PipelineStepResponse
@@ -17,6 +19,7 @@ import org.springframework.context.annotation.Import
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.patch
@@ -25,7 +28,8 @@ import org.springframework.test.web.servlet.put
 import org.mockito.Mockito.`when` as whenever
 
 @WebMvcTest(PipelineController::class)
-@Import(SecurityConfig::class)
+@Import(SecurityConfig::class, JwtAuthenticationFilter::class)
+@WithMockUser
 class PipelineControllerTest {
     @Autowired
     lateinit var mockMvc: MockMvc
@@ -35,6 +39,9 @@ class PipelineControllerTest {
 
     @MockBean
     lateinit var pipelineService: PipelineService
+
+    @MockBean
+    lateinit var jwtTokenProvider: JwtTokenProvider
 
     private val sampleResponse =
         PipelineRunResponse(

--- a/server/src/test/kotlin/com/orchestradashboard/server/controller/PipelineRunIntegrationTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/controller/PipelineRunIntegrationTest.kt
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.patch
@@ -17,6 +18,7 @@ import org.springframework.test.web.servlet.post
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
+@WithMockUser
 class PipelineRunIntegrationTest {
     @Autowired
     private lateinit var mockMvc: MockMvc

--- a/server/src/test/kotlin/com/orchestradashboard/server/controller/PipelineRunRedirectControllerTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/controller/PipelineRunRedirectControllerTest.kt
@@ -1,19 +1,27 @@
 package com.orchestradashboard.server.controller
 
+import com.orchestradashboard.server.config.JwtAuthenticationFilter
+import com.orchestradashboard.server.config.JwtTokenProvider
 import com.orchestradashboard.server.config.SecurityConfig
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
+import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 
 @WebMvcTest(PipelineRunRedirectController::class)
-@Import(SecurityConfig::class)
+@Import(SecurityConfig::class, JwtAuthenticationFilter::class)
+@WithMockUser
 class PipelineRunRedirectControllerTest {
     @Autowired
     lateinit var mockMvc: MockMvc
+
+    @MockBean
+    lateinit var jwtTokenProvider: JwtTokenProvider
 
     @Test
     fun `GET api-v1-pipelines redirects 308 to pipeline-runs`() {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -65,6 +65,7 @@ kotlin {
             dependencies {
                 implementation(libs.coroutines.android)
                 implementation(libs.ktor.client.okhttp)
+                implementation(libs.androidx.security.crypto)
             }
         }
 

--- a/shared/src/androidMain/kotlin/com/orchestradashboard/shared/data/repository/AndroidTokenRepository.kt
+++ b/shared/src/androidMain/kotlin/com/orchestradashboard/shared/data/repository/AndroidTokenRepository.kt
@@ -1,0 +1,54 @@
+package com.orchestradashboard.shared.data.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import com.orchestradashboard.shared.domain.model.AuthenticationResult
+import com.orchestradashboard.shared.domain.repository.TokenRepository
+import kotlinx.datetime.Clock
+
+class AndroidTokenRepository(context: Context) : TokenRepository {
+    private val prefs: SharedPreferences by lazy {
+        val masterKey =
+            MasterKey.Builder(context)
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build()
+        EncryptedSharedPreferences.create(
+            context,
+            PREFS_FILE_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+    }
+
+    override suspend fun saveTokens(result: AuthenticationResult) {
+        val expiryTimestamp = Clock.System.now().toEpochMilliseconds() + (result.expiresIn * 1000)
+        prefs.edit()
+            .putString(KEY_ACCESS_TOKEN, result.accessToken)
+            .putString(KEY_REFRESH_TOKEN, result.refreshToken)
+            .putLong(KEY_TOKEN_EXPIRY, expiryTimestamp)
+            .apply()
+    }
+
+    override suspend fun getAccessToken(): String? = prefs.getString(KEY_ACCESS_TOKEN, null)
+
+    override suspend fun getRefreshToken(): String? = prefs.getString(KEY_REFRESH_TOKEN, null)
+
+    override suspend fun getTokenExpiryTimestamp(): Long? {
+        val v = prefs.getLong(KEY_TOKEN_EXPIRY, -1L)
+        return if (v == -1L) null else v
+    }
+
+    override suspend fun clearTokens() {
+        prefs.edit().clear().apply()
+    }
+
+    companion object {
+        private const val PREFS_FILE_NAME = "orchestra_auth_prefs"
+        private const val KEY_ACCESS_TOKEN = "access_token"
+        private const val KEY_REFRESH_TOKEN = "refresh_token"
+        private const val KEY_TOKEN_EXPIRY = "token_expiry"
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/AuthRequestDto.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/AuthRequestDto.kt
@@ -1,0 +1,14 @@
+package com.orchestradashboard.shared.data.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LoginRequestDto(
+    @SerialName("api_key") val apiKey: String,
+)
+
+@Serializable
+data class RefreshRequestDto(
+    @SerialName("refresh_token") val refreshToken: String,
+)

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/AuthResponseDto.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/AuthResponseDto.kt
@@ -1,0 +1,12 @@
+package com.orchestradashboard.shared.data.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AuthResponseDto(
+    @SerialName("access_token") val accessToken: String,
+    @SerialName("refresh_token") val refreshToken: String,
+    @SerialName("expires_in") val expiresIn: Long,
+    @SerialName("token_type") val tokenType: String = "Bearer",
+)

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/network/DashboardApi.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/network/DashboardApi.kt
@@ -2,6 +2,7 @@ package com.orchestradashboard.shared.data.network
 
 import com.orchestradashboard.shared.data.dto.AgentDto
 import com.orchestradashboard.shared.data.dto.AgentEventDto
+import com.orchestradashboard.shared.data.dto.AuthResponseDto
 import com.orchestradashboard.shared.data.dto.PipelineRunDto
 import kotlinx.coroutines.flow.Flow
 
@@ -31,4 +32,8 @@ interface DashboardApi {
     suspend fun registerAgent(agent: AgentDto): AgentDto
 
     suspend fun deregisterAgent(agentId: String)
+
+    suspend fun login(apiKey: String): AuthResponseDto
+
+    suspend fun refreshToken(refreshToken: String): AuthResponseDto
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/network/DashboardApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/network/DashboardApiClient.kt
@@ -2,8 +2,11 @@ package com.orchestradashboard.shared.data.network
 
 import com.orchestradashboard.shared.data.dto.AgentDto
 import com.orchestradashboard.shared.data.dto.AgentEventDto
+import com.orchestradashboard.shared.data.dto.AuthResponseDto
+import com.orchestradashboard.shared.data.dto.LoginRequestDto
 import com.orchestradashboard.shared.data.dto.PipelineRunDto
 import com.orchestradashboard.shared.data.dto.PipelineRunPageDto
+import com.orchestradashboard.shared.data.dto.RefreshRequestDto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.delete
@@ -85,5 +88,19 @@ class DashboardApiClient(
 
     override suspend fun deregisterAgent(agentId: String) {
         httpClient.delete("$baseUrl/api/v1/agents/$agentId")
+    }
+
+    override suspend fun login(apiKey: String): AuthResponseDto {
+        return httpClient.post("$baseUrl/api/v1/auth/login") {
+            contentType(ContentType.Application.Json)
+            setBody(LoginRequestDto(apiKey))
+        }.body()
+    }
+
+    override suspend fun refreshToken(refreshToken: String): AuthResponseDto {
+        return httpClient.post("$baseUrl/api/v1/auth/refresh") {
+            contentType(ContentType.Application.Json)
+            setBody(RefreshRequestDto(refreshToken))
+        }.body()
     }
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/TokenRefreshHandler.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/TokenRefreshHandler.kt
@@ -1,0 +1,69 @@
+package com.orchestradashboard.shared.data.repository
+
+import com.orchestradashboard.shared.data.dto.AuthResponseDto
+import com.orchestradashboard.shared.data.dto.RefreshRequestDto
+import com.orchestradashboard.shared.domain.model.AuthenticationResult
+import com.orchestradashboard.shared.domain.repository.TokenRepository
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.datetime.Clock
+
+class TokenRefreshHandler(
+    private val httpClient: HttpClient,
+    private val baseUrl: String,
+    private val tokenRepository: TokenRepository,
+) {
+    private val refreshMutex = Mutex()
+
+    suspend fun getValidAccessToken(): String? {
+        val token = tokenRepository.getAccessToken() ?: return null
+        val expiry = tokenRepository.getTokenExpiryTimestamp() ?: return token
+        val now = Clock.System.now().toEpochMilliseconds()
+
+        return if (expiry - now < REFRESH_THRESHOLD_MS) {
+            refreshToken() ?: token
+        } else {
+            token
+        }
+    }
+
+    private suspend fun refreshToken(): String? =
+        refreshMutex.withLock {
+            val expiry = tokenRepository.getTokenExpiryTimestamp() ?: return null
+            val now = Clock.System.now().toEpochMilliseconds()
+            if (expiry - now >= REFRESH_THRESHOLD_MS) {
+                return tokenRepository.getAccessToken()
+            }
+
+            val refreshToken = tokenRepository.getRefreshToken() ?: return null
+            @Suppress("TooGenericExceptionCaught")
+            return try {
+                val response: AuthResponseDto =
+                    httpClient.post("$baseUrl/api/v1/auth/refresh") {
+                        contentType(ContentType.Application.Json)
+                        setBody(RefreshRequestDto(refreshToken))
+                    }.body()
+                val result =
+                    AuthenticationResult(
+                        accessToken = response.accessToken,
+                        refreshToken = response.refreshToken,
+                        expiresIn = response.expiresIn,
+                    )
+                tokenRepository.saveTokens(result)
+                response.accessToken
+            } catch (e: Exception) {
+                null
+            }
+        }
+
+    companion object {
+        // 2 minutes before expiry
+        const val REFRESH_THRESHOLD_MS = 120_000L
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/AuthenticationResult.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/AuthenticationResult.kt
@@ -1,0 +1,8 @@
+package com.orchestradashboard.shared.domain.model
+
+data class AuthenticationResult(
+    val accessToken: String,
+    val refreshToken: String,
+    val expiresIn: Long,
+    val tokenType: String = "Bearer",
+)

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/TokenRepository.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/TokenRepository.kt
@@ -1,0 +1,15 @@
+package com.orchestradashboard.shared.domain.repository
+
+import com.orchestradashboard.shared.domain.model.AuthenticationResult
+
+interface TokenRepository {
+    suspend fun saveTokens(result: AuthenticationResult)
+
+    suspend fun getAccessToken(): String?
+
+    suspend fun getRefreshToken(): String?
+
+    suspend fun getTokenExpiryTimestamp(): Long?
+
+    suspend fun clearTokens()
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/network/FakeDashboardApiClient.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/network/FakeDashboardApiClient.kt
@@ -2,6 +2,7 @@ package com.orchestradashboard.shared.data.network
 
 import com.orchestradashboard.shared.data.dto.AgentDto
 import com.orchestradashboard.shared.data.dto.AgentEventDto
+import com.orchestradashboard.shared.data.dto.AuthResponseDto
 import com.orchestradashboard.shared.data.dto.PipelineRunDto
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -109,5 +110,15 @@ class FakeDashboardApiClient : DashboardApi {
 
     override suspend fun deregisterAgent(agentId: String) {
         maybeThrow()
+    }
+
+    override suspend fun login(apiKey: String): AuthResponseDto {
+        maybeThrow()
+        return AuthResponseDto(accessToken = "fake-access", refreshToken = "fake-refresh", expiresIn = 900)
+    }
+
+    override suspend fun refreshToken(refreshToken: String): AuthResponseDto {
+        maybeThrow()
+        return AuthResponseDto(accessToken = "fake-access", refreshToken = "fake-refresh", expiresIn = 900)
     }
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/FakeDashboardApiClient.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/FakeDashboardApiClient.kt
@@ -2,6 +2,7 @@ package com.orchestradashboard.shared.data.repository
 
 import com.orchestradashboard.shared.data.dto.AgentDto
 import com.orchestradashboard.shared.data.dto.AgentEventDto
+import com.orchestradashboard.shared.data.dto.AuthResponseDto
 import com.orchestradashboard.shared.data.dto.PipelineRunDto
 import com.orchestradashboard.shared.data.network.DashboardApi
 import kotlinx.coroutines.delay
@@ -88,5 +89,15 @@ class FakeDashboardApiClient(
 
     override suspend fun deregisterAgent(agentId: String) {
         if (shouldFail) throw RuntimeException("Network error")
+    }
+
+    override suspend fun login(apiKey: String): AuthResponseDto {
+        if (shouldFail) throw RuntimeException("Network error")
+        return AuthResponseDto(accessToken = "fake-access", refreshToken = "fake-refresh", expiresIn = 900)
+    }
+
+    override suspend fun refreshToken(refreshToken: String): AuthResponseDto {
+        if (shouldFail) throw RuntimeException("Network error")
+        return AuthResponseDto(accessToken = "fake-access", refreshToken = "fake-refresh", expiresIn = 900)
     }
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/TokenRefreshHandlerTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/TokenRefreshHandlerTest.kt
@@ -1,0 +1,134 @@
+package com.orchestradashboard.shared.data.repository
+
+import com.orchestradashboard.shared.domain.model.AuthenticationResult
+import com.orchestradashboard.shared.domain.repository.TokenRepository
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TokenRefreshHandlerTest {
+    private fun createMockClient(
+        responseBody: String,
+        status: HttpStatusCode = HttpStatusCode.OK,
+    ): HttpClient {
+        val engine =
+            MockEngine {
+                respond(
+                    content = responseBody,
+                    status = status,
+                    headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                )
+            }
+        return HttpClient(engine) {
+            install(ContentNegotiation) { json() }
+        }
+    }
+
+    private class FakeTokenRepository : TokenRepository {
+        private var accessToken: String? = null
+        private var refreshToken: String? = null
+        private var expiryTimestamp: Long? = null
+
+        override suspend fun saveTokens(result: AuthenticationResult) {
+            accessToken = result.accessToken
+            refreshToken = result.refreshToken
+            expiryTimestamp = Clock.System.now().toEpochMilliseconds() + (result.expiresIn * 1000)
+        }
+
+        override suspend fun getAccessToken(): String? = accessToken
+
+        override suspend fun getRefreshToken(): String? = refreshToken
+
+        override suspend fun getTokenExpiryTimestamp(): Long? = expiryTimestamp
+
+        override suspend fun clearTokens() {
+            accessToken = null
+            refreshToken = null
+            expiryTimestamp = null
+        }
+
+        fun setTokens(
+            access: String,
+            refresh: String,
+            expiryMs: Long,
+        ) {
+            accessToken = access
+            refreshToken = refresh
+            expiryTimestamp = expiryMs
+        }
+    }
+
+    @Test
+    fun `should refresh token automatically before expiration`() =
+        runTest {
+            val refreshResponse =
+                """
+                {"access_token":"new-access","refresh_token":"new-refresh","expires_in":900,"token_type":"Bearer"}
+                """.trimIndent()
+            val client = createMockClient(refreshResponse)
+            val repo = FakeTokenRepository()
+            // Token expires in 60 seconds (< 2 min threshold)
+            val soonExpiry = Clock.System.now().toEpochMilliseconds() + 60_000L
+            repo.setTokens("old-access", "old-refresh", soonExpiry)
+
+            val handler = TokenRefreshHandler(client, "http://localhost:8080", repo)
+            val token = handler.getValidAccessToken()
+
+            assertEquals("new-access", token)
+            assertEquals("new-access", repo.getAccessToken())
+            assertEquals("new-refresh", repo.getRefreshToken())
+        }
+
+    @Test
+    fun `should propagate error when refresh fails`() =
+        runTest {
+            val client = createMockClient("", HttpStatusCode.Unauthorized)
+            val repo = FakeTokenRepository()
+            val soonExpiry = Clock.System.now().toEpochMilliseconds() + 60_000L
+            repo.setTokens("old-access", "old-refresh", soonExpiry)
+
+            val handler = TokenRefreshHandler(client, "http://localhost:8080", repo)
+            val token = handler.getValidAccessToken()
+
+            // Falls back to old token when refresh fails
+            assertEquals("old-access", token)
+        }
+
+    @Test
+    fun `should not refresh when token is still valid`() =
+        runTest {
+            val client = createMockClient("{}")
+            val repo = FakeTokenRepository()
+            // Token expires in 10 minutes (> 2 min threshold)
+            val farExpiry = Clock.System.now().toEpochMilliseconds() + 600_000L
+            repo.setTokens("valid-access", "valid-refresh", farExpiry)
+
+            val handler = TokenRefreshHandler(client, "http://localhost:8080", repo)
+            val token = handler.getValidAccessToken()
+
+            assertEquals("valid-access", token)
+        }
+
+    @Test
+    fun `should return null when no token stored`() =
+        runTest {
+            val client = createMockClient("{}")
+            val repo = FakeTokenRepository()
+
+            val handler = TokenRefreshHandler(client, "http://localhost:8080", repo)
+            val token = handler.getValidAccessToken()
+
+            assertNull(token)
+        }
+}

--- a/shared/src/desktopMain/kotlin/com/orchestradashboard/shared/data/repository/DesktopTokenRepository.kt
+++ b/shared/src/desktopMain/kotlin/com/orchestradashboard/shared/data/repository/DesktopTokenRepository.kt
@@ -1,0 +1,39 @@
+package com.orchestradashboard.shared.data.repository
+
+import com.orchestradashboard.shared.domain.model.AuthenticationResult
+import com.orchestradashboard.shared.domain.repository.TokenRepository
+import java.util.prefs.Preferences
+
+class DesktopTokenRepository : TokenRepository {
+    private val prefs: Preferences = Preferences.userNodeForPackage(DesktopTokenRepository::class.java)
+
+    override suspend fun saveTokens(result: AuthenticationResult) {
+        val expiryTimestamp = System.currentTimeMillis() + (result.expiresIn * 1000)
+        prefs.put(KEY_ACCESS_TOKEN, result.accessToken)
+        prefs.put(KEY_REFRESH_TOKEN, result.refreshToken)
+        prefs.putLong(KEY_TOKEN_EXPIRY, expiryTimestamp)
+        prefs.flush()
+    }
+
+    override suspend fun getAccessToken(): String? = prefs.get(KEY_ACCESS_TOKEN, null)
+
+    override suspend fun getRefreshToken(): String? = prefs.get(KEY_REFRESH_TOKEN, null)
+
+    override suspend fun getTokenExpiryTimestamp(): Long? {
+        val v = prefs.getLong(KEY_TOKEN_EXPIRY, -1L)
+        return if (v == -1L) null else v
+    }
+
+    override suspend fun clearTokens() {
+        prefs.remove(KEY_ACCESS_TOKEN)
+        prefs.remove(KEY_REFRESH_TOKEN)
+        prefs.remove(KEY_TOKEN_EXPIRY)
+        prefs.flush()
+    }
+
+    companion object {
+        private const val KEY_ACCESS_TOKEN = "access_token"
+        private const val KEY_REFRESH_TOKEN = "refresh_token"
+        private const val KEY_TOKEN_EXPIRY = "token_expiry"
+    }
+}


### PR DESCRIPTION
Closes #28

## Design
Here is the comprehensive implementation plan for Issue #28: JWT Authentication and Authorization.

---

## Implementation Plan: JWT Authentication & Authorization

### 1. Architecture Overview

```
┌─────────────────────────────────────────────────────────────────┐
│                        CLIENT APPS                               │
│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐          │
│  │  Android App  │  │  Desktop App │  │   iOS App    │          │
│  │  Encrypted    │  │  Java        │  │  Keychain    │          │
│  │  SharedPrefs  │  │  Preferences │  │  Services    │          │
│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘          │
│         └─────────────┬────┴─────────────────┘                   │
│                       ▼                                          │
│  ┌────────────────────────────────────────────┐                 │
│  │  shared/DashboardApiClient (Ktor)          │                 │
│  │  ┌──────────────────────────────────┐      │                 │
│  │  │ Auth Interceptor Plugin          │      │                 │
│  │  │ - Injects Bearer token           │      │                 │
│  │  │ - Handles 401 → refresh flow     │      │                 │
│  │  └──────────────────────────────────┘      │                 │
│  └────────────────────┬───────────────────────┘                 │
└───────────────────────┼─────────────────────────────────────────┘
                        │ HTTP + Authorization: Bearer <JWT>
               

_(truncated)_

## Changed Files (28)
- `androidApp/proguard-rules.pro`
- `androidApp/src/main/kotlin/com/orchestradashboard/android/App.kt`
- `androidApp/src/main/kotlin/com/orchestradashboard/android/di/AppContainer.kt`
- `desktopApp/src/main/kotlin/com/orchestradashboard/desktop/di/AppContainer.kt`
- `gradle/libs.versions.toml`
- `server/build.gradle.kts`
- `server/src/main/kotlin/com/orchestradashboard/server/config/JwtAuthenticationFilter.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/config/JwtTokenProvider.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/config/SecurityConfig.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/controller/AuthController.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/model/AuthRequest.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/model/AuthResponse.kt`
- `server/src/main/resources/application.yml`
- `server/src/test/kotlin/com/orchestradashboard/server/config/JwtTokenProviderTest.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/controller/AgentControllerTest.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/controller/AuthControllerIntegrationTest.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/controller/EventControllerTest.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/controller/PipelineControllerTest.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/controller/PipelineRunIntegrationTest.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/controller/PipelineRunRedirectControllerTest.kt`

## Review
This review finds that while the server-side implementation and testing are of high quality and closely follow the design document, the submission has critical flaws on the client-side that prevent the feature from functioning as intended.

### 1. Business Logic Correctness
- **Server-Side Logic: Correct.** The JWT provider, authentication filter, security configuration, and authentication controller on the server are implemented correctly. They properly secure endpoints, validate credentials, and issue/refresh tokens according to the plan.
- **Client-Side Logic: Critically Flawed.** The implementation is missing the Ktor `HttpSend` interceptor in `androidApp/di/AppContainer.kt` and `desktopApp/di/AppContainer.kt`. According to the design document (Step 13), this interceptor is responsible

_(truncated)_

## AI Audit: PASS
[AUDIT: FAIL]

### 1. Intent Alignment
- **CRITICAL**: The implementation fails to include the Ktor `HttpSend` interceptor in both `androidApp/di/AppContainer.kt` and `desktopApp/di/AppContainer.kt`. This omission prevents the client applications from sending authentication tokens, rendering the feature inoperable. Without the interceptor, all API requests to protected endpoints will fail with a `401 Unauthorized` error.
- **CRITICAL**: The server's `application.properties` file uses a default JWT secret (`default-dev-secret-that-is-at-least-32-bytes-long!!`) that is not secure for production use. This violates security best practices and exposes the system to potential token forgery attacks.
- **MAJOR**: The implementation does not include the required test file `shared/src/androidTest/kotlin/.../data/repository/AndroidTokenRepositoryTest.kt`, which was explicitly required by the design document (Test Plan Phase 3) and the GitHub issue's acceptance criteria (Test Requirement #3).

###

_(truncated)_