### PR TITLE
feat: Pipeline Monitor 화면 — 실시간 스텝 타임라인

### DIFF
--- a/androidApp/src/main/kotlin/com/orchestradashboard/android/App.kt
+++ b/androidApp/src/main/kotlin/com/orchestradashboard/android/App.kt
@@ -36,6 +36,9 @@ class MainActivity : ComponentActivity() {
                     projectExplorerViewModelFactory = {
                         AppContainer.createProjectExplorerViewModel()
                     },
+                    pipelineMonitorViewModelFactory = { pipelineId ->
+                        AppContainer.createPipelineMonitorViewModel(pipelineId)
+                    },
                 )
             }
         }

--- a/androidApp/src/main/kotlin/com/orchestradashboard/android/di/AppContainer.kt
+++ b/androidApp/src/main/kotlin/com/orchestradashboard/android/di/AppContainer.kt
@@ -7,6 +7,7 @@ import com.orchestradashboard.shared.data.mapper.AgentEventMapper
 import com.orchestradashboard.shared.data.mapper.AgentMapper
 import com.orchestradashboard.shared.data.mapper.CheckpointMapper
 import com.orchestradashboard.shared.data.mapper.IssueMapper
+import com.orchestradashboard.shared.data.mapper.MonitoredPipelineMapper
 import com.orchestradashboard.shared.data.mapper.PipelineHistoryMapper
 import com.orchestradashboard.shared.data.mapper.PipelineRunMapper
 import com.orchestradashboard.shared.data.mapper.ProjectMapper
@@ -17,6 +18,7 @@ import com.orchestradashboard.shared.data.repository.AndroidTokenRepository
 import com.orchestradashboard.shared.data.repository.CheckpointRepositoryImpl
 import com.orchestradashboard.shared.data.repository.EventRepositoryImpl
 import com.orchestradashboard.shared.data.repository.MetricRepositoryImpl
+import com.orchestradashboard.shared.data.repository.PipelineMonitorRepositoryImpl
 import com.orchestradashboard.shared.data.repository.PipelineRepositoryImpl
 import com.orchestradashboard.shared.data.repository.ProjectRepositoryImpl
 import com.orchestradashboard.shared.data.repository.SystemRepositoryImpl
@@ -26,6 +28,7 @@ import com.orchestradashboard.shared.domain.repository.AgentRepository
 import com.orchestradashboard.shared.domain.repository.CheckpointRepository
 import com.orchestradashboard.shared.domain.repository.EventRepository
 import com.orchestradashboard.shared.domain.repository.MetricRepository
+import com.orchestradashboard.shared.domain.repository.PipelineMonitorRepository
 import com.orchestradashboard.shared.domain.repository.PipelineRepository
 import com.orchestradashboard.shared.domain.repository.ProjectRepository
 import com.orchestradashboard.shared.domain.repository.SystemRepository
@@ -45,6 +48,7 @@ import com.orchestradashboard.shared.domain.usecase.ObserveSystemEventsUseCase
 import com.orchestradashboard.shared.domain.usecase.RetryCheckpointUseCase
 import com.orchestradashboard.shared.ui.agentdetail.AgentDetailViewModel
 import com.orchestradashboard.shared.ui.dashboardhome.DashboardHomeViewModel
+import com.orchestradashboard.shared.ui.pipelinemonitor.PipelineMonitorViewModel
 import com.orchestradashboard.shared.ui.projectexplorer.ProjectExplorerViewModel
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
@@ -125,6 +129,7 @@ object AppContainer {
     private val systemStatusMapper: SystemStatusMapper by lazy { SystemStatusMapper() }
     private val activePipelineMapper: ActivePipelineMapper by lazy { ActivePipelineMapper() }
     private val pipelineHistoryMapper: PipelineHistoryMapper by lazy { PipelineHistoryMapper() }
+    private val monitoredPipelineMapper: MonitoredPipelineMapper by lazy { MonitoredPipelineMapper() }
 
     // ─── Repositories ───────────────────────────────────────────
 
@@ -150,6 +155,10 @@ object AppContainer {
 
     private val checkpointRepository: CheckpointRepository by lazy {
         CheckpointRepositoryImpl(orchestratorApiClient, checkpointMapper)
+    }
+
+    private val pipelineMonitorRepository: PipelineMonitorRepository by lazy {
+        PipelineMonitorRepositoryImpl(orchestratorApiClient, monitoredPipelineMapper)
     }
 
     private val systemRepository: SystemRepository by lazy {
@@ -225,6 +234,9 @@ object AppContainer {
 
     fun createProjectExplorerViewModel(): ProjectExplorerViewModel =
         ProjectExplorerViewModel(getProjectsUseCase, getProjectIssuesUseCase, getCheckpointsUseCase, retryCheckpointUseCase)
+
+    fun createPipelineMonitorViewModel(pipelineId: String): PipelineMonitorViewModel =
+        PipelineMonitorViewModel(pipelineId, pipelineMonitorRepository)
 
     fun createDashboardHomeViewModel(): DashboardHomeViewModel =
         DashboardHomeViewModel(

--- a/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/Main.kt
@@ -32,6 +32,9 @@ fun main() =
                     projectExplorerViewModelFactory = {
                         AppContainer.createProjectExplorerViewModel()
                     },
+                    pipelineMonitorViewModelFactory = { pipelineId ->
+                        AppContainer.createPipelineMonitorViewModel(pipelineId)
+                    },
                 )
             }
         }

--- a/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/di/AppContainer.kt
+++ b/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/di/AppContainer.kt
@@ -6,6 +6,7 @@ import com.orchestradashboard.shared.data.mapper.AgentEventMapper
 import com.orchestradashboard.shared.data.mapper.AgentMapper
 import com.orchestradashboard.shared.data.mapper.CheckpointMapper
 import com.orchestradashboard.shared.data.mapper.IssueMapper
+import com.orchestradashboard.shared.data.mapper.MonitoredPipelineMapper
 import com.orchestradashboard.shared.data.mapper.PipelineHistoryMapper
 import com.orchestradashboard.shared.data.mapper.PipelineRunMapper
 import com.orchestradashboard.shared.data.mapper.ProjectMapper
@@ -16,6 +17,7 @@ import com.orchestradashboard.shared.data.repository.CheckpointRepositoryImpl
 import com.orchestradashboard.shared.data.repository.DesktopTokenRepository
 import com.orchestradashboard.shared.data.repository.EventRepositoryImpl
 import com.orchestradashboard.shared.data.repository.MetricRepositoryImpl
+import com.orchestradashboard.shared.data.repository.PipelineMonitorRepositoryImpl
 import com.orchestradashboard.shared.data.repository.PipelineRepositoryImpl
 import com.orchestradashboard.shared.data.repository.ProjectRepositoryImpl
 import com.orchestradashboard.shared.data.repository.SystemRepositoryImpl
@@ -25,6 +27,7 @@ import com.orchestradashboard.shared.domain.repository.AgentRepository
 import com.orchestradashboard.shared.domain.repository.CheckpointRepository
 import com.orchestradashboard.shared.domain.repository.EventRepository
 import com.orchestradashboard.shared.domain.repository.MetricRepository
+import com.orchestradashboard.shared.domain.repository.PipelineMonitorRepository
 import com.orchestradashboard.shared.domain.repository.PipelineRepository
 import com.orchestradashboard.shared.domain.repository.ProjectRepository
 import com.orchestradashboard.shared.domain.repository.SystemRepository
@@ -44,6 +47,7 @@ import com.orchestradashboard.shared.domain.usecase.ObserveSystemEventsUseCase
 import com.orchestradashboard.shared.domain.usecase.RetryCheckpointUseCase
 import com.orchestradashboard.shared.ui.agentdetail.AgentDetailViewModel
 import com.orchestradashboard.shared.ui.dashboardhome.DashboardHomeViewModel
+import com.orchestradashboard.shared.ui.pipelinemonitor.PipelineMonitorViewModel
 import com.orchestradashboard.shared.ui.projectexplorer.ProjectExplorerViewModel
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
@@ -140,6 +144,7 @@ object AppContainer {
     private val systemStatusMapper: SystemStatusMapper by lazy { SystemStatusMapper() }
     private val activePipelineMapper: ActivePipelineMapper by lazy { ActivePipelineMapper() }
     private val pipelineHistoryMapper: PipelineHistoryMapper by lazy { PipelineHistoryMapper() }
+    private val monitoredPipelineMapper: MonitoredPipelineMapper by lazy { MonitoredPipelineMapper() }
 
     // ─── Repositories ───────────────────────────────────────────
 
@@ -165,6 +170,10 @@ object AppContainer {
 
     private val checkpointRepository: CheckpointRepository by lazy {
         CheckpointRepositoryImpl(orchestratorApiClient, checkpointMapper)
+    }
+
+    private val pipelineMonitorRepository: PipelineMonitorRepository by lazy {
+        PipelineMonitorRepositoryImpl(orchestratorApiClient, monitoredPipelineMapper)
     }
 
     private val systemRepository: SystemRepository by lazy {
@@ -240,6 +249,9 @@ object AppContainer {
 
     fun createProjectExplorerViewModel(): ProjectExplorerViewModel =
         ProjectExplorerViewModel(getProjectsUseCase, getProjectIssuesUseCase, getCheckpointsUseCase, retryCheckpointUseCase)
+
+    fun createPipelineMonitorViewModel(pipelineId: String): PipelineMonitorViewModel =
+        PipelineMonitorViewModel(pipelineId, pipelineMonitorRepository)
 
     fun createDashboardHomeViewModel(): DashboardHomeViewModel =
         DashboardHomeViewModel(

--- a/iosApp/iosApp/IOSAppContainer.swift
+++ b/iosApp/iosApp/IOSAppContainer.swift
@@ -19,4 +19,8 @@ final class IOSAppContainer {
     func createDashboardHomeViewModel() -> DashboardHomeViewModel {
         fatalError("KMP framework must be linked via Gradle :shared:iosArm64Binaries")
     }
+
+    func createPipelineMonitorViewModel(pipelineId: String) -> PipelineMonitorViewModel {
+        fatalError("KMP framework must be linked via Gradle :shared:iosArm64Binaries")
+    }
 }

--- a/iosApp/iosApp/IOSPipelineMonitorViewModel.swift
+++ b/iosApp/iosApp/IOSPipelineMonitorViewModel.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Shared
+
+/// iOS-specific wrapper around the KMP PipelineMonitorViewModel.
+/// Bridges Kotlin coroutine StateFlow to Swift's ObservableObject/Combine.
+@MainActor
+final class IOSPipelineMonitorViewModel: ObservableObject {
+    @Published var pipeline: MonitoredPipeline? = nil
+    @Published var logLines: [String] = []
+    @Published var pendingApproval: ApprovalRequest? = nil
+    @Published var isLoading: Bool = false
+    @Published var error: String? = nil
+    @Published var connectionStatus: ConnectionStatus = .disconnected
+
+    private let viewModel: PipelineMonitorViewModel
+    private var collectTask: Task<Void, Never>?
+
+    init(pipelineId: String) {
+        let container = IOSAppContainer.shared
+        self.viewModel = container.createPipelineMonitorViewModel(pipelineId: pipelineId)
+        startCollecting()
+    }
+
+    private func startCollecting() {
+        collectTask?.cancel()
+        collectTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let collector = PipelineUiStateCollector { [weak self] state in
+                self?.updateFromState(state)
+            }
+            try? await self.viewModel.uiState.collect(collector: collector)
+        }
+    }
+
+    private func updateFromState(_ state: PipelineMonitorUiState) {
+        self.pipeline = state.pipeline
+        self.logLines = state.logLines as? [String] ?? []
+        self.pendingApproval = state.pendingApproval
+        self.isLoading = state.isLoading
+        self.error = state.error
+        self.connectionStatus = state.connectionStatus
+    }
+
+    func loadPipeline() {
+        viewModel.loadPipeline()
+    }
+
+    func startObserving() {
+        viewModel.startObserving()
+    }
+
+    func refresh() {
+        viewModel.refresh()
+    }
+
+    func dismissApproval() {
+        viewModel.dismissApproval()
+    }
+
+    func clearError() {
+        viewModel.clearError()
+    }
+
+    func onCleared() {
+        collectTask?.cancel()
+        viewModel.onCleared()
+    }
+}
+
+private final class PipelineUiStateCollector: Kotlinx_coroutines_coreFlowCollector {
+    let onValue: (PipelineMonitorUiState) -> Void
+
+    init(onValue: @escaping (PipelineMonitorUiState) -> Void) {
+        self.onValue = onValue
+    }
+
+    func emit(value: Any?, completionHandler: @escaping (Error?) -> Void) {
+        if let state = value as? PipelineMonitorUiState {
+            onValue(state)
+        }
+        completionHandler(nil)
+    }
+}

--- a/iosApp/iosApp/PipelineMonitorView.swift
+++ b/iosApp/iosApp/PipelineMonitorView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+import Shared
+
+/// Pipeline Monitor screen — displays step timeline, live logs, and approval dialogs.
+struct PipelineMonitorView: View {
+    @StateObject private var viewModel: IOSPipelineMonitorViewModel
+
+    init(pipelineId: String) {
+        _viewModel = StateObject(wrappedValue: IOSPipelineMonitorViewModel(pipelineId: pipelineId))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if viewModel.isLoading {
+                ProgressView("Loading pipeline...")
+            } else {
+                ScrollView {
+                    VStack(spacing: 16) {
+                        if let pipeline = viewModel.pipeline {
+                            StepTimelineView(steps: pipeline.steps)
+                        }
+
+                        logPanel
+                    }
+                    .padding()
+                }
+            }
+        }
+        .navigationTitle(
+            viewModel.pipeline.map { "\($0.projectName) #\($0.issueNum)" } ?? "Pipeline Monitor"
+        )
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: { viewModel.refresh() }) {
+                    Image(systemName: "arrow.clockwise")
+                }
+            }
+        }
+        .onAppear {
+            viewModel.loadPipeline()
+            viewModel.startObserving()
+        }
+        .onDisappear { viewModel.onCleared() }
+        .alert("Error", isPresented: .constant(viewModel.error != nil)) {
+            Button("OK") { viewModel.clearError() }
+        } message: {
+            Text(viewModel.error ?? "")
+        }
+        .sheet(isPresented: .constant(viewModel.pendingApproval != nil)) {
+            if let approval = viewModel.pendingApproval {
+                ApprovalDialogView(approval: approval, onDismiss: { viewModel.dismissApproval() })
+            }
+        }
+    }
+
+    private var logPanel: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Logs")
+                .font(.headline)
+
+            if viewModel.logLines.isEmpty {
+                Text("Waiting for logs...")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading) {
+                        ForEach(Array(viewModel.logLines.enumerated()), id: \.offset) { _, line in
+                            Text(line)
+                                .font(.system(.caption, design: .monospaced))
+                        }
+                    }
+                }
+                .frame(maxHeight: 300)
+                .background(Color(.systemGray6))
+                .cornerRadius(8)
+            }
+        }
+    }
+}

--- a/iosApp/iosApp/components/ApprovalDialogView.swift
+++ b/iosApp/iosApp/components/ApprovalDialogView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import Shared
+
+/// Modal dialog for pipeline approval requests.
+struct ApprovalDialogView: View {
+    let approval: ApprovalRequest
+    let onDismiss: () -> Void
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 16) {
+                Text("Approval Required")
+                    .font(.title2)
+                    .bold()
+
+                Text("This step requires \(approval.approvalType) approval.")
+                    .font(.body)
+
+                if !approval.options.isEmpty {
+                    VStack(spacing: 8) {
+                        Text("Options:")
+                            .font(.headline)
+
+                        ForEach(approval.options, id: \.self) { option in
+                            Button(action: { /* Phase 2 */ }) {
+                                Text(option)
+                                    .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(.bordered)
+                        }
+
+                        Text("Actions available in Phase 2")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer()
+            }
+            .padding()
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Dismiss", action: onDismiss)
+                }
+            }
+        }
+    }
+}

--- a/iosApp/iosApp/components/StepTimelineView.swift
+++ b/iosApp/iosApp/components/StepTimelineView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+import Shared
+
+/// Horizontal step timeline displaying pipeline steps with status colors.
+struct StepTimelineView: View {
+    let steps: [MonitoredStep]
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 4) {
+                ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
+                    HStack(spacing: 4) {
+                        stepNode(step)
+
+                        if index < steps.count - 1 {
+                            Rectangle()
+                                .fill(connectorColor(for: step.status))
+                                .frame(width: 24, height: 2)
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+        }
+    }
+
+    private func stepNode(_ step: MonitoredStep) -> some View {
+        VStack(spacing: 4) {
+            Circle()
+                .fill(statusColor(for: step.status))
+                .frame(width: 24, height: 24)
+
+            Text(step.name)
+                .font(.caption2)
+                .lineLimit(1)
+                .frame(width: 60)
+
+            if step.elapsedMs > 0 {
+                Text(formatElapsed(step.elapsedMs))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func statusColor(for status: StepStatus) -> Color {
+        switch status {
+        case .pending: return .gray
+        case .running: return .blue
+        case .passed: return .green
+        case .failed: return .red
+        case .skipped: return .orange
+        default: return .gray
+        }
+    }
+
+    private func connectorColor(for status: StepStatus) -> Color {
+        switch status {
+        case .passed: return .green
+        case .running: return .blue
+        default: return .gray
+        }
+    }
+
+    private func formatElapsed(_ ms: Int64) -> String {
+        let totalSec = Int(ms / 1000)
+        let m = totalSec / 60
+        let s = totalSec % 60
+        return "\(m)m \(s)s"
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/api/OrchestratorApi.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/api/OrchestratorApi.kt
@@ -34,4 +34,6 @@ interface OrchestratorApi {
     suspend fun getPipelineHistory(): List<PipelineHistoryDto>
 
     fun connectEvents(): Flow<PipelineEventDto>
+
+    fun connectEvents(pipelineId: String): Flow<PipelineEventDto>
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/api/OrchestratorApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/api/OrchestratorApiClient.kt
@@ -70,6 +70,23 @@ class OrchestratorApiClient(
             }
         }
 
+    override fun connectEvents(pipelineId: String): Flow<PipelineEventDto> =
+        flow {
+            httpClient.webSocket(
+                request = {
+                    url("$baseUrl/ws/events/$pipelineId")
+                    header("X-API-Key", apiKey)
+                },
+            ) {
+                for (frame in incoming) {
+                    if (frame is Frame.Text) {
+                        val event = json.decodeFromString<PipelineEventDto>(frame.readText())
+                        emit(event)
+                    }
+                }
+            }
+        }
+
     @Suppress("TooGenericExceptionCaught")
     private suspend inline fun <reified T> request(path: String): T {
         try {

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/mapper/MonitoredPipelineMapper.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/mapper/MonitoredPipelineMapper.kt
@@ -1,0 +1,67 @@
+package com.orchestradashboard.shared.data.mapper
+
+import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorPipelineDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PipelineStepDto
+import com.orchestradashboard.shared.domain.model.MonitoredPipeline
+import com.orchestradashboard.shared.domain.model.MonitoredStep
+import com.orchestradashboard.shared.domain.model.PipelineRunStatus
+import com.orchestradashboard.shared.domain.model.StepStatus
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+class MonitoredPipelineMapper {
+    fun mapToDomain(dto: OrchestratorPipelineDto): MonitoredPipeline =
+        MonitoredPipeline(
+            id = dto.id,
+            projectName = dto.projectName,
+            issueNum = dto.issueNum,
+            issueTitle = dto.issueTitle,
+            mode = dto.mode,
+            status = parseRunStatus(dto.status),
+            steps = dto.steps.map { mapStep(it) },
+            startedAtMs = parseIsoToEpochMs(dto.startedAt),
+            elapsedTotalSec = dto.elapsedTotalSec,
+        )
+
+    private fun mapStep(dto: PipelineStepDto): MonitoredStep {
+        val status = parseStepStatus(dto.status)
+        return MonitoredStep(
+            name = dto.name,
+            status = status,
+            elapsedMs = (dto.elapsedSec * 1000).toLong(),
+            startedAtMs =
+                if (status == StepStatus.RUNNING) {
+                    Clock.System.now().toEpochMilliseconds() - (dto.elapsedSec * 1000).toLong()
+                } else {
+                    null
+                },
+            detail = "",
+        )
+    }
+
+    fun parseStepStatus(status: String): StepStatus =
+        when (status.uppercase()) {
+            "RUNNING" -> StepStatus.RUNNING
+            "PASSED", "SUCCESS" -> StepStatus.PASSED
+            "FAILED", "ERROR" -> StepStatus.FAILED
+            "SKIPPED" -> StepStatus.SKIPPED
+            else -> StepStatus.PENDING
+        }
+
+    fun parseRunStatus(status: String): PipelineRunStatus =
+        when (status.uppercase()) {
+            "RUNNING" -> PipelineRunStatus.RUNNING
+            "PASSED", "SUCCESS" -> PipelineRunStatus.PASSED
+            "FAILED", "ERROR" -> PipelineRunStatus.FAILED
+            "CANCELLED" -> PipelineRunStatus.CANCELLED
+            "QUEUED" -> PipelineRunStatus.QUEUED
+            else -> PipelineRunStatus.QUEUED
+        }
+
+    private fun parseIsoToEpochMs(iso: String): Long? =
+        try {
+            Instant.parse(iso).toEpochMilliseconds()
+        } catch (_: Exception) {
+            null
+        }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/PipelineMonitorRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/PipelineMonitorRepositoryImpl.kt
@@ -19,6 +19,5 @@ class PipelineMonitorRepositoryImpl(
             Result.failure(e)
         }
 
-    override fun observePipelineEvents(pipelineId: String): Flow<PipelineEventDto> =
-        api.connectEvents(pipelineId)
+    override fun observePipelineEvents(pipelineId: String): Flow<PipelineEventDto> = api.connectEvents(pipelineId)
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/PipelineMonitorRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/PipelineMonitorRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package com.orchestradashboard.shared.data.repository
+
+import com.orchestradashboard.shared.data.api.OrchestratorApi
+import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
+import com.orchestradashboard.shared.data.mapper.MonitoredPipelineMapper
+import com.orchestradashboard.shared.domain.model.MonitoredPipeline
+import com.orchestradashboard.shared.domain.repository.PipelineMonitorRepository
+import kotlinx.coroutines.flow.Flow
+
+class PipelineMonitorRepositoryImpl(
+    private val api: OrchestratorApi,
+    private val mapper: MonitoredPipelineMapper,
+) : PipelineMonitorRepository {
+    override suspend fun getPipelineDetail(pipelineId: String): Result<MonitoredPipeline> =
+        try {
+            val dto = api.getPipeline(pipelineId)
+            Result.success(mapper.mapToDomain(dto))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+
+    override fun observePipelineEvents(pipelineId: String): Flow<PipelineEventDto> =
+        api.connectEvents(pipelineId)
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/MonitoredPipeline.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/MonitoredPipeline.kt
@@ -1,0 +1,41 @@
+package com.orchestradashboard.shared.domain.model
+
+data class MonitoredStep(
+    val name: String,
+    val status: StepStatus,
+    val elapsedMs: Long,
+    val startedAtMs: Long?,
+    val detail: String,
+)
+
+data class ApprovalRequest(
+    val approvalType: String,
+    val options: List<String>,
+)
+
+data class MonitoredPipeline(
+    val id: String,
+    val projectName: String,
+    val issueNum: Int,
+    val issueTitle: String,
+    val mode: String,
+    val status: PipelineRunStatus,
+    val steps: List<MonitoredStep>,
+    val startedAtMs: Long?,
+    val elapsedTotalSec: Double,
+) {
+    val currentRunningStep: MonitoredStep?
+        get() = steps.firstOrNull { it.status == StepStatus.RUNNING }
+
+    val progressFraction: Float
+        get() {
+            if (steps.isEmpty()) return 0f
+            val completed =
+                steps.count {
+                    it.status == StepStatus.PASSED || it.status == StepStatus.FAILED || it.status == StepStatus.SKIPPED
+                }
+            return completed.toFloat() / steps.size
+        }
+
+    val isParallel: Boolean get() = mode == "parallel"
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/PipelineMonitorRepository.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/PipelineMonitorRepository.kt
@@ -1,0 +1,11 @@
+package com.orchestradashboard.shared.domain.repository
+
+import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
+import com.orchestradashboard.shared.domain.model.MonitoredPipeline
+import kotlinx.coroutines.flow.Flow
+
+interface PipelineMonitorRepository {
+    suspend fun getPipelineDetail(pipelineId: String): Result<MonitoredPipeline>
+
+    fun observePipelineEvents(pipelineId: String): Flow<PipelineEventDto>
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ApprovalDialog.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ApprovalDialog.kt
@@ -1,0 +1,66 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.orchestradashboard.shared.domain.model.ApprovalRequest
+
+@Composable
+fun ApprovalDialog(
+    approval: ApprovalRequest,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = modifier,
+        title = {
+            Text("Approval Required: ${approval.approvalType}")
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = "This step requires ${approval.approvalType} approval.",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                if (approval.options.isNotEmpty()) {
+                    Text(
+                        text = "Options:",
+                        style = MaterialTheme.typography.labelMedium,
+                    )
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        approval.options.forEach { option ->
+                            OutlinedButton(onClick = { /* Phase 2 */ }) {
+                                Text(option)
+                            }
+                        }
+                    }
+                    Text(
+                        text = "Actions available in Phase 2",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Dismiss")
+            }
+        },
+    )
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/LiveLogPanel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/LiveLogPanel.kt
@@ -1,0 +1,61 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+
+private const val MAX_LOG_PANEL_HEIGHT = 300
+
+@Composable
+fun LiveLogPanel(
+    logLines: List<String>,
+    modifier: Modifier = Modifier,
+) {
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(logLines.size) {
+        if (logLines.isNotEmpty()) {
+            listState.animateScrollToItem(logLines.lastIndex)
+        }
+    }
+
+    Surface(
+        modifier = modifier.fillMaxWidth().heightIn(max = MAX_LOG_PANEL_HEIGHT.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        if (logLines.isEmpty()) {
+            Text(
+                text = "Waiting for logs...",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(16.dp),
+            )
+        } else {
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.padding(12.dp),
+            ) {
+                items(logLines) { line ->
+                    Text(
+                        text = line,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineView.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineView.kt
@@ -1,0 +1,37 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.orchestradashboard.shared.domain.model.MonitoredPipeline
+
+@Composable
+fun ParallelPipelineView(
+    pipelines: List<MonitoredPipeline>,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        pipelines.forEach { pipeline ->
+            Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                Row {
+                    Text(
+                        text = pipeline.id,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+                StepTimeline(steps = pipeline.steps)
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/StepNode.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/StepNode.kt
@@ -1,0 +1,130 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.orchestradashboard.shared.domain.model.MonitoredStep
+import com.orchestradashboard.shared.domain.model.StepStatus
+import kotlinx.coroutines.delay
+import kotlinx.datetime.Clock
+
+private const val TIMER_INTERVAL_MS = 1000L
+
+@Composable
+fun StepNode(
+    step: MonitoredStep,
+    modifier: Modifier = Modifier,
+) {
+    val color = stepStatusColor(step.status)
+
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        StepCircle(step.status, color)
+
+        Text(
+            text = step.name,
+            style = MaterialTheme.typography.labelSmall,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center,
+        )
+
+        StepTimer(step)
+    }
+}
+
+@Composable
+private fun StepCircle(
+    status: StepStatus,
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    if (status == StepStatus.RUNNING) {
+        val infiniteTransition = rememberInfiniteTransition()
+        val alpha by infiniteTransition.animateFloat(
+            initialValue = 0.4f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(tween(800), RepeatMode.Reverse),
+        )
+        Box(
+            modifier = modifier.size(24.dp).alpha(alpha).background(color, CircleShape),
+        )
+    } else {
+        Box(
+            modifier = modifier.size(24.dp).background(color, CircleShape),
+        )
+    }
+}
+
+@Composable
+private fun StepTimer(
+    step: MonitoredStep,
+    modifier: Modifier = Modifier,
+) {
+    if (step.status == StepStatus.RUNNING && step.startedAtMs != null) {
+        var elapsedMs by remember(step.startedAtMs) {
+            mutableLongStateOf(Clock.System.now().toEpochMilliseconds() - step.startedAtMs)
+        }
+        LaunchedEffect(step.startedAtMs) {
+            while (true) {
+                delay(TIMER_INTERVAL_MS)
+                elapsedMs = Clock.System.now().toEpochMilliseconds() - step.startedAtMs
+            }
+        }
+        Text(
+            text = formatElapsedMs(elapsedMs),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = modifier,
+        )
+    } else if (step.elapsedMs > 0) {
+        Text(
+            text = formatElapsedMs(step.elapsedMs),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = modifier,
+        )
+    }
+}
+
+internal fun stepStatusColor(status: StepStatus): Color =
+    when (status) {
+        StepStatus.PENDING -> Color(0xFF9E9E9E)
+        StepStatus.RUNNING -> Color(0xFF2196F3)
+        StepStatus.PASSED -> Color(0xFF4CAF50)
+        StepStatus.FAILED -> Color(0xFFF44336)
+        StepStatus.SKIPPED -> Color(0xFFFF9800)
+    }
+
+internal fun formatElapsedMs(ms: Long): String {
+    val totalSec = (ms / 1000).toInt()
+    val m = totalSec / 60
+    val s = totalSec % 60
+    return "${m}m ${s}s"
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/StepTimeline.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/StepTimeline.kt
@@ -1,0 +1,67 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.orchestradashboard.shared.domain.model.MonitoredStep
+import com.orchestradashboard.shared.domain.model.StepStatus
+
+@Composable
+fun StepTimeline(
+    steps: List<MonitoredStep>,
+    modifier: Modifier = Modifier,
+) {
+    if (steps.isEmpty()) {
+        Text(
+            text = "No steps available",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = modifier.padding(16.dp),
+        )
+        return
+    }
+
+    LazyRow(
+        modifier = modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        itemsIndexed(steps) { index, step ->
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                StepNode(step = step, modifier = Modifier.width(72.dp))
+
+                if (index < steps.lastIndex) {
+                    StepConnector(step.status)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StepConnector(
+    previousStepStatus: StepStatus,
+    modifier: Modifier = Modifier,
+) {
+    val color =
+        when (previousStepStatus) {
+            StepStatus.PASSED -> stepStatusColor(StepStatus.PASSED)
+            StepStatus.RUNNING -> stepStatusColor(StepStatus.RUNNING)
+            else -> stepStatusColor(StepStatus.PENDING)
+        }
+    Box(
+        modifier = modifier.width(24.dp).height(2.dp).background(color),
+    )
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorUiState.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorUiState.kt
@@ -1,0 +1,19 @@
+package com.orchestradashboard.shared.ui.pipelinemonitor
+
+import com.orchestradashboard.shared.domain.model.ApprovalRequest
+import com.orchestradashboard.shared.domain.model.ConnectionStatus
+import com.orchestradashboard.shared.domain.model.MonitoredPipeline
+
+data class PipelineMonitorUiState(
+    val pipeline: MonitoredPipeline? = null,
+    val logLines: List<String> = emptyList(),
+    val pendingApproval: ApprovalRequest? = null,
+    val parallelPipelines: List<MonitoredPipeline> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val connectionStatus: ConnectionStatus = ConnectionStatus.DISCONNECTED,
+) {
+    val isParallelView: Boolean get() = parallelPipelines.isNotEmpty()
+
+    val currentStepName: String? get() = pipeline?.currentRunningStep?.name
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModel.kt
@@ -1,0 +1,152 @@
+package com.orchestradashboard.shared.ui.pipelinemonitor
+
+import com.orchestradashboard.shared.domain.model.ApprovalRequest
+import com.orchestradashboard.shared.domain.model.ConnectionStatus
+import com.orchestradashboard.shared.domain.model.PipelineRunStatus
+import com.orchestradashboard.shared.domain.model.StepStatus
+import com.orchestradashboard.shared.domain.repository.PipelineMonitorRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+
+private const val MAX_LOG_LINES = 500
+
+class PipelineMonitorViewModel(
+    private val pipelineId: String,
+    private val repository: PipelineMonitorRepository,
+) {
+    private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val _uiState = MutableStateFlow(PipelineMonitorUiState())
+    val uiState: StateFlow<PipelineMonitorUiState> = _uiState.asStateFlow()
+
+    fun loadPipeline() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            repository.getPipelineDetail(pipelineId)
+                .onSuccess { newPipeline ->
+                    val oldSteps = _uiState.value.pipeline?.steps
+                    val mergedSteps =
+                        if (oldSteps != null) {
+                            newPipeline.steps.map { newStep ->
+                                val oldStep = oldSteps.firstOrNull { it.name == newStep.name }
+                                if (newStep.status == StepStatus.RUNNING &&
+                                    oldStep?.status == StepStatus.RUNNING &&
+                                    oldStep.startedAtMs != null
+                                ) {
+                                    newStep.copy(startedAtMs = oldStep.startedAtMs)
+                                } else {
+                                    newStep
+                                }
+                            }
+                        } else {
+                            newPipeline.steps
+                        }
+                    _uiState.update { it.copy(pipeline = newPipeline.copy(steps = mergedSteps), isLoading = false) }
+                }
+                .onFailure { e ->
+                    _uiState.update { it.copy(error = e.message, isLoading = false) }
+                }
+        }
+    }
+
+    fun startObserving() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(connectionStatus = ConnectionStatus.CONNECTED) }
+            repository.observePipelineEvents(pipelineId)
+                .catch { e ->
+                    _uiState.update {
+                        it.copy(connectionStatus = ConnectionStatus.DISCONNECTED, error = e.message)
+                    }
+                }
+                .collect { event -> handleEvent(event) }
+        }
+    }
+
+    private fun handleEvent(event: com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto) {
+        when (event.type) {
+            "step.started" -> updateStepStatus(event.step, StepStatus.RUNNING, event.elapsedSec)
+            "step.completed" -> updateStepStatus(event.step, StepStatus.PASSED, event.elapsedSec)
+            "step.failed" -> updateStepStatus(event.step, StepStatus.FAILED, event.elapsedSec)
+            "pipeline.completed" -> updatePipelineStatus(PipelineRunStatus.PASSED)
+            "pipeline.failed" -> updatePipelineStatus(PipelineRunStatus.FAILED)
+            "approval.requested" -> {
+                _uiState.update {
+                    it.copy(
+                        pendingApproval =
+                            ApprovalRequest(
+                                approvalType = event.approvalType ?: "unknown",
+                                options = event.options ?: emptyList(),
+                            ),
+                    )
+                }
+            }
+            "log" -> {
+                event.detail?.let { line ->
+                    _uiState.update { state ->
+                        val updated = state.logLines.toMutableList().apply { add(line) }
+                        state.copy(logLines = if (updated.size > MAX_LOG_LINES) updated.takeLast(MAX_LOG_LINES) else updated)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun updateStepStatus(
+        stepName: String?,
+        status: StepStatus,
+        elapsedSec: Double?,
+    ) {
+        if (stepName == null) return
+        _uiState.update { state ->
+            val pipeline = state.pipeline ?: return@update state
+            val updatedSteps =
+                pipeline.steps.map { step ->
+                    if (step.name == stepName) {
+                        step.copy(
+                            status = status,
+                            elapsedMs = elapsedSec?.let { (it * 1000).toLong() } ?: step.elapsedMs,
+                            startedAtMs =
+                                if (status == StepStatus.RUNNING) {
+                                    Clock.System.now().toEpochMilliseconds()
+                                } else {
+                                    null
+                                },
+                        )
+                    } else {
+                        step
+                    }
+                }
+            state.copy(pipeline = pipeline.copy(steps = updatedSteps))
+        }
+    }
+
+    private fun updatePipelineStatus(status: PipelineRunStatus) {
+        _uiState.update { state ->
+            state.copy(pipeline = state.pipeline?.copy(status = status))
+        }
+    }
+
+    fun dismissApproval() {
+        _uiState.update { it.copy(pendingApproval = null) }
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(error = null) }
+    }
+
+    fun refresh() {
+        loadPipeline()
+    }
+
+    fun onCleared() {
+        viewModelScope.cancel()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/AppNavigation.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/AppNavigation.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import com.orchestradashboard.shared.domain.model.DashboardViewModel
 import com.orchestradashboard.shared.ui.agentdetail.AgentDetailViewModel
 import com.orchestradashboard.shared.ui.dashboardhome.DashboardHomeViewModel
+import com.orchestradashboard.shared.ui.pipelinemonitor.PipelineMonitorViewModel
 import com.orchestradashboard.shared.ui.projectexplorer.ProjectExplorerViewModel
 
 sealed class Screen {
@@ -20,6 +21,8 @@ sealed class Screen {
     data class AgentDetail(val agentId: String) : Screen()
 
     data object ProjectExplorer : Screen()
+
+    data class PipelineMonitor(val pipelineId: String) : Screen()
 }
 
 @Composable
@@ -28,6 +31,7 @@ fun AppNavigation(
     dashboardHomeViewModelFactory: () -> DashboardHomeViewModel,
     agentDetailViewModelFactory: (String) -> AgentDetailViewModel,
     projectExplorerViewModelFactory: () -> ProjectExplorerViewModel,
+    pipelineMonitorViewModelFactory: (String) -> PipelineMonitorViewModel,
     modifier: Modifier = Modifier,
 ) {
     var currentScreen: Screen by remember { mutableStateOf(Screen.DashboardHome) }
@@ -42,7 +46,7 @@ fun AppNavigation(
                 viewModel = vm,
                 onNewSolveClick = { currentScreen = Screen.ProjectExplorer },
                 onViewProjectsClick = { currentScreen = Screen.ProjectExplorer },
-                onPipelineClick = { /* future: detail screen */ },
+                onPipelineClick = { pipelineId -> currentScreen = Screen.PipelineMonitor(pipelineId) },
                 modifier = modifier,
             )
         }
@@ -70,6 +74,20 @@ fun AppNavigation(
                 onDispose { vm.onCleared() }
             }
             ProjectExplorerScreen(
+                viewModel = vm,
+                onBackClick = { currentScreen = Screen.DashboardHome },
+                modifier = modifier,
+            )
+        }
+        is Screen.PipelineMonitor -> {
+            val vm =
+                remember(screen.pipelineId) {
+                    pipelineMonitorViewModelFactory(screen.pipelineId)
+                }
+            DisposableEffect(screen.pipelineId) {
+                onDispose { vm.onCleared() }
+            }
+            PipelineMonitorScreen(
                 viewModel = vm,
                 onBackClick = { currentScreen = Screen.DashboardHome },
                 modifier = modifier,

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/PipelineMonitorScreen.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/PipelineMonitorScreen.kt
@@ -1,0 +1,126 @@
+package com.orchestradashboard.shared.ui.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.orchestradashboard.shared.domain.model.ConnectionStatus
+import com.orchestradashboard.shared.ui.component.ApprovalDialog
+import com.orchestradashboard.shared.ui.component.ErrorBanner
+import com.orchestradashboard.shared.ui.component.LiveLogPanel
+import com.orchestradashboard.shared.ui.component.LoadingOverlay
+import com.orchestradashboard.shared.ui.component.ParallelPipelineView
+import com.orchestradashboard.shared.ui.component.StepTimeline
+import com.orchestradashboard.shared.ui.pipelinemonitor.PipelineMonitorViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PipelineMonitorScreen(
+    viewModel: PipelineMonitorViewModel,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadPipeline()
+        viewModel.startObserving()
+    }
+
+    uiState.pendingApproval?.let { approval ->
+        ApprovalDialog(
+            approval = approval,
+            onDismiss = { viewModel.dismissApproval() },
+        )
+    }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Column {
+                        Text(
+                            text =
+                                uiState.pipeline?.let {
+                                    "${it.projectName} #${it.issueNum}"
+                                } ?: "Pipeline Monitor",
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                        uiState.currentStepName?.let { stepName ->
+                            Text(
+                                text = stepName,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    }
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { viewModel.refresh() }) {
+                        Icon(Icons.Default.Refresh, contentDescription = "Refresh")
+                    }
+                },
+            )
+        },
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier.fillMaxSize().padding(paddingValues),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            uiState.error?.let { error ->
+                ErrorBanner(message = error, onDismiss = { viewModel.clearError() })
+            }
+
+            if (uiState.connectionStatus == ConnectionStatus.DISCONNECTED && uiState.pipeline != null) {
+                ErrorBanner(
+                    message = "Connection lost. Data may be stale.",
+                    onDismiss = {},
+                )
+            }
+
+            when {
+                uiState.isLoading -> LoadingOverlay()
+                uiState.isParallelView -> {
+                    ParallelPipelineView(
+                        pipelines = uiState.parallelPipelines,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+                uiState.pipeline != null -> {
+                    StepTimeline(
+                        steps = uiState.pipeline!!.steps,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+
+            LiveLogPanel(
+                logLines = uiState.logLines,
+                modifier = Modifier.fillMaxWidth().weight(1f).padding(horizontal = 16.dp),
+            )
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/api/FakeOrchestratorApiClient.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/api/FakeOrchestratorApiClient.kt
@@ -116,4 +116,10 @@ class FakeOrchestratorApiClient : OrchestratorApi {
         maybeThrow()
         return eventsResult.asFlow()
     }
+
+    override fun connectEvents(pipelineId: String): Flow<PipelineEventDto> {
+        connectEventsCallCount++
+        maybeThrow()
+        return eventsResult.filter { it.pipelineId == pipelineId }.asFlow()
+    }
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/mapper/MonitoredPipelineMapperTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/mapper/MonitoredPipelineMapperTest.kt
@@ -1,0 +1,100 @@
+package com.orchestradashboard.shared.data.mapper
+
+import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorPipelineDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PipelineStepDto
+import com.orchestradashboard.shared.domain.model.PipelineRunStatus
+import com.orchestradashboard.shared.domain.model.StepStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class MonitoredPipelineMapperTest {
+    private val mapper = MonitoredPipelineMapper()
+
+    private val sampleDto =
+        OrchestratorPipelineDto(
+            id = "pipe-1",
+            projectName = "my-project",
+            issueNum = 42,
+            issueTitle = "Fix the bug",
+            mode = "sequential",
+            status = "running",
+            currentStep = "testing",
+            startedAt = "2024-06-15T10:30:00Z",
+            steps =
+                listOf(
+                    PipelineStepDto("planning", "passed", 5.0),
+                    PipelineStepDto("coding", "running", 12.5),
+                    PipelineStepDto("testing", "pending", 0.0),
+                ),
+            elapsedTotalSec = 17.5,
+        )
+
+    @Test
+    fun `maps OrchestratorPipelineDto to MonitoredPipeline correctly`() {
+        val result = mapper.mapToDomain(sampleDto)
+        assertEquals("pipe-1", result.id)
+        assertEquals("my-project", result.projectName)
+        assertEquals(42, result.issueNum)
+        assertEquals("Fix the bug", result.issueTitle)
+        assertEquals("sequential", result.mode)
+        assertEquals(PipelineRunStatus.RUNNING, result.status)
+        assertEquals(3, result.steps.size)
+        assertEquals(17.5, result.elapsedTotalSec)
+    }
+
+    @Test
+    fun `maps step status strings to StepStatus enum`() {
+        assertEquals(StepStatus.PASSED, mapper.parseStepStatus("passed"))
+        assertEquals(StepStatus.RUNNING, mapper.parseStepStatus("running"))
+        assertEquals(StepStatus.FAILED, mapper.parseStepStatus("failed"))
+        assertEquals(StepStatus.SKIPPED, mapper.parseStepStatus("skipped"))
+    }
+
+    @Test
+    fun `handles unknown step status gracefully defaults to PENDING`() {
+        assertEquals(StepStatus.PENDING, mapper.parseStepStatus("unknown_status"))
+        assertEquals(StepStatus.PENDING, mapper.parseStepStatus(""))
+    }
+
+    @Test
+    fun `converts elapsedSec to elapsedMs`() {
+        val result = mapper.mapToDomain(sampleDto)
+        assertEquals(5000L, result.steps[0].elapsedMs)
+        assertEquals(12500L, result.steps[1].elapsedMs)
+        assertEquals(0L, result.steps[2].elapsedMs)
+    }
+
+    @Test
+    fun `maps startedAt ISO string to epoch milliseconds`() {
+        val result = mapper.mapToDomain(sampleDto)
+        assertEquals(1718447400000L, result.startedAtMs)
+    }
+
+    @Test
+    fun `maps SUCCESS status to PASSED`() {
+        assertEquals(StepStatus.PASSED, mapper.parseStepStatus("SUCCESS"))
+        assertEquals(PipelineRunStatus.PASSED, mapper.parseRunStatus("SUCCESS"))
+    }
+
+    @Test
+    fun `maps ERROR status to FAILED`() {
+        assertEquals(StepStatus.FAILED, mapper.parseStepStatus("ERROR"))
+        assertEquals(PipelineRunStatus.FAILED, mapper.parseRunStatus("ERROR"))
+    }
+
+    @Test
+    fun `running step has non-null startedAtMs`() {
+        val result = mapper.mapToDomain(sampleDto)
+        val runningStep = result.steps.first { it.status == StepStatus.RUNNING }
+        assertTrue(runningStep.startedAtMs != null)
+    }
+
+    @Test
+    fun `passed step has null startedAtMs`() {
+        val result = mapper.mapToDomain(sampleDto)
+        val passedStep = result.steps.first { it.status == StepStatus.PASSED }
+        assertNull(passedStep.startedAtMs)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/PipelineMonitorRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/PipelineMonitorRepositoryImplTest.kt
@@ -1,0 +1,74 @@
+package com.orchestradashboard.shared.data.repository
+
+import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
+import com.orchestradashboard.shared.ui.pipelinemonitor.FakePipelineMonitorRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PipelineMonitorRepositoryImplTest {
+    @Test
+    fun `getPipelineDetail returns mapped MonitoredPipeline on success`() =
+        runTest {
+            val repo = FakePipelineMonitorRepository()
+            val result = repo.getPipelineDetail("p1")
+            assertTrue(result.isSuccess)
+            assertEquals("p1", result.getOrNull()?.id)
+        }
+
+    @Test
+    fun `getPipelineDetail returns failure when error configured`() =
+        runTest {
+            val repo = FakePipelineMonitorRepository()
+            repo.pipelineDetailResult = Result.failure(RuntimeException("not found"))
+            val result = repo.getPipelineDetail("p1")
+            assertTrue(result.isFailure)
+            assertEquals("not found", result.exceptionOrNull()?.message)
+        }
+
+    @Test
+    fun `observePipelineEvents emits events with matching pipelineId`() =
+        runTest {
+            val repo = FakePipelineMonitorRepository()
+            val collected = mutableListOf<PipelineEventDto>()
+
+            val job =
+                launch(UnconfinedTestDispatcher(testScheduler)) {
+                    repo.observePipelineEvents("p1").collect { collected.add(it) }
+                }
+
+            repo.eventsFlow.emit(PipelineEventDto(type = "step.started", pipelineId = "p1", step = "coding"))
+            repo.eventsFlow.emit(PipelineEventDto(type = "step.started", pipelineId = "p2", step = "testing"))
+            repo.eventsFlow.emit(PipelineEventDto(type = "log", pipelineId = "p1", detail = "hello"))
+
+            job.cancel()
+
+            assertEquals(2, collected.size)
+            assertEquals("p1", collected[0].pipelineId)
+            assertEquals("p1", collected[1].pipelineId)
+        }
+
+    @Test
+    fun `observePipelineEvents skips events with null pipelineId`() =
+        runTest {
+            val repo = FakePipelineMonitorRepository()
+            val collected = mutableListOf<PipelineEventDto>()
+
+            val job =
+                launch(UnconfinedTestDispatcher(testScheduler)) {
+                    repo.observePipelineEvents("p1").collect { collected.add(it) }
+                }
+
+            repo.eventsFlow.emit(PipelineEventDto(type = "system.status", pipelineId = null))
+            repo.eventsFlow.emit(PipelineEventDto(type = "step.started", pipelineId = "p1", step = "a"))
+
+            job.cancel()
+
+            assertEquals(1, collected.size)
+        }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/model/MonitoredPipelineTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/model/MonitoredPipelineTest.kt
@@ -1,0 +1,85 @@
+package com.orchestradashboard.shared.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class MonitoredPipelineTest {
+    private fun step(
+        name: String,
+        status: StepStatus = StepStatus.PENDING,
+        elapsedMs: Long = 0L,
+        startedAtMs: Long? = null,
+    ) = MonitoredStep(name, status, elapsedMs, startedAtMs, "")
+
+    private fun pipeline(
+        steps: List<MonitoredStep> = emptyList(),
+        mode: String = "sequential",
+    ) = MonitoredPipeline(
+        id = "p1",
+        projectName = "proj",
+        issueNum = 1,
+        issueTitle = "title",
+        mode = mode,
+        status = PipelineRunStatus.RUNNING,
+        steps = steps,
+        startedAtMs = 0L,
+        elapsedTotalSec = 0.0,
+    )
+
+    @Test
+    fun `currentRunningStep returns first step with RUNNING status`() {
+        val steps =
+            listOf(
+                step("a", StepStatus.PASSED),
+                step("b", StepStatus.RUNNING),
+                step("c", StepStatus.PENDING),
+            )
+        assertEquals("b", pipeline(steps).currentRunningStep?.name)
+    }
+
+    @Test
+    fun `currentRunningStep returns null when no step is RUNNING`() {
+        val steps = listOf(step("a", StepStatus.PASSED), step("b", StepStatus.PENDING))
+        assertNull(pipeline(steps).currentRunningStep)
+    }
+
+    @Test
+    fun `progressFraction returns completed count over total steps`() {
+        val steps =
+            listOf(
+                step("a", StepStatus.PASSED),
+                step("b", StepStatus.FAILED),
+                step("c", StepStatus.RUNNING),
+                step("d", StepStatus.PENDING),
+            )
+        assertEquals(0.5f, pipeline(steps).progressFraction)
+    }
+
+    @Test
+    fun `progressFraction returns 0 for empty steps`() {
+        assertEquals(0f, pipeline(emptyList()).progressFraction)
+    }
+
+    @Test
+    fun `progressFraction counts SKIPPED as completed`() {
+        val steps =
+            listOf(
+                step("a", StepStatus.PASSED),
+                step("b", StepStatus.SKIPPED),
+            )
+        assertEquals(1f, pipeline(steps).progressFraction)
+    }
+
+    @Test
+    fun `isParallel returns true when mode is parallel`() {
+        assertTrue(pipeline(mode = "parallel").isParallel)
+    }
+
+    @Test
+    fun `isParallel returns false when mode is sequential`() {
+        assertFalse(pipeline(mode = "sequential").isParallel)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/FakePipelineMonitorRepository.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/FakePipelineMonitorRepository.kt
@@ -1,0 +1,46 @@
+package com.orchestradashboard.shared.ui.pipelinemonitor
+
+import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
+import com.orchestradashboard.shared.domain.model.MonitoredPipeline
+import com.orchestradashboard.shared.domain.model.MonitoredStep
+import com.orchestradashboard.shared.domain.model.PipelineRunStatus
+import com.orchestradashboard.shared.domain.model.StepStatus
+import com.orchestradashboard.shared.domain.repository.PipelineMonitorRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.filter
+
+class FakePipelineMonitorRepository : PipelineMonitorRepository {
+    var pipelineDetailResult: Result<MonitoredPipeline> = Result.success(defaultPipeline())
+    val eventsFlow = MutableSharedFlow<PipelineEventDto>()
+
+    var getPipelineDetailCallCount = 0
+        private set
+
+    override suspend fun getPipelineDetail(pipelineId: String): Result<MonitoredPipeline> {
+        getPipelineDetailCallCount++
+        return pipelineDetailResult
+    }
+
+    override fun observePipelineEvents(pipelineId: String): Flow<PipelineEventDto> = eventsFlow.filter { it.pipelineId == pipelineId }
+
+    companion object {
+        fun defaultPipeline() =
+            MonitoredPipeline(
+                id = "p1",
+                projectName = "test-project",
+                issueNum = 1,
+                issueTitle = "Test Issue",
+                mode = "sequential",
+                status = PipelineRunStatus.RUNNING,
+                steps =
+                    listOf(
+                        MonitoredStep("planning", StepStatus.PASSED, 5000L, null, ""),
+                        MonitoredStep("coding", StepStatus.RUNNING, 3000L, 1000L, ""),
+                        MonitoredStep("testing", StepStatus.PENDING, 0L, null, ""),
+                    ),
+                startedAtMs = 1718447400000L,
+                elapsedTotalSec = 8.0,
+            )
+    }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModelTest.kt
@@ -1,0 +1,312 @@
+package com.orchestradashboard.shared.ui.pipelinemonitor
+
+import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
+import com.orchestradashboard.shared.domain.model.ConnectionStatus
+import com.orchestradashboard.shared.domain.model.PipelineRunStatus
+import com.orchestradashboard.shared.domain.model.StepStatus
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PipelineMonitorViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var repository: FakePipelineMonitorRepository
+    private lateinit var viewModel: PipelineMonitorViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        repository = FakePipelineMonitorRepository()
+        viewModel = PipelineMonitorViewModel("p1", repository)
+    }
+
+    @AfterTest
+    fun teardown() {
+        viewModel.onCleared()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state has isLoading false and null pipeline`() {
+        val state = viewModel.uiState.value
+        assertFalse(state.isLoading)
+        assertNull(state.pipeline)
+        assertNull(state.error)
+        assertEquals(ConnectionStatus.DISCONNECTED, state.connectionStatus)
+    }
+
+    @Test
+    fun `loadPipeline sets isLoading true then false`() =
+        runTest {
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.value.isLoading)
+        }
+
+    @Test
+    fun `loadPipeline sets pipeline on success`() =
+        runTest {
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertNotNull(state.pipeline)
+            assertEquals("p1", state.pipeline!!.id)
+            assertEquals("test-project", state.pipeline!!.projectName)
+            assertEquals(3, state.pipeline!!.steps.size)
+        }
+
+    @Test
+    fun `loadPipeline sets error on failure`() =
+        runTest {
+            repository.pipelineDetailResult = Result.failure(RuntimeException("API error"))
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertNull(state.pipeline)
+            assertEquals("API error", state.error)
+            assertFalse(state.isLoading)
+        }
+
+    @Test
+    fun `startObserving sets connectionStatus to CONNECTED`() =
+        runTest {
+            viewModel.startObserving()
+            advanceUntilIdle()
+            assertEquals(ConnectionStatus.CONNECTED, viewModel.uiState.value.connectionStatus)
+        }
+
+    @Test
+    fun `step started event updates step status to RUNNING`() =
+        runTest {
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            viewModel.startObserving()
+            advanceUntilIdle()
+
+            repository.eventsFlow.emit(
+                PipelineEventDto(type = "step.started", pipelineId = "p1", step = "testing", elapsedSec = 0.0),
+            )
+            advanceUntilIdle()
+
+            val step = viewModel.uiState.value.pipeline!!.steps.first { it.name == "testing" }
+            assertEquals(StepStatus.RUNNING, step.status)
+            assertNotNull(step.startedAtMs)
+        }
+
+    @Test
+    fun `step completed event updates step status to PASSED and sets elapsedMs`() =
+        runTest {
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            viewModel.startObserving()
+            advanceUntilIdle()
+
+            repository.eventsFlow.emit(
+                PipelineEventDto(type = "step.completed", pipelineId = "p1", step = "coding", elapsedSec = 15.0),
+            )
+            advanceUntilIdle()
+
+            val step = viewModel.uiState.value.pipeline!!.steps.first { it.name == "coding" }
+            assertEquals(StepStatus.PASSED, step.status)
+            assertEquals(15000L, step.elapsedMs)
+            assertNull(step.startedAtMs)
+        }
+
+    @Test
+    fun `step failed event updates step status to FAILED`() =
+        runTest {
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            viewModel.startObserving()
+            advanceUntilIdle()
+
+            repository.eventsFlow.emit(
+                PipelineEventDto(type = "step.failed", pipelineId = "p1", step = "testing", elapsedSec = 3.0),
+            )
+            advanceUntilIdle()
+
+            val step = viewModel.uiState.value.pipeline!!.steps.first { it.name == "testing" }
+            assertEquals(StepStatus.FAILED, step.status)
+        }
+
+    @Test
+    fun `pipeline completed event updates pipeline status to PASSED`() =
+        runTest {
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            viewModel.startObserving()
+            advanceUntilIdle()
+
+            repository.eventsFlow.emit(
+                PipelineEventDto(type = "pipeline.completed", pipelineId = "p1"),
+            )
+            advanceUntilIdle()
+
+            assertEquals(PipelineRunStatus.PASSED, viewModel.uiState.value.pipeline!!.status)
+        }
+
+    @Test
+    fun `pipeline failed event updates pipeline status to FAILED`() =
+        runTest {
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            viewModel.startObserving()
+            advanceUntilIdle()
+
+            repository.eventsFlow.emit(
+                PipelineEventDto(type = "pipeline.failed", pipelineId = "p1"),
+            )
+            advanceUntilIdle()
+
+            assertEquals(PipelineRunStatus.FAILED, viewModel.uiState.value.pipeline!!.status)
+        }
+
+    @Test
+    fun `approval requested event sets pendingApproval in state`() =
+        runTest {
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            viewModel.startObserving()
+            advanceUntilIdle()
+
+            repository.eventsFlow.emit(
+                PipelineEventDto(
+                    type = "approval.requested",
+                    pipelineId = "p1",
+                    approvalType = "strategy",
+                    options = listOf("approve", "reject"),
+                ),
+            )
+            advanceUntilIdle()
+
+            val approval = viewModel.uiState.value.pendingApproval
+            assertNotNull(approval)
+            assertEquals("strategy", approval.approvalType)
+            assertEquals(listOf("approve", "reject"), approval.options)
+        }
+
+    @Test
+    fun `log event appends to logLines`() =
+        runTest {
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            viewModel.startObserving()
+            advanceUntilIdle()
+
+            repository.eventsFlow.emit(
+                PipelineEventDto(type = "log", pipelineId = "p1", detail = "Building module..."),
+            )
+            repository.eventsFlow.emit(
+                PipelineEventDto(type = "log", pipelineId = "p1", detail = "Tests running..."),
+            )
+            advanceUntilIdle()
+
+            assertEquals(2, viewModel.uiState.value.logLines.size)
+            assertEquals("Building module...", viewModel.uiState.value.logLines[0])
+            assertEquals("Tests running...", viewModel.uiState.value.logLines[1])
+        }
+
+    @Test
+    fun `clearError sets error to null`() =
+        runTest {
+            repository.pipelineDetailResult = Result.failure(RuntimeException("error"))
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            assertNotNull(viewModel.uiState.value.error)
+
+            viewModel.clearError()
+
+            assertNull(viewModel.uiState.value.error)
+        }
+
+    @Test
+    fun `refresh reloads pipeline data`() =
+        runTest {
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+            assertEquals(1, repository.getPipelineDetailCallCount)
+
+            viewModel.refresh()
+            advanceUntilIdle()
+            assertEquals(2, repository.getPipelineDetailCallCount)
+        }
+
+    @Test
+    fun `dismissApproval clears pendingApproval`() =
+        runTest {
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            viewModel.startObserving()
+            advanceUntilIdle()
+
+            repository.eventsFlow.emit(
+                PipelineEventDto(
+                    type = "approval.requested",
+                    pipelineId = "p1",
+                    approvalType = "supreme_court",
+                    options = listOf("approve"),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertNotNull(viewModel.uiState.value.pendingApproval)
+
+            viewModel.dismissApproval()
+
+            assertNull(viewModel.uiState.value.pendingApproval)
+        }
+
+    @Test
+    fun `step event with unknown step name does not crash`() =
+        runTest {
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            viewModel.startObserving()
+            advanceUntilIdle()
+
+            repository.eventsFlow.emit(
+                PipelineEventDto(type = "step.started", pipelineId = "p1", step = "nonexistent"),
+            )
+            advanceUntilIdle()
+
+            assertEquals(3, viewModel.uiState.value.pipeline!!.steps.size)
+        }
+
+    @Test
+    fun `step event before pipeline loaded is ignored`() =
+        runTest {
+            viewModel.startObserving()
+            advanceUntilIdle()
+
+            repository.eventsFlow.emit(
+                PipelineEventDto(type = "step.started", pipelineId = "p1", step = "coding"),
+            )
+            advanceUntilIdle()
+
+            assertNull(viewModel.uiState.value.pipeline)
+        }
+}

--- a/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/data/repository/ProjectRepositoryImplTest.kt
+++ b/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/data/repository/ProjectRepositoryImplTest.kt
@@ -65,6 +65,8 @@ class FakeOrchestratorApi(
     override suspend fun getPipelineHistory(): List<PipelineHistoryDto> = throw NotImplementedError()
 
     override fun connectEvents(): Flow<PipelineEventDto> = emptyFlow()
+
+    override fun connectEvents(pipelineId: String): Flow<PipelineEventDto> = emptyFlow()
 }
 
 class ProjectRepositoryImplTest {


### PR DESCRIPTION
Closes #61

## Design
Now I have a thorough understanding of the codebase. Here is the design document.

---

# Pipeline Monitor — Design Document

## SECTION A: Design Document

### 1. Files to Create/Modify

#### New Files — Domain Layer
| # | Path | Purpose |
|---|------|---------|
| 1 | `shared/.../domain/model/MonitoredPipeline.kt` | Enriched pipeline model with `startedAtMs` per step for timer calculation |
| 2 | `shared/.../domain/repository/PipelineMonitorRepository.kt` | Repository interface for pipeline detail + event stream |
| 3 | `shared/.../domain/usecase/GetPipelineDetailUseCase.kt` | Fetches single pipeline by ID |
| 4 | `shared/.../domain/usecase/ObservePipelineEventsUseCase.kt` | Filtered event stream for a specific pipeline |

#### New Files — Data Layer
| # | Path | Purpose |
|---|------|---------|
| 5 | `shared/.../data/repository/PipelineMonitorRepositoryImpl.kt` | Implementation hitting OrchestratorApi |
| 6 | `shared/.../data/mapper/MonitoredPipelineMapper.kt` | Maps `OrchestratorPipelineDto` → `MonitoredPipeline` |

#### New Files — UI Layer (shared)
| # | Path | Purpose |
|---|------|---------|
| 7 | `shared/.../ui/pipelinemonitor/PipelineMonitorViewModel.kt` | ViewModel with coroutine scope, state management, event handling |
| 8 | `shared/.../ui/pipelinemonitor/PipelineMonitorUiState.kt` | UI state data class |
| 9 | `shared/.../ui/screen/PipelineMonitorScreen.kt` | Root Composable screen |
| 10 | `shared/.../ui/component/StepTimeline.kt` | Horizontal step timeline with

_(truncated)_

## Changed Files (21)
- `androidApp/src/main/kotlin/com/orchestradashboard/android/App.kt`
- `androidApp/src/main/kotlin/com/orchestradashboard/android/di/AppContainer.kt`
- `desktopApp/src/main/kotlin/com/orchestradashboard/desktop/Main.kt`
- `desktopApp/src/main/kotlin/com/orchestradashboard/desktop/di/AppContainer.kt`
- `iosApp/iosApp/IOSAppContainer.swift`
- `iosApp/iosApp/IOSPipelineMonitorViewModel.swift`
- `iosApp/iosApp/PipelineMonitorView.swift`
- `iosApp/iosApp/components/ApprovalDialogView.swift`
- `iosApp/iosApp/components/StepTimelineView.swift`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/mapper/MonitoredPipelineMapper.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/PipelineMonitorRepositoryImpl.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/MonitoredPipeline.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/PipelineMonitorRepository.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ApprovalDialog.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/LiveLogPanel.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineView.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/StepNode.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/StepTimeline.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorUiState.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModel.kt`

## Review
Based on my review, here are the findings:

1.  **File**: `iosApp/iosApp/IOSPipelineMonitorViewModel.swift`
    **Line**: 17-46
    **Issue**: The `IOSPipelineMonitorViewModel` does not collect the `StateFlow` from the shared KMP `PipelineMonitorViewModel`. It initializes the KMP ViewModel and exposes `@Published` properties, but there is no mechanism to update these properties when the KMP `uiState` changes. As a result, the iOS UI will show its initial state and will never receive any updates (e.g., from loading data, WebSocket events, or timers).
    **Fix**: Implement a collector that observes the `viewModel.uiState` `StateFlow`. This is typically done in the `init` or a dedicated `startObserving` method by launching a `Task` that loops and collects values from the flow, updating the `

_(truncated)_

## AI Audit: PASS
### Audit Verdict

[AUDIT: FAIL]

---

### Acceptance Criteria Evaluation

#### **Passing Criteria**

1. **`Screen.PipelineMonitor(pipelineId: String)` exists in `AppNavigation.kt`**  
   [PASS] - Added to `Screen` sealed class.

2. **`MonitoredPipeline` domain model has specified fields**  
   [PASS] - All required fields are present.

3. **`MonitoredStep` has specified fields**  
   [PASS] - All required fields are present.

4. **`PipelineMonitorRepository` interface has required methods**  
   [PASS] - Both `getPipelineDetail` and `observePipelineEvents` are implemented.

5. **`PipelineMonitorViewModel.loadPipeline()` fetches pipeline and updates `uiState.pipeline`**  
   [PASS] - Method fetches pipeline and updates UI state.

6. **`PipelineMonitorViewModel.startObserving()` subscribes to WebSocket events and updates step statuses**  
   [PASS] - Subscribes to events and handles `step.started/completed/failed`.

7. **`PipelineMonitorUiState` exposes required fields**  
   [PASS] - A

_(truncated)_