### PR TITLE
feat: feat: Add pagination and caching to shared repository layer

### DIFF
--- a/server/src/main/kotlin/com/orchestradashboard/server/controller/AgentController.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/controller/AgentController.kt
@@ -3,9 +3,14 @@ package com.orchestradashboard.server.controller
 import com.orchestradashboard.server.model.AgentRegistrationRequest
 import com.orchestradashboard.server.model.AgentResponse
 import com.orchestradashboard.server.model.HeartbeatRequest
+import com.orchestradashboard.server.model.PagedAgentResponse
 import com.orchestradashboard.server.service.AgentService
+import jakarta.validation.ConstraintViolationException
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -16,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
+@Validated
 @RestController
 @RequestMapping("/api/v1/agents")
 class AgentController(
@@ -50,6 +56,16 @@ class AgentController(
         @RequestBody request: HeartbeatRequest,
     ): ResponseEntity<AgentResponse> = ResponseEntity.ok(agentService.updateHeartbeat(id, request.status))
 
+    @GetMapping("/paged")
+    fun getAgentsPaged(
+        @RequestParam(defaultValue = "0") @Min(0) page: Int,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(100) pageSize: Int,
+        @RequestParam status: String?,
+    ): ResponseEntity<PagedAgentResponse> = ResponseEntity.ok(agentService.getAgentsPaged(page, pageSize, status))
+
     @ExceptionHandler(NoSuchElementException::class)
     fun handleNotFound(ex: NoSuchElementException): ResponseEntity<Void> = ResponseEntity.notFound().build()
+
+    @ExceptionHandler(ConstraintViolationException::class)
+    fun handleValidation(ex: ConstraintViolationException): ResponseEntity<Void> = ResponseEntity.badRequest().build()
 }

--- a/server/src/main/kotlin/com/orchestradashboard/server/model/PagedAgentResponse.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/model/PagedAgentResponse.kt
@@ -1,0 +1,9 @@
+package com.orchestradashboard.server.model
+
+data class PagedAgentResponse(
+    val content: List<AgentResponse>,
+    val page: Int,
+    val pageSize: Int,
+    val totalElements: Long,
+    val totalPages: Int,
+)

--- a/server/src/main/kotlin/com/orchestradashboard/server/repository/AgentJpaRepository.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/repository/AgentJpaRepository.kt
@@ -1,12 +1,19 @@
 package com.orchestradashboard.server.repository
 
 import com.orchestradashboard.server.model.AgentEntity
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface AgentJpaRepository : JpaRepository<AgentEntity, String> {
     fun findByStatus(status: String): List<AgentEntity>
+
+    fun findByStatus(
+        status: String,
+        pageable: Pageable,
+    ): Page<AgentEntity>
 
     fun findByType(type: String): List<AgentEntity>
 }

--- a/server/src/main/kotlin/com/orchestradashboard/server/service/AgentService.kt
+++ b/server/src/main/kotlin/com/orchestradashboard/server/service/AgentService.kt
@@ -4,7 +4,9 @@ import com.orchestradashboard.server.model.AgentEntity
 import com.orchestradashboard.server.model.AgentMapper
 import com.orchestradashboard.server.model.AgentRegistrationRequest
 import com.orchestradashboard.server.model.AgentResponse
+import com.orchestradashboard.server.model.PagedAgentResponse
 import com.orchestradashboard.server.repository.AgentJpaRepository
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -23,6 +25,27 @@ class AgentService(
     }
 
     fun getAgentsByStatus(status: String): List<AgentResponse> = agentMapper.toResponseList(agentRepository.findByStatus(status))
+
+    fun getAgentsPaged(
+        page: Int,
+        pageSize: Int,
+        status: String?,
+    ): PagedAgentResponse {
+        val pageable = PageRequest.of(page, pageSize)
+        val result =
+            if (status != null) {
+                agentRepository.findByStatus(status, pageable)
+            } else {
+                agentRepository.findAll(pageable)
+            }
+        return PagedAgentResponse(
+            content = agentMapper.toResponseList(result.content),
+            page = result.number,
+            pageSize = result.size,
+            totalElements = result.totalElements,
+            totalPages = result.totalPages,
+        )
+    }
 
     fun registerAgent(request: AgentRegistrationRequest): AgentResponse {
         val id = request.id ?: UUID.randomUUID().toString()

--- a/server/src/test/kotlin/com/orchestradashboard/server/controller/AgentPaginationControllerTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/controller/AgentPaginationControllerTest.kt
@@ -1,0 +1,119 @@
+package com.orchestradashboard.server.controller
+
+import com.orchestradashboard.server.config.JwtAuthenticationFilter
+import com.orchestradashboard.server.config.JwtTokenProvider
+import com.orchestradashboard.server.config.SecurityConfig
+import com.orchestradashboard.server.model.AgentResponse
+import com.orchestradashboard.server.model.PagedAgentResponse
+import com.orchestradashboard.server.service.AgentService
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.mockito.Mockito.`when` as whenever
+
+@WebMvcTest(AgentController::class)
+@Import(SecurityConfig::class, JwtAuthenticationFilter::class)
+@WithMockUser
+class AgentPaginationControllerTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockBean
+    lateinit var agentService: AgentService
+
+    @MockBean
+    lateinit var jwtTokenProvider: JwtTokenProvider
+
+    private val sampleResponse =
+        AgentResponse(
+            id = "agent-1",
+            name = "Worker Alpha",
+            type = "WORKER",
+            status = "RUNNING",
+            lastHeartbeat = 1700000000L,
+        )
+
+    @Test
+    fun `should update pagination metadata correctly`() {
+        whenever(agentService.getAgentsPaged(0, 10, null)).thenReturn(
+            PagedAgentResponse(
+                content = listOf(sampleResponse),
+                page = 0,
+                pageSize = 10,
+                totalElements = 25,
+                totalPages = 3,
+            ),
+        )
+
+        mockMvc.get("/api/v1/agents/paged?page=0&pageSize=10")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.page") { value(0) }
+                jsonPath("$.pageSize") { value(10) }
+                jsonPath("$.totalElements") { value(25) }
+                jsonPath("$.totalPages") { value(3) }
+                jsonPath("$.content[0].id") { value("agent-1") }
+            }
+    }
+
+    @Test
+    fun `should combine status filter with pagination`() {
+        whenever(agentService.getAgentsPaged(0, 10, "RUNNING")).thenReturn(
+            PagedAgentResponse(
+                content = listOf(sampleResponse),
+                page = 0,
+                pageSize = 10,
+                totalElements = 1,
+                totalPages = 1,
+            ),
+        )
+
+        mockMvc.get("/api/v1/agents/paged?page=0&pageSize=10&status=RUNNING")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.totalElements") { value(1) }
+                jsonPath("$.content[0].status") { value("RUNNING") }
+            }
+    }
+
+    @Test
+    fun `should reject pageSize exceeding maximum`() {
+        mockMvc.get("/api/v1/agents/paged?page=0&pageSize=200")
+            .andExpect {
+                status { isBadRequest() }
+            }
+    }
+
+    @Test
+    fun `should reject negative page number`() {
+        mockMvc.get("/api/v1/agents/paged?page=-1&pageSize=10")
+            .andExpect {
+                status { isBadRequest() }
+            }
+    }
+
+    @Test
+    fun `should use default page and pageSize when not provided`() {
+        whenever(agentService.getAgentsPaged(0, 20, null)).thenReturn(
+            PagedAgentResponse(
+                content = emptyList(),
+                page = 0,
+                pageSize = 20,
+                totalElements = 0,
+                totalPages = 0,
+            ),
+        )
+
+        mockMvc.get("/api/v1/agents/paged")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.page") { value(0) }
+                jsonPath("$.pageSize") { value(20) }
+            }
+    }
+}

--- a/server/src/test/kotlin/com/orchestradashboard/server/repository/AgentJpaRepositoryPaginationTest.kt
+++ b/server/src/test/kotlin/com/orchestradashboard/server/repository/AgentJpaRepositoryPaginationTest.kt
@@ -1,0 +1,73 @@
+package com.orchestradashboard.server.repository
+
+import com.orchestradashboard.server.model.AgentEntity
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.data.domain.PageRequest
+
+@DataJpaTest
+class AgentJpaRepositoryPaginationTest {
+    @Autowired
+    lateinit var repository: AgentJpaRepository
+
+    @BeforeEach
+    fun seed() {
+        repository.deleteAll()
+        (1..10).forEach {
+            repository.save(
+                AgentEntity(
+                    id = "r-$it",
+                    name = "Runner $it",
+                    type = "WORKER",
+                    status = "RUNNING",
+                    lastHeartbeat = 1000L + it,
+                ),
+            )
+        }
+        (1..5).forEach {
+            repository.save(
+                AgentEntity(
+                    id = "i-$it",
+                    name = "Idler $it",
+                    type = "WORKER",
+                    status = "IDLE",
+                    lastHeartbeat = 2000L + it,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `should return paginated results when page size exceeds total`() {
+        val page = repository.findAll(PageRequest.of(0, 50))
+        assertEquals(15, page.content.size)
+        assertEquals(15L, page.totalElements)
+        assertEquals(1, page.totalPages)
+    }
+
+    @Test
+    fun `should return correct page slice`() {
+        val page = repository.findAll(PageRequest.of(1, 5))
+        assertEquals(5, page.content.size)
+        assertEquals(15L, page.totalElements)
+        assertEquals(3, page.totalPages)
+    }
+
+    @Test
+    fun `should return filtered paginated results by status`() {
+        val page = repository.findByStatus("RUNNING", PageRequest.of(0, 5))
+        assertEquals(5, page.content.size)
+        assertEquals(10L, page.totalElements)
+    }
+
+    @Test
+    fun `should return empty page for out-of-range page number`() {
+        val page = repository.findAll(PageRequest.of(100, 10))
+        assertTrue(page.content.isEmpty())
+        assertEquals(15L, page.totalElements)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/AgentPageDto.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/AgentPageDto.kt
@@ -1,0 +1,12 @@
+package com.orchestradashboard.shared.data.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AgentPageDto(
+    val content: List<AgentDto>,
+    val page: Int,
+    val pageSize: Int,
+    val totalElements: Long,
+    val totalPages: Int,
+)

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/network/DashboardApi.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/network/DashboardApi.kt
@@ -2,6 +2,7 @@ package com.orchestradashboard.shared.data.network
 
 import com.orchestradashboard.shared.data.dto.AgentDto
 import com.orchestradashboard.shared.data.dto.AgentEventDto
+import com.orchestradashboard.shared.data.dto.AgentPageDto
 import com.orchestradashboard.shared.data.dto.AuthResponseDto
 import com.orchestradashboard.shared.data.dto.PipelineRunDto
 import kotlinx.coroutines.flow.Flow
@@ -32,6 +33,12 @@ interface DashboardApi {
     suspend fun registerAgent(agent: AgentDto): AgentDto
 
     suspend fun deregisterAgent(agentId: String)
+
+    suspend fun getAgentsPaged(
+        page: Int,
+        pageSize: Int,
+        status: String? = null,
+    ): AgentPageDto
 
     suspend fun login(apiKey: String): AuthResponseDto
 

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/network/DashboardApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/network/DashboardApiClient.kt
@@ -2,6 +2,7 @@ package com.orchestradashboard.shared.data.network
 
 import com.orchestradashboard.shared.data.dto.AgentDto
 import com.orchestradashboard.shared.data.dto.AgentEventDto
+import com.orchestradashboard.shared.data.dto.AgentPageDto
 import com.orchestradashboard.shared.data.dto.AuthResponseDto
 import com.orchestradashboard.shared.data.dto.LoginRequestDto
 import com.orchestradashboard.shared.data.dto.PipelineRunDto
@@ -88,6 +89,18 @@ class DashboardApiClient(
 
     override suspend fun deregisterAgent(agentId: String) {
         httpClient.delete("$baseUrl/api/v1/agents/$agentId")
+    }
+
+    override suspend fun getAgentsPaged(
+        page: Int,
+        pageSize: Int,
+        status: String?,
+    ): AgentPageDto {
+        return httpClient.get("$baseUrl/api/v1/agents/paged") {
+            parameter("page", page)
+            parameter("pageSize", pageSize)
+            if (status != null) parameter("status", status)
+        }.body()
     }
 
     override suspend fun login(apiKey: String): AuthResponseDto {

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/AgentRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/AgentRepositoryImpl.kt
@@ -5,9 +5,12 @@ import com.orchestradashboard.shared.data.mapper.AgentMapper
 import com.orchestradashboard.shared.data.network.DashboardApi
 import com.orchestradashboard.shared.domain.model.Agent
 import com.orchestradashboard.shared.domain.model.Agent.AgentStatus
+import com.orchestradashboard.shared.domain.model.PagedResult
 import com.orchestradashboard.shared.domain.repository.AgentRepository
+import com.orchestradashboard.shared.util.CacheManager
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -19,7 +22,16 @@ class AgentRepositoryImpl(
     companion object {
         // 5000ms — matches DashboardApiClient default polling interval
         private const val POLLING_INTERVAL_MS = 5000L
+        private const val CACHE_MAX_SIZE = 20
+
+        // 30s — balances freshness with network load
+        private const val CACHE_TTL_MS = 30_000L
     }
+
+    private data class CacheKey(val page: Int, val pageSize: Int)
+
+    private val cache = CacheManager<CacheKey, PagedResult<Agent>>(maxSize = CACHE_MAX_SIZE, ttlMs = CACHE_TTL_MS)
+    private val refreshTrigger = MutableSharedFlow<Unit>(replay = 1).apply { tryEmit(Unit) }
 
     override fun observeAgents(): Flow<List<Agent>> =
         api.observeAgents()
@@ -61,4 +73,26 @@ class AgentRepositoryImpl(
         runCatching {
             api.deregisterAgent(agentId)
         }
+
+    override fun observeAgents(
+        page: Int,
+        pageSize: Int,
+    ): Flow<PagedResult<Agent>> =
+        refreshTrigger.map {
+            cache.getOrFetch(CacheKey(page, pageSize)) {
+                val dto = api.getAgentsPaged(page, pageSize)
+                PagedResult(
+                    agents = agentMapper.toDomain(dto.content),
+                    page = dto.page,
+                    pageSize = dto.pageSize,
+                    totalElements = dto.totalElements,
+                    totalPages = dto.totalPages,
+                )
+            }
+        }
+
+    override suspend fun invalidateCache() {
+        cache.invalidateAll()
+        refreshTrigger.emit(Unit)
+    }
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/DashboardUiState.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/DashboardUiState.kt
@@ -8,9 +8,16 @@ data class DashboardUiState(
     val filter: Agent.AgentStatus? = null,
     val connectionStatus: ConnectionStatus = ConnectionStatus.DISCONNECTED,
     val statusFilter: Agent.AgentStatus? = null,
+    val currentPage: Int = 0,
+    val pageSize: Int = 20,
+    val totalElements: Long = 0,
+    val totalPages: Int = 0,
 ) {
     val filteredAgents: List<Agent>
         get() = if (statusFilter == null) agents else agents.filter { it.status == statusFilter }
+
+    val hasNextPage: Boolean get() = currentPage < totalPages - 1
+    val hasPreviousPage: Boolean get() = currentPage > 0
 }
 
 enum class ConnectionStatus {

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/DashboardViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/DashboardViewModel.kt
@@ -4,6 +4,7 @@ import com.orchestradashboard.shared.domain.usecase.GetAgentUseCase
 import com.orchestradashboard.shared.domain.usecase.ObserveAgentsUseCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,6 +20,7 @@ class DashboardViewModel(
 ) {
     private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private val _uiState = MutableStateFlow(DashboardUiState())
+    private var paginatedJob: Job? = null
 
     val uiState: StateFlow<DashboardUiState> = _uiState.asStateFlow()
 
@@ -45,6 +47,46 @@ class DashboardViewModel(
                     }
                 }
         }
+    }
+
+    fun loadPage(page: Int) {
+        paginatedJob?.cancel()
+        paginatedJob =
+            viewModelScope.launch {
+                _uiState.update { it.copy(isLoading = true, error = null) }
+                val currentPageSize = _uiState.value.pageSize
+                observeAgentsUseCase(page, currentPageSize)
+                    .catch { e ->
+                        _uiState.update {
+                            it.copy(
+                                error = e.message ?: "Unknown error",
+                                isLoading = false,
+                            )
+                        }
+                    }
+                    .collect { pagedResult ->
+                        _uiState.update {
+                            it.copy(
+                                agents = pagedResult.agents,
+                                isLoading = false,
+                                currentPage = pagedResult.page,
+                                totalElements = pagedResult.totalElements,
+                                totalPages = pagedResult.totalPages,
+                                connectionStatus = ConnectionStatus.CONNECTED,
+                            )
+                        }
+                    }
+            }
+    }
+
+    fun nextPage() {
+        val state = _uiState.value
+        if (state.hasNextPage) loadPage(state.currentPage + 1)
+    }
+
+    fun previousPage() {
+        val state = _uiState.value
+        if (state.hasPreviousPage) loadPage(state.currentPage - 1)
     }
 
     fun selectAgent(agentId: String?) {

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/PagedResult.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/PagedResult.kt
@@ -1,0 +1,12 @@
+package com.orchestradashboard.shared.domain.model
+
+data class PagedResult<T>(
+    val agents: List<T>,
+    val page: Int,
+    val pageSize: Int,
+    val totalElements: Long,
+    val totalPages: Int,
+) {
+    val hasNextPage: Boolean get() = page < totalPages - 1
+    val hasPreviousPage: Boolean get() = page > 0
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/AgentRepository.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/AgentRepository.kt
@@ -2,6 +2,7 @@ package com.orchestradashboard.shared.domain.repository
 
 import com.orchestradashboard.shared.domain.model.Agent
 import com.orchestradashboard.shared.domain.model.Agent.AgentStatus
+import com.orchestradashboard.shared.domain.model.PagedResult
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -55,4 +56,19 @@ interface AgentRepository {
      * @return [Result] containing Unit on success, or an exception on failure
      */
     suspend fun deregisterAgent(agentId: String): Result<Unit>
+
+    /**
+     * Observes paginated agents with caching support.
+     *
+     * @return [Flow] emitting paginated agent results, re-emits on cache invalidation
+     */
+    fun observeAgents(
+        page: Int,
+        pageSize: Int,
+    ): Flow<PagedResult<Agent>>
+
+    /**
+     * Clears cached data and triggers re-fetch for active observers.
+     */
+    suspend fun invalidateCache()
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveAgentsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveAgentsUseCase.kt
@@ -1,6 +1,7 @@
 package com.orchestradashboard.shared.domain.usecase
 
 import com.orchestradashboard.shared.domain.model.Agent
+import com.orchestradashboard.shared.domain.model.PagedResult
 import com.orchestradashboard.shared.domain.repository.AgentRepository
 import kotlinx.coroutines.flow.Flow
 
@@ -18,4 +19,9 @@ class ObserveAgentsUseCase(
      * @return [Flow] emitting updated agent lists on each state change
      */
     operator fun invoke(): Flow<List<Agent>> = agentRepository.observeAgents()
+
+    operator fun invoke(
+        page: Int,
+        pageSize: Int,
+    ): Flow<PagedResult<Agent>> = agentRepository.observeAgents(page, pageSize)
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/util/CacheManager.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/util/CacheManager.kt
@@ -1,0 +1,66 @@
+package com.orchestradashboard.shared.util
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.datetime.Clock
+
+class CacheManager<K, V>(
+    private val maxSize: Int,
+    private val ttlMs: Long,
+    private val clock: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+) {
+    private data class CachedValue<V>(val value: V, val timestamp: Long)
+
+    private val cache = mutableMapOf<K, CachedValue<V>>()
+    private val accessOrder = mutableListOf<K>()
+    private val mutex = Mutex()
+
+    private fun touchKey(key: K) {
+        accessOrder.remove(key)
+        accessOrder.add(key)
+    }
+
+    private fun evictIfNeeded() {
+        while (cache.size > maxSize && accessOrder.isNotEmpty()) {
+            val oldest = accessOrder.removeFirst()
+            cache.remove(oldest)
+        }
+    }
+
+    suspend fun getOrFetch(
+        key: K,
+        fetcher: suspend () -> V,
+    ): V {
+        mutex.withLock {
+            val entry = cache[key]
+            if (entry != null && clock() - entry.timestamp < ttlMs) {
+                touchKey(key)
+                return entry.value
+            }
+            cache.remove(key)
+            accessOrder.remove(key)
+        }
+
+        val newValue = fetcher()
+        mutex.withLock {
+            cache[key] = CachedValue(newValue, clock())
+            touchKey(key)
+            evictIfNeeded()
+        }
+        return newValue
+    }
+
+    suspend fun invalidateAll() {
+        mutex.withLock {
+            cache.clear()
+            accessOrder.clear()
+        }
+    }
+
+    suspend fun invalidate(key: K) {
+        mutex.withLock {
+            cache.remove(key)
+            accessOrder.remove(key)
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/network/FakeDashboardApiClient.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/network/FakeDashboardApiClient.kt
@@ -2,6 +2,7 @@ package com.orchestradashboard.shared.data.network
 
 import com.orchestradashboard.shared.data.dto.AgentDto
 import com.orchestradashboard.shared.data.dto.AgentEventDto
+import com.orchestradashboard.shared.data.dto.AgentPageDto
 import com.orchestradashboard.shared.data.dto.AuthResponseDto
 import com.orchestradashboard.shared.data.dto.PipelineRunDto
 import kotlinx.coroutines.delay
@@ -110,6 +111,15 @@ class FakeDashboardApiClient : DashboardApi {
 
     override suspend fun deregisterAgent(agentId: String) {
         maybeThrow()
+    }
+
+    override suspend fun getAgentsPaged(
+        page: Int,
+        pageSize: Int,
+        status: String?,
+    ): AgentPageDto {
+        maybeThrow()
+        return AgentPageDto(agentsResponse, page, pageSize, agentsResponse.size.toLong(), 1)
     }
 
     override suspend fun login(apiKey: String): AuthResponseDto {

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/AgentRepositoryPaginationTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/AgentRepositoryPaginationTest.kt
@@ -1,0 +1,66 @@
+package com.orchestradashboard.shared.data.repository
+
+import com.orchestradashboard.shared.data.dto.AgentDto
+import com.orchestradashboard.shared.data.dto.AgentPageDto
+import com.orchestradashboard.shared.data.mapper.AgentMapper
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AgentRepositoryPaginationTest {
+    private val agentMapper = AgentMapper()
+    private val sampleDto =
+        AgentDto(
+            id = "agent-1",
+            name = "Alpha",
+            type = "WORKER",
+            status = "RUNNING",
+            lastHeartbeat = 1000L,
+        )
+
+    @Test
+    fun `should return cached data immediately on subsequent fetches`() =
+        runTest {
+            val fake = FakeDashboardApiClient()
+            fake.pagedAgents = AgentPageDto(listOf(sampleDto), page = 0, pageSize = 10, totalElements = 1, totalPages = 1)
+            val repo = AgentRepositoryImpl(fake, agentMapper)
+
+            val first = repo.observeAgents(page = 0, pageSize = 10).first()
+            fake.pagedAgents = AgentPageDto(emptyList(), page = 0, pageSize = 10, totalElements = 0, totalPages = 0)
+            val second = repo.observeAgents(page = 0, pageSize = 10).first()
+
+            assertEquals(1, first.agents.size)
+            assertEquals(1, second.agents.size)
+        }
+
+    @Test
+    fun `should invalidate cache when agent status changes via WebSocket`() =
+        runTest {
+            val fake = FakeDashboardApiClient()
+            fake.pagedAgents = AgentPageDto(listOf(sampleDto), page = 0, pageSize = 10, totalElements = 1, totalPages = 1)
+            val repo = AgentRepositoryImpl(fake, agentMapper)
+
+            assertEquals("RUNNING", repo.observeAgents(page = 0, pageSize = 10).first().agents[0].status.name)
+
+            fake.pagedAgents =
+                AgentPageDto(listOf(sampleDto.copy(status = "IDLE")), page = 0, pageSize = 10, totalElements = 1, totalPages = 1)
+            repo.invalidateCache()
+
+            assertEquals("IDLE", repo.observeAgents(page = 0, pageSize = 10).first().agents[0].status.name)
+        }
+
+    @Test
+    fun `should handle empty pages gracefully`() =
+        runTest {
+            val fake = FakeDashboardApiClient()
+            fake.pagedAgents = AgentPageDto(emptyList(), page = 5, pageSize = 10, totalElements = 25, totalPages = 3)
+            val repo = AgentRepositoryImpl(fake, agentMapper)
+
+            val result = repo.observeAgents(page = 5, pageSize = 10).first()
+            assertTrue(result.agents.isEmpty())
+            assertEquals(25L, result.totalElements)
+            assertEquals(3, result.totalPages)
+        }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/FakeDashboardApiClient.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/FakeDashboardApiClient.kt
@@ -2,6 +2,7 @@ package com.orchestradashboard.shared.data.repository
 
 import com.orchestradashboard.shared.data.dto.AgentDto
 import com.orchestradashboard.shared.data.dto.AgentEventDto
+import com.orchestradashboard.shared.data.dto.AgentPageDto
 import com.orchestradashboard.shared.data.dto.AuthResponseDto
 import com.orchestradashboard.shared.data.dto.PipelineRunDto
 import com.orchestradashboard.shared.data.network.DashboardApi
@@ -13,6 +14,7 @@ class FakeDashboardApiClient(
     private val pollingIntervalMs: Long = 5000L,
 ) : DashboardApi {
     var agents: List<AgentDto> = emptyList()
+    var pagedAgents: AgentPageDto = AgentPageDto(emptyList(), 0, 20, 0, 0)
     var pipelineRuns: List<PipelineRunDto> = emptyList()
     var events: List<AgentEventDto> = emptyList()
     var shouldFail: Boolean = false
@@ -89,6 +91,15 @@ class FakeDashboardApiClient(
 
     override suspend fun deregisterAgent(agentId: String) {
         if (shouldFail) throw RuntimeException("Network error")
+    }
+
+    override suspend fun getAgentsPaged(
+        page: Int,
+        pageSize: Int,
+        status: String?,
+    ): AgentPageDto {
+        if (shouldFail) throw RuntimeException("Network error")
+        return pagedAgents
     }
 
     override suspend fun login(apiKey: String): AuthResponseDto {

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/model/FakeAgentRepository.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/model/FakeAgentRepository.kt
@@ -26,4 +26,13 @@ class FakeAgentRepository : AgentRepository {
     override suspend fun registerAgent(agent: Agent) = Result.failure<Agent>(NotImplementedError())
 
     override suspend fun deregisterAgent(agentId: String) = Result.failure<Unit>(NotImplementedError())
+
+    val pagedAgentsFlow = MutableSharedFlow<PagedResult<Agent>>(replay = 1)
+
+    override fun observeAgents(
+        page: Int,
+        pageSize: Int,
+    ): Flow<PagedResult<Agent>> = pagedAgentsFlow
+
+    override suspend fun invalidateCache() {}
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/FakeAgentRepository.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/FakeAgentRepository.kt
@@ -1,8 +1,10 @@
 package com.orchestradashboard.shared.domain.usecase
 
 import com.orchestradashboard.shared.domain.model.Agent
+import com.orchestradashboard.shared.domain.model.PagedResult
 import com.orchestradashboard.shared.domain.repository.AgentRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 
@@ -27,4 +29,15 @@ class FakeAgentRepository(
     override suspend fun registerAgent(agent: Agent): Result<Agent> = Result.success(agent)
 
     override suspend fun deregisterAgent(agentId: String): Result<Unit> = Result.success(Unit)
+
+    val pagedAgentsFlow = MutableSharedFlow<PagedResult<Agent>>(replay = 1)
+
+    override fun observeAgents(
+        page: Int,
+        pageSize: Int,
+    ): Flow<PagedResult<Agent>> = pagedAgentsFlow
+
+    override suspend fun invalidateCache() {
+        // no-op for tests
+    }
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/agentdetail/FakeAgentRepository.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/agentdetail/FakeAgentRepository.kt
@@ -1,10 +1,12 @@
 package com.orchestradashboard.shared.ui.agentdetail
 
 import com.orchestradashboard.shared.domain.model.Agent
+import com.orchestradashboard.shared.domain.model.PagedResult
 import com.orchestradashboard.shared.domain.repository.AgentRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 
 class FakeAgentRepository : AgentRepository {
     val agentsFlow = MutableSharedFlow<List<Agent>>()
@@ -27,4 +29,11 @@ class FakeAgentRepository : AgentRepository {
     override suspend fun registerAgent(agent: Agent) = Result.failure<Agent>(NotImplementedError())
 
     override suspend fun deregisterAgent(agentId: String) = Result.failure<Unit>(NotImplementedError())
+
+    override fun observeAgents(
+        page: Int,
+        pageSize: Int,
+    ): Flow<PagedResult<Agent>> = flowOf(PagedResult(emptyList(), 0, pageSize, 0, 0))
+
+    override suspend fun invalidateCache() {}
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/util/CacheManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/util/CacheManagerTest.kt
@@ -1,0 +1,88 @@
+package com.orchestradashboard.shared.util
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CacheManagerTest {
+    @Test
+    fun `should return cached data immediately on subsequent fetches`() =
+        runTest {
+            val cache = CacheManager<String, List<String>>(maxSize = 10, ttlMs = 60_000L)
+            var fetchCount = 0
+            cache.getOrFetch("key") {
+                fetchCount++
+                listOf("a", "b")
+            }
+            cache.getOrFetch("key") {
+                fetchCount++
+                listOf("a", "b")
+            }
+            assertEquals(1, fetchCount)
+        }
+
+    @Test
+    fun `should evict entry after TTL expires`() =
+        runTest {
+            var currentTime = 0L
+            val cache = CacheManager<String, String>(maxSize = 10, ttlMs = 1000L, clock = { currentTime })
+            cache.getOrFetch("key") { "value" }
+            currentTime = 1001L
+            var fetchCount = 0
+            cache.getOrFetch("key") {
+                fetchCount++
+                "new"
+            }
+            assertEquals(1, fetchCount)
+        }
+
+    @Test
+    fun `should evict LRU entry when max size exceeded`() =
+        runTest {
+            val cache = CacheManager<String, String>(maxSize = 2, ttlMs = 60_000L)
+            cache.getOrFetch("a") { "1" }
+            cache.getOrFetch("b") { "2" }
+            cache.getOrFetch("c") { "3" }
+            var fetchCount = 0
+            cache.getOrFetch("a") {
+                fetchCount++
+                "re-fetched"
+            }
+            assertEquals(1, fetchCount)
+        }
+
+    @Test
+    fun `invalidateAll clears all entries`() =
+        runTest {
+            val cache = CacheManager<String, String>(maxSize = 10, ttlMs = 60_000L)
+            cache.getOrFetch("a") { "1" }
+            cache.invalidateAll()
+            var fetchCount = 0
+            cache.getOrFetch("a") {
+                fetchCount++
+                "new"
+            }
+            assertEquals(1, fetchCount)
+        }
+
+    @Test
+    fun `invalidate removes specific key`() =
+        runTest {
+            val cache = CacheManager<String, String>(maxSize = 10, ttlMs = 60_000L)
+            cache.getOrFetch("a") { "1" }
+            cache.getOrFetch("b") { "2" }
+            cache.invalidate("a")
+            var aCount = 0
+            var bCount = 0
+            cache.getOrFetch("a") {
+                aCount++
+                "new"
+            }
+            cache.getOrFetch("b") {
+                bCount++
+                "new"
+            }
+            assertEquals(1, aCount)
+            assertEquals(0, bCount)
+        }
+}

--- a/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/screen/AgentDetailScreenTest.kt
+++ b/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/screen/AgentDetailScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.runComposeUiTest
 import com.orchestradashboard.shared.domain.model.Agent
 import com.orchestradashboard.shared.domain.model.AgentEvent
 import com.orchestradashboard.shared.domain.model.EventType
+import com.orchestradashboard.shared.domain.model.PagedResult
 import com.orchestradashboard.shared.domain.model.PipelineRun
 import com.orchestradashboard.shared.domain.model.PipelineRunStatus
 import com.orchestradashboard.shared.domain.model.PipelineStep
@@ -75,6 +76,13 @@ private class StaticAgentRepository : AgentRepository {
     override suspend fun registerAgent(agent: Agent) = Result.success(agent)
 
     override suspend fun deregisterAgent(agentId: String) = Result.success(Unit)
+
+    override fun observeAgents(
+        page: Int,
+        pageSize: Int,
+    ): Flow<PagedResult<Agent>> = flowOf(PagedResult(listOf(testAgent), 0, pageSize, 1, 1))
+
+    override suspend fun invalidateCache() {}
 }
 
 private class StaticPipelineRepository : PipelineRepository {

--- a/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/screen/DashboardScreenTest.kt
+++ b/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/screen/DashboardScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
 import com.orchestradashboard.shared.domain.model.Agent
 import com.orchestradashboard.shared.domain.model.DashboardViewModel
+import com.orchestradashboard.shared.domain.model.PagedResult
 import com.orchestradashboard.shared.domain.repository.AgentRepository
 import com.orchestradashboard.shared.domain.usecase.GetAgentUseCase
 import com.orchestradashboard.shared.domain.usecase.ObserveAgentsUseCase
@@ -36,6 +37,13 @@ class FakeAgentRepository(
     override suspend fun registerAgent(agent: Agent): Result<Agent> = Result.success(agent)
 
     override suspend fun deregisterAgent(agentId: String): Result<Unit> = Result.success(Unit)
+
+    override fun observeAgents(
+        page: Int,
+        pageSize: Int,
+    ): Flow<PagedResult<Agent>> = flowOf(PagedResult(agents, 0, pageSize, agents.size.toLong(), 1))
+
+    override suspend fun invalidateCache() {}
 }
 
 private fun createViewModel(agents: List<Agent> = emptyList()): DashboardViewModel {


### PR DESCRIPTION
Closes #29

## Design
---

# Design: Pagination and Caching for Agent Repository (Issue #29)

## 1. Architecture Overview

### Data Flow

```
UI Layer          Shared Repo              Server (Spring)
ViewModel  ◄──paginated Flow──  + CacheManager  ◄──HTTP──  Controller
   │                  │                              │
   │ DashboardUiState │ invalidate()                 │ Pageable
   │                  ▼                              ▼
   │           MutableSharedFlow              AgentJpaRepository
   │           (trigger)
   │                  ▲
   │                  │ emit(Unit)
   │           WebSocket Events
```

### Key Design Decisions

1. **New endpoint** (`GET /api/v1/agents/paged`) — avoids breaking existing `GET /api/v1/agents` that returns `List<AgentResponse>`.
2. **Event-driven Flow** — `MutableSharedFlow` trigger replaces polling `while(true)` loop. Re-fetches **only** on `invalidateCache()`.
3. **Filtering + Pagination combined** — `status` works alongside `page`/`pageSize`, not as alternative.
4. **Max page size = 100** — `@Max(100)` on `pageSize` prevents DoS.
5. **LRU cache with TTL** — keyed by `(page, pageSize, status?)`, 30s TTL, max 20 entries.

---

## 2. Files to Create / Modify

### New Files

| # | Path | Purpose |
|---|------|---------|
| N1 | `shared/src/commonMain/kotlin/.../util/CacheManager.kt` | Generic LRU cache with TTL |
| N2 | `shared/src/commonMain/kotlin/.../data/dto/AgentPageDto.kt` | Paginated response DTO |
| N3 | `shared/src/commonMain/kotlin/.../dom

_(truncated)_

## Changed Files (25)
- `server/src/main/kotlin/com/orchestradashboard/server/controller/AgentController.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/model/PagedAgentResponse.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/repository/AgentJpaRepository.kt`
- `server/src/main/kotlin/com/orchestradashboard/server/service/AgentService.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/controller/AgentPaginationControllerTest.kt`
- `server/src/test/kotlin/com/orchestradashboard/server/repository/AgentJpaRepositoryPaginationTest.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/AgentPageDto.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/network/DashboardApi.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/network/DashboardApiClient.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/AgentRepositoryImpl.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/DashboardUiState.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/DashboardViewModel.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/PagedResult.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/AgentRepository.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveAgentsUseCase.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/util/CacheManager.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/network/FakeDashboardApiClient.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/AgentRepositoryPaginationTest.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/FakeDashboardApiClient.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/model/FakeAgentRepository.kt`

## Review
### Review of GitHub Issue #29: `feat: Add pagination and caching to shared repository layer`

The implementation successfully introduces a paginated and cached data-fetching mechanism, replacing the previous polling-based approach. The architecture is robust, with clear separation of concerns and excellent test coverage that validates the core requirements.

However, a detailed analysis reveals one critical issue and one minor code quality problem.

#### Business Logic Correctness

**[CRITICAL] Server-Side Filtering Not Exposed to Client:**
The design document specifies: "Filtering + Pagination combined — `status` works alongside `page`/`pageSize`". The server-side implementation correctly supports this by adding a `status` parameter to `AgentService.getAgentsPaged` and a `findByStatus(st

_(truncated)_

## AI Audit: PASS
[AUDIT: FAIL]

### 1. Intent Alignment

**[CRITICAL] Missing Client-Side Status Filtering:**
The implementation fails to expose the server-side status filtering to the client. While the server correctly supports filtering by status, the `AgentRepository` interface and its implementation lack a `status` parameter in the `observeAgents` method. This prevents the client from requesting filtered results, defeating the purpose of server-side filtering and pagination.

### 2. Logic Flaws

**[MAJOR] Inconsistent Cache Key Handling:**
The `CacheKey` in `AgentRepositoryImpl` does not include the `status` parameter, leading to incorrect caching behavior. Different status filters will incorrectly share the same cache key, causing stale or incorrect data to be returned.

### 3. Security

**[MINOR] Incorrect Validation Annotations:**
The validation annotations in `AgentController.kt` are malformed, using non-standard annotations. While the validation logic works, the code is confusing and prone to 

_(truncated)_