### PR TITLE
feat(shared): Parallel View — State, ViewModel, Model

### DIFF
--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/api/OrchestratorApi.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/api/OrchestratorApi.kt
@@ -3,6 +3,7 @@ package com.orchestradashboard.shared.data.api
 import com.orchestradashboard.shared.data.dto.orchestrator.CheckpointDto
 import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorIssueDto
 import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorPipelineDto
+import com.orchestradashboard.shared.data.dto.orchestrator.ParallelPipelineGroupDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineHistoryDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ProjectDetailDto
@@ -32,6 +33,8 @@ interface OrchestratorApi {
     suspend fun retryCheckpoint(checkpointId: String): CheckpointDto
 
     suspend fun getPipelineHistory(): List<PipelineHistoryDto>
+
+    suspend fun getParallelPipelines(parentId: String): ParallelPipelineGroupDto
 
     fun connectEvents(): Flow<PipelineEventDto>
 

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/api/OrchestratorApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/api/OrchestratorApiClient.kt
@@ -3,6 +3,7 @@ package com.orchestradashboard.shared.data.api
 import com.orchestradashboard.shared.data.dto.orchestrator.CheckpointDto
 import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorIssueDto
 import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorPipelineDto
+import com.orchestradashboard.shared.data.dto.orchestrator.ParallelPipelineGroupDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineHistoryDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ProjectDetailDto
@@ -52,6 +53,8 @@ class OrchestratorApiClient(
     override suspend fun retryCheckpoint(checkpointId: String): CheckpointDto = request("/api/checkpoints/$checkpointId/retry")
 
     override suspend fun getPipelineHistory(): List<PipelineHistoryDto> = request("/api/pipelines/history")
+
+    override suspend fun getParallelPipelines(parentId: String): ParallelPipelineGroupDto = request("/api/pipelines/$parentId/parallel")
 
     override fun connectEvents(): Flow<PipelineEventDto> =
         flow {

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/orchestrator/ParallelPipelineDto.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/orchestrator/ParallelPipelineDto.kt
@@ -1,0 +1,18 @@
+package com.orchestradashboard.shared.data.dto.orchestrator
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ParallelPipelineGroupDto(
+    @SerialName("parent_pipeline_id") val parentPipelineId: String,
+    val lanes: List<OrchestratorPipelineDto>,
+    val dependencies: List<PipelineDependencyDto> = emptyList(),
+)
+
+@Serializable
+data class PipelineDependencyDto(
+    @SerialName("source_lane_id") val sourceLaneId: String,
+    @SerialName("target_lane_id") val targetLaneId: String,
+    val type: String,
+)

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/orchestrator/PipelineEventDto.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/orchestrator/PipelineEventDto.kt
@@ -21,4 +21,5 @@ data class PipelineEventDto(
     @SerialName("cpu_percent") val cpuPercent: Double? = null,
     val thermal: String? = null,
     val timestamp: String? = null,
+    @SerialName("lane_id") val laneId: String? = null,
 )

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/mapper/ParallelPipelineMapper.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/mapper/ParallelPipelineMapper.kt
@@ -1,0 +1,31 @@
+package com.orchestradashboard.shared.data.mapper
+
+import com.orchestradashboard.shared.data.dto.orchestrator.ParallelPipelineGroupDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PipelineDependencyDto
+import com.orchestradashboard.shared.domain.model.DependencyType
+import com.orchestradashboard.shared.domain.model.ParallelPipelineGroup
+import com.orchestradashboard.shared.domain.model.PipelineDependency
+
+class ParallelPipelineMapper(
+    private val pipelineMapper: MonitoredPipelineMapper,
+) {
+    fun mapToParallelGroup(dto: ParallelPipelineGroupDto): ParallelPipelineGroup =
+        ParallelPipelineGroup(
+            parentPipelineId = dto.parentPipelineId,
+            pipelines = dto.lanes.map { pipelineMapper.mapToDomain(it) },
+            dependencies = dto.dependencies.map { mapDependency(it) },
+        )
+
+    private fun mapDependency(dto: PipelineDependencyDto): PipelineDependency =
+        PipelineDependency(
+            sourceLaneId = dto.sourceLaneId,
+            targetLaneId = dto.targetLaneId,
+            type = parseDependencyType(dto.type),
+        )
+
+    fun parseDependencyType(type: String): DependencyType =
+        when (type.lowercase()) {
+            "provides_input" -> DependencyType.PROVIDES_INPUT
+            else -> DependencyType.BLOCKS_START
+        }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/PipelineMonitorRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/PipelineMonitorRepositoryImpl.kt
@@ -3,18 +3,29 @@ package com.orchestradashboard.shared.data.repository
 import com.orchestradashboard.shared.data.api.OrchestratorApi
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
 import com.orchestradashboard.shared.data.mapper.MonitoredPipelineMapper
+import com.orchestradashboard.shared.data.mapper.ParallelPipelineMapper
 import com.orchestradashboard.shared.domain.model.MonitoredPipeline
+import com.orchestradashboard.shared.domain.model.ParallelPipelineGroup
 import com.orchestradashboard.shared.domain.repository.PipelineMonitorRepository
 import kotlinx.coroutines.flow.Flow
 
 class PipelineMonitorRepositoryImpl(
     private val api: OrchestratorApi,
     private val mapper: MonitoredPipelineMapper,
+    private val parallelMapper: ParallelPipelineMapper = ParallelPipelineMapper(mapper),
 ) : PipelineMonitorRepository {
     override suspend fun getPipelineDetail(pipelineId: String): Result<MonitoredPipeline> =
         try {
             val dto = api.getPipeline(pipelineId)
             Result.success(mapper.mapToDomain(dto))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+
+    override suspend fun getParallelPipelines(parentId: String): Result<ParallelPipelineGroup> =
+        try {
+            val dto = api.getParallelPipelines(parentId)
+            Result.success(parallelMapper.mapToParallelGroup(dto))
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/ParallelPipeline.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/ParallelPipeline.kt
@@ -1,0 +1,37 @@
+package com.orchestradashboard.shared.domain.model
+
+enum class DependencyType {
+    BLOCKS_START,
+    PROVIDES_INPUT,
+}
+
+data class PipelineDependency(
+    val sourceLaneId: String,
+    val targetLaneId: String,
+    val type: DependencyType,
+)
+
+data class ParallelPipelineGroup(
+    val parentPipelineId: String,
+    val pipelines: List<MonitoredPipeline>,
+    val dependencies: List<PipelineDependency>,
+) {
+    val overallStatus: PipelineRunStatus
+        get() =
+            when {
+                pipelines.isEmpty() -> PipelineRunStatus.QUEUED
+                pipelines.any { it.status == PipelineRunStatus.RUNNING } -> PipelineRunStatus.RUNNING
+                pipelines.any { it.status == PipelineRunStatus.FAILED } -> PipelineRunStatus.FAILED
+                pipelines.all { it.status == PipelineRunStatus.PASSED } -> PipelineRunStatus.PASSED
+                else -> PipelineRunStatus.QUEUED
+            }
+
+    val progressFraction: Float
+        get() {
+            if (pipelines.isEmpty()) return 0f
+            return pipelines.map { it.progressFraction }.average().toFloat()
+        }
+
+    val activeLaneCount: Int
+        get() = pipelines.count { it.status == PipelineRunStatus.RUNNING }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/PipelineMonitorRepository.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/PipelineMonitorRepository.kt
@@ -2,10 +2,13 @@ package com.orchestradashboard.shared.domain.repository
 
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
 import com.orchestradashboard.shared.domain.model.MonitoredPipeline
+import com.orchestradashboard.shared.domain.model.ParallelPipelineGroup
 import kotlinx.coroutines.flow.Flow
 
 interface PipelineMonitorRepository {
     suspend fun getPipelineDetail(pipelineId: String): Result<MonitoredPipeline>
+
+    suspend fun getParallelPipelines(parentId: String): Result<ParallelPipelineGroup>
 
     fun observePipelineEvents(pipelineId: String): Flow<PipelineEventDto>
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorUiState.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorUiState.kt
@@ -3,17 +3,24 @@ package com.orchestradashboard.shared.ui.pipelinemonitor
 import com.orchestradashboard.shared.domain.model.ApprovalRequest
 import com.orchestradashboard.shared.domain.model.ConnectionStatus
 import com.orchestradashboard.shared.domain.model.MonitoredPipeline
+import com.orchestradashboard.shared.domain.model.ParallelPipelineGroup
+import com.orchestradashboard.shared.domain.model.PipelineDependency
 
 data class PipelineMonitorUiState(
     val pipeline: MonitoredPipeline? = null,
     val logLines: List<String> = emptyList(),
     val pendingApproval: ApprovalRequest? = null,
     val parallelPipelines: List<MonitoredPipeline> = emptyList(),
+    val parallelGroup: ParallelPipelineGroup? = null,
     val isLoading: Boolean = false,
     val error: String? = null,
     val connectionStatus: ConnectionStatus = ConnectionStatus.DISCONNECTED,
 ) {
-    val isParallelView: Boolean get() = parallelPipelines.isNotEmpty()
+    val isParallel: Boolean get() = pipeline?.isParallel == true
+
+    val isParallelView: Boolean get() = parallelGroup != null && parallelGroup.pipelines.isNotEmpty()
 
     val currentStepName: String? get() = pipeline?.currentRunningStep?.name
+
+    val dependencies: List<PipelineDependency> get() = parallelGroup?.dependencies ?: emptyList()
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModel.kt
@@ -1,7 +1,9 @@
 package com.orchestradashboard.shared.ui.pipelinemonitor
 
+import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
 import com.orchestradashboard.shared.domain.model.ApprovalRequest
 import com.orchestradashboard.shared.domain.model.ConnectionStatus
+import com.orchestradashboard.shared.domain.model.MonitoredPipeline
 import com.orchestradashboard.shared.domain.model.PipelineRunStatus
 import com.orchestradashboard.shared.domain.model.StepStatus
 import com.orchestradashboard.shared.domain.repository.PipelineMonitorRepository
@@ -50,9 +52,29 @@ class PipelineMonitorViewModel(
                             newPipeline.steps
                         }
                     _uiState.update { it.copy(pipeline = newPipeline.copy(steps = mergedSteps), isLoading = false) }
+                    if (newPipeline.isParallel) {
+                        loadParallelPipelines()
+                    }
                 }
                 .onFailure { e ->
                     _uiState.update { it.copy(error = e.message, isLoading = false) }
+                }
+        }
+    }
+
+    fun loadParallelPipelines() {
+        viewModelScope.launch {
+            repository.getParallelPipelines(pipelineId)
+                .onSuccess { group ->
+                    _uiState.update {
+                        it.copy(
+                            parallelGroup = group,
+                            parallelPipelines = group.pipelines,
+                        )
+                    }
+                }
+                .onFailure { e ->
+                    _uiState.update { it.copy(error = e.message) }
                 }
         }
     }
@@ -70,7 +92,12 @@ class PipelineMonitorViewModel(
         }
     }
 
-    private fun handleEvent(event: com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto) {
+    private fun handleEvent(event: PipelineEventDto) {
+        val laneId = event.laneId
+        if (laneId != null) {
+            handleLaneEvent(laneId, event)
+            return
+        }
         when (event.type) {
             "step.started" -> updateStepStatus(event.step, StepStatus.RUNNING, event.elapsedSec)
             "step.completed" -> updateStepStatus(event.step, StepStatus.PASSED, event.elapsedSec)
@@ -98,6 +125,61 @@ class PipelineMonitorViewModel(
             }
         }
     }
+
+    private fun handleLaneEvent(
+        laneId: String,
+        event: PipelineEventDto,
+    ) {
+        _uiState.update { state ->
+            val group = state.parallelGroup ?: return@update state
+            val updatedPipelines =
+                group.pipelines.map { lane ->
+                    if (lane.id == laneId) applyEventToLane(lane, event) else lane
+                }
+            val updatedGroup = group.copy(pipelines = updatedPipelines)
+            state.copy(
+                parallelGroup = updatedGroup,
+                parallelPipelines = updatedGroup.pipelines,
+            )
+        }
+    }
+
+    private fun applyEventToLane(
+        lane: MonitoredPipeline,
+        event: PipelineEventDto,
+    ): MonitoredPipeline =
+        when (event.type) {
+            "step.started", "step.completed", "step.failed" -> {
+                val stepName = event.step ?: return lane
+                val newStatus =
+                    when (event.type) {
+                        "step.started" -> StepStatus.RUNNING
+                        "step.completed" -> StepStatus.PASSED
+                        else -> StepStatus.FAILED
+                    }
+                val updatedSteps =
+                    lane.steps.map { step ->
+                        if (step.name == stepName) {
+                            step.copy(
+                                status = newStatus,
+                                elapsedMs = event.elapsedSec?.let { (it * 1000).toLong() } ?: step.elapsedMs,
+                                startedAtMs =
+                                    if (newStatus == StepStatus.RUNNING) {
+                                        Clock.System.now().toEpochMilliseconds()
+                                    } else {
+                                        null
+                                    },
+                            )
+                        } else {
+                            step
+                        }
+                    }
+                lane.copy(steps = updatedSteps)
+            }
+            "pipeline.completed" -> lane.copy(status = PipelineRunStatus.PASSED)
+            "pipeline.failed" -> lane.copy(status = PipelineRunStatus.FAILED)
+            else -> lane
+        }
 
     private fun updateStepStatus(
         stepName: String?,

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/api/FakeOrchestratorApiClient.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/api/FakeOrchestratorApiClient.kt
@@ -3,6 +3,7 @@ package com.orchestradashboard.shared.data.api
 import com.orchestradashboard.shared.data.dto.orchestrator.CheckpointDto
 import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorIssueDto
 import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorPipelineDto
+import com.orchestradashboard.shared.data.dto.orchestrator.ParallelPipelineGroupDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineHistoryDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ProjectDetailDto
@@ -24,6 +25,7 @@ class FakeOrchestratorApiClient : OrchestratorApi {
     var retryCheckpointResult: CheckpointDto? = null
     var pipelineHistoryResult: List<PipelineHistoryDto> = emptyList()
     var eventsResult: List<PipelineEventDto> = emptyList()
+    var parallelPipelinesResult: ParallelPipelineGroupDto? = null
 
     var getStatusCallCount = 0
         private set
@@ -109,6 +111,11 @@ class FakeOrchestratorApiClient : OrchestratorApi {
         getPipelineHistoryCallCount++
         maybeThrow()
         return pipelineHistoryResult
+    }
+
+    override suspend fun getParallelPipelines(parentId: String): ParallelPipelineGroupDto {
+        maybeThrow()
+        return parallelPipelinesResult ?: throw OrchestratorNotFoundException("Parallel pipelines for $parentId not found")
     }
 
     override fun connectEvents(): Flow<PipelineEventDto> {

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/mapper/ParallelPipelineMapperTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/mapper/ParallelPipelineMapperTest.kt
@@ -1,0 +1,110 @@
+package com.orchestradashboard.shared.data.mapper
+
+import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorPipelineDto
+import com.orchestradashboard.shared.data.dto.orchestrator.ParallelPipelineGroupDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PipelineDependencyDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PipelineStepDto
+import com.orchestradashboard.shared.domain.model.DependencyType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ParallelPipelineMapperTest {
+    private val pipelineMapper = MonitoredPipelineMapper()
+    private val mapper = ParallelPipelineMapper(pipelineMapper)
+
+    @Test
+    fun `mapToParallelGroup maps DTO with multiple lanes correctly`() {
+        val dto =
+            ParallelPipelineGroupDto(
+                parentPipelineId = "p1",
+                lanes =
+                    listOf(
+                        makeLaneDto("lane-1", listOf(PipelineStepDto("coding", "running", 1.0))),
+                        makeLaneDto("lane-2", listOf(PipelineStepDto("design", "passed", 2.0))),
+                    ),
+                dependencies = emptyList(),
+            )
+
+        val group = mapper.mapToParallelGroup(dto)
+
+        assertEquals("p1", group.parentPipelineId)
+        assertEquals(2, group.pipelines.size)
+        assertEquals("lane-1", group.pipelines[0].id)
+        assertEquals("lane-2", group.pipelines[1].id)
+    }
+
+    @Test
+    fun `mapToParallelGroup maps dependencies correctly`() {
+        val dto =
+            ParallelPipelineGroupDto(
+                parentPipelineId = "p1",
+                lanes =
+                    listOf(
+                        makeLaneDto("lane-1"),
+                        makeLaneDto("lane-2"),
+                    ),
+                dependencies =
+                    listOf(
+                        PipelineDependencyDto("lane-1", "lane-2", "blocks_start"),
+                        PipelineDependencyDto("lane-1", "lane-3", "provides_input"),
+                    ),
+            )
+
+        val group = mapper.mapToParallelGroup(dto)
+
+        assertEquals(2, group.dependencies.size)
+        assertEquals("lane-1", group.dependencies[0].sourceLaneId)
+        assertEquals("lane-2", group.dependencies[0].targetLaneId)
+        assertEquals(DependencyType.BLOCKS_START, group.dependencies[0].type)
+        assertEquals(DependencyType.PROVIDES_INPUT, group.dependencies[1].type)
+    }
+
+    @Test
+    fun `mapToParallelGroup with empty lanes returns empty group`() {
+        val dto =
+            ParallelPipelineGroupDto(
+                parentPipelineId = "p1",
+                lanes = emptyList(),
+                dependencies = emptyList(),
+            )
+
+        val group = mapper.mapToParallelGroup(dto)
+
+        assertEquals("p1", group.parentPipelineId)
+        assertEquals(0, group.pipelines.size)
+        assertEquals(0, group.dependencies.size)
+    }
+
+    @Test
+    fun `mapToParallelGroup with unknown dependency type defaults to BLOCKS_START`() {
+        val dto =
+            ParallelPipelineGroupDto(
+                parentPipelineId = "p1",
+                lanes = listOf(makeLaneDto("lane-1"), makeLaneDto("lane-2")),
+                dependencies =
+                    listOf(
+                        PipelineDependencyDto("lane-1", "lane-2", "unknown_type"),
+                    ),
+            )
+
+        val group = mapper.mapToParallelGroup(dto)
+
+        assertEquals(DependencyType.BLOCKS_START, group.dependencies[0].type)
+    }
+
+    private fun makeLaneDto(
+        id: String,
+        steps: List<PipelineStepDto> = emptyList(),
+    ) = OrchestratorPipelineDto(
+        id = id,
+        projectName = "test-project",
+        issueNum = 1,
+        issueTitle = "Test Issue",
+        mode = "parallel",
+        status = "running",
+        currentStep = null,
+        startedAt = "2024-06-15T10:00:00Z",
+        steps = steps,
+        elapsedTotalSec = 0.0,
+    )
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/model/ParallelPipelineTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/model/ParallelPipelineTest.kt
@@ -1,0 +1,166 @@
+package com.orchestradashboard.shared.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ParallelPipelineTest {
+    // ─── ParallelPipelineGroup ────────────────────────────────────────────────
+
+    @Test
+    fun `ParallelPipelineGroup with empty pipelines has zero progress`() {
+        val group =
+            ParallelPipelineGroup(
+                parentPipelineId = "p1",
+                pipelines = emptyList(),
+                dependencies = emptyList(),
+            )
+        assertEquals(0f, group.progressFraction)
+    }
+
+    @Test
+    fun `ParallelPipelineGroup progressFraction averages across all lanes`() {
+        val lane1 =
+            makePipeline(
+                id = "lane-1",
+                steps =
+                    listOf(
+                        MonitoredStep("a", StepStatus.PASSED, 1000L, null, ""),
+                        MonitoredStep("b", StepStatus.PASSED, 1000L, null, ""),
+                    ),
+            )
+        val lane2 =
+            makePipeline(
+                id = "lane-2",
+                steps =
+                    listOf(
+                        MonitoredStep("c", StepStatus.PASSED, 1000L, null, ""),
+                        MonitoredStep("d", StepStatus.PENDING, 0L, null, ""),
+                    ),
+            )
+        val group =
+            ParallelPipelineGroup(
+                parentPipelineId = "p1",
+                pipelines = listOf(lane1, lane2),
+                dependencies = emptyList(),
+            )
+        // lane1: 2/2 = 1.0, lane2: 1/2 = 0.5 → average = 0.75
+        assertEquals(0.75f, group.progressFraction, absoluteTolerance = 0.001f)
+    }
+
+    @Test
+    fun `ParallelPipelineGroup overallStatus is RUNNING if any lane is RUNNING`() {
+        val group =
+            ParallelPipelineGroup(
+                parentPipelineId = "p1",
+                pipelines =
+                    listOf(
+                        makePipeline(id = "lane-1", status = PipelineRunStatus.RUNNING),
+                        makePipeline(id = "lane-2", status = PipelineRunStatus.PASSED),
+                    ),
+                dependencies = emptyList(),
+            )
+        assertEquals(PipelineRunStatus.RUNNING, group.overallStatus)
+    }
+
+    @Test
+    fun `ParallelPipelineGroup overallStatus is FAILED if any lane is FAILED and none RUNNING`() {
+        val group =
+            ParallelPipelineGroup(
+                parentPipelineId = "p1",
+                pipelines =
+                    listOf(
+                        makePipeline(id = "lane-1", status = PipelineRunStatus.FAILED),
+                        makePipeline(id = "lane-2", status = PipelineRunStatus.PASSED),
+                    ),
+                dependencies = emptyList(),
+            )
+        assertEquals(PipelineRunStatus.FAILED, group.overallStatus)
+    }
+
+    @Test
+    fun `ParallelPipelineGroup overallStatus is PASSED when all lanes PASSED`() {
+        val group =
+            ParallelPipelineGroup(
+                parentPipelineId = "p1",
+                pipelines =
+                    listOf(
+                        makePipeline(id = "lane-1", status = PipelineRunStatus.PASSED),
+                        makePipeline(id = "lane-2", status = PipelineRunStatus.PASSED),
+                    ),
+                dependencies = emptyList(),
+            )
+        assertEquals(PipelineRunStatus.PASSED, group.overallStatus)
+    }
+
+    @Test
+    fun `ParallelPipelineGroup activeLaneCount returns count of RUNNING pipelines`() {
+        val group =
+            ParallelPipelineGroup(
+                parentPipelineId = "p1",
+                pipelines =
+                    listOf(
+                        makePipeline(id = "lane-1", status = PipelineRunStatus.RUNNING),
+                        makePipeline(id = "lane-2", status = PipelineRunStatus.RUNNING),
+                        makePipeline(id = "lane-3", status = PipelineRunStatus.PASSED),
+                    ),
+                dependencies = emptyList(),
+            )
+        assertEquals(2, group.activeLaneCount)
+    }
+
+    // ─── PipelineDependency ───────────────────────────────────────────────────
+
+    @Test
+    fun `PipelineDependency holds source and target lane IDs`() {
+        val dep = PipelineDependency("lane-1", "lane-2", DependencyType.BLOCKS_START)
+        assertEquals("lane-1", dep.sourceLaneId)
+        assertEquals("lane-2", dep.targetLaneId)
+    }
+
+    @Test
+    fun `PipelineDependency with BLOCKS_START type is correctly modeled`() {
+        val dep = PipelineDependency("lane-1", "lane-2", DependencyType.BLOCKS_START)
+        assertEquals(DependencyType.BLOCKS_START, dep.type)
+    }
+
+    @Test
+    fun `PipelineDependency with PROVIDES_INPUT type is correctly modeled`() {
+        val dep = PipelineDependency("lane-1", "lane-2", DependencyType.PROVIDES_INPUT)
+        assertEquals(DependencyType.PROVIDES_INPUT, dep.type)
+    }
+
+    // ─── MonitoredPipeline.isParallel ─────────────────────────────────────────
+
+    @Test
+    fun `MonitoredPipeline isParallel returns true for mode parallel`() {
+        val pipeline = makePipeline(id = "p1", mode = "parallel")
+        assertTrue(pipeline.isParallel)
+    }
+
+    @Test
+    fun `MonitoredPipeline isParallel returns false for mode sequential`() {
+        val pipeline = makePipeline(id = "p1", mode = "sequential")
+        assertFalse(pipeline.isParallel)
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private fun makePipeline(
+        id: String,
+        status: PipelineRunStatus = PipelineRunStatus.QUEUED,
+        mode: String = "parallel",
+        steps: List<MonitoredStep> = emptyList(),
+    ) = MonitoredPipeline(
+        id = id,
+        projectName = "test-project",
+        issueNum = 1,
+        issueTitle = "Test Issue",
+        mode = mode,
+        status = status,
+        steps = steps,
+        startedAtMs = 1718447400000L,
+        elapsedTotalSec = 0.0,
+    )
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/FakePipelineMonitorRepository.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/FakePipelineMonitorRepository.kt
@@ -1,8 +1,11 @@
 package com.orchestradashboard.shared.ui.pipelinemonitor
 
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
+import com.orchestradashboard.shared.domain.model.DependencyType
 import com.orchestradashboard.shared.domain.model.MonitoredPipeline
 import com.orchestradashboard.shared.domain.model.MonitoredStep
+import com.orchestradashboard.shared.domain.model.ParallelPipelineGroup
+import com.orchestradashboard.shared.domain.model.PipelineDependency
 import com.orchestradashboard.shared.domain.model.PipelineRunStatus
 import com.orchestradashboard.shared.domain.model.StepStatus
 import com.orchestradashboard.shared.domain.repository.PipelineMonitorRepository
@@ -12,14 +15,23 @@ import kotlinx.coroutines.flow.filter
 
 class FakePipelineMonitorRepository : PipelineMonitorRepository {
     var pipelineDetailResult: Result<MonitoredPipeline> = Result.success(defaultPipeline())
+    var parallelPipelinesResult: Result<ParallelPipelineGroup> = Result.success(defaultParallelGroup())
     val eventsFlow = MutableSharedFlow<PipelineEventDto>()
 
     var getPipelineDetailCallCount = 0
         private set
 
+    var getParallelPipelinesCallCount = 0
+        private set
+
     override suspend fun getPipelineDetail(pipelineId: String): Result<MonitoredPipeline> {
         getPipelineDetailCallCount++
         return pipelineDetailResult
+    }
+
+    override suspend fun getParallelPipelines(parentId: String): Result<ParallelPipelineGroup> {
+        getParallelPipelinesCallCount++
+        return parallelPipelinesResult
     }
 
     override fun observePipelineEvents(pipelineId: String): Flow<PipelineEventDto> = eventsFlow.filter { it.pipelineId == pipelineId }
@@ -41,6 +53,48 @@ class FakePipelineMonitorRepository : PipelineMonitorRepository {
                     ),
                 startedAtMs = 1718447400000L,
                 elapsedTotalSec = 8.0,
+            )
+
+        fun defaultParallelGroup() =
+            ParallelPipelineGroup(
+                parentPipelineId = "p1",
+                pipelines =
+                    listOf(
+                        MonitoredPipeline(
+                            id = "lane-1",
+                            projectName = "test-project",
+                            issueNum = 1,
+                            issueTitle = "Test Issue",
+                            mode = "parallel",
+                            status = PipelineRunStatus.RUNNING,
+                            steps =
+                                listOf(
+                                    MonitoredStep("coding", StepStatus.RUNNING, 2000L, 1000L, ""),
+                                    MonitoredStep("testing", StepStatus.PENDING, 0L, null, ""),
+                                ),
+                            startedAtMs = 1718447400000L,
+                            elapsedTotalSec = 2.0,
+                        ),
+                        MonitoredPipeline(
+                            id = "lane-2",
+                            projectName = "test-project",
+                            issueNum = 1,
+                            issueTitle = "Test Issue",
+                            mode = "parallel",
+                            status = PipelineRunStatus.RUNNING,
+                            steps =
+                                listOf(
+                                    MonitoredStep("design", StepStatus.PASSED, 3000L, null, ""),
+                                    MonitoredStep("build", StepStatus.RUNNING, 1000L, 1000L, ""),
+                                ),
+                            startedAtMs = 1718447400000L,
+                            elapsedTotalSec = 4.0,
+                        ),
+                    ),
+                dependencies =
+                    listOf(
+                        PipelineDependency("lane-1", "lane-2", DependencyType.BLOCKS_START),
+                    ),
             )
     }
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/ParallelPipelineViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/ParallelPipelineViewModelTest.kt
@@ -1,0 +1,269 @@
+package com.orchestradashboard.shared.ui.pipelinemonitor
+
+import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
+import com.orchestradashboard.shared.domain.model.DependencyType
+import com.orchestradashboard.shared.domain.model.MonitoredPipeline
+import com.orchestradashboard.shared.domain.model.PipelineRunStatus
+import com.orchestradashboard.shared.domain.model.StepStatus
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ParallelPipelineViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var repository: FakePipelineMonitorRepository
+    private lateinit var viewModel: PipelineMonitorViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        repository = FakePipelineMonitorRepository()
+        viewModel = PipelineMonitorViewModel("p1", repository)
+    }
+
+    @AfterTest
+    fun teardown() {
+        viewModel.onCleared()
+        Dispatchers.resetMain()
+    }
+
+    // ─── State management ────────────────────────────────────────────────────
+
+    @Test
+    fun `loadPipeline with parallel mode sets isParallel true in state`() =
+        runTest {
+            repository.pipelineDetailResult = Result.success(parallelPipeline())
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.isParallel)
+        }
+
+    @Test
+    fun `loadParallelPipelines populates parallelPipelines in state`() =
+        runTest {
+            repository.pipelineDetailResult = Result.success(parallelPipeline())
+            repository.parallelPipelinesResult = Result.success(FakePipelineMonitorRepository.defaultParallelGroup())
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertNotNull(state.parallelGroup)
+            assertEquals(2, state.parallelGroup!!.pipelines.size)
+            assertEquals(2, state.parallelPipelines.size)
+        }
+
+    @Test
+    fun `loadParallelPipelines sets error on failure`() =
+        runTest {
+            repository.pipelineDetailResult = Result.success(parallelPipeline())
+            repository.parallelPipelinesResult = Result.failure(RuntimeException("parallel load failed"))
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            assertEquals("parallel load failed", viewModel.uiState.value.error)
+        }
+
+    @Test
+    fun `isParallelView returns true when parallelPipelines is non-empty`() =
+        runTest {
+            repository.pipelineDetailResult = Result.success(parallelPipeline())
+            repository.parallelPipelinesResult = Result.success(FakePipelineMonitorRepository.defaultParallelGroup())
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.isParallelView)
+        }
+
+    @Test
+    fun `isParallelView returns false when parallelPipelines is empty`() =
+        runTest {
+            // Default pipeline is sequential, so loadParallelPipelines is not called
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.isParallelView)
+        }
+
+    // ─── Event handling for parallel lanes ───────────────────────────────────
+
+    @Test
+    fun `step event with laneId updates correct parallel pipeline lane`() =
+        runTest {
+            repository.pipelineDetailResult = Result.success(parallelPipeline())
+            repository.parallelPipelinesResult = Result.success(FakePipelineMonitorRepository.defaultParallelGroup())
+            viewModel.loadPipeline()
+            viewModel.startObserving()
+            advanceUntilIdle()
+
+            repository.eventsFlow.emit(
+                PipelineEventDto(
+                    type = "step.started",
+                    pipelineId = "p1",
+                    laneId = "lane-1",
+                    step = "testing",
+                    elapsedSec = 0.0,
+                ),
+            )
+            advanceUntilIdle()
+
+            val lane1 = viewModel.uiState.value.parallelPipelines.first { it.id == "lane-1" }
+            val step = lane1.steps.first { it.name == "testing" }
+            assertEquals(StepStatus.RUNNING, step.status)
+        }
+
+    @Test
+    fun `step event with laneId for nonexistent lane is ignored`() =
+        runTest {
+            repository.pipelineDetailResult = Result.success(parallelPipeline())
+            repository.parallelPipelinesResult = Result.success(FakePipelineMonitorRepository.defaultParallelGroup())
+            viewModel.loadPipeline()
+            viewModel.startObserving()
+            advanceUntilIdle()
+
+            val countBefore = viewModel.uiState.value.parallelPipelines.size
+
+            repository.eventsFlow.emit(
+                PipelineEventDto(
+                    type = "step.started",
+                    pipelineId = "p1",
+                    laneId = "lane-nonexistent",
+                    step = "coding",
+                ),
+            )
+            advanceUntilIdle()
+
+            // State is unchanged
+            assertEquals(countBefore, viewModel.uiState.value.parallelPipelines.size)
+        }
+
+    @Test
+    fun `pipeline completed event with laneId updates lane status to PASSED`() =
+        runTest {
+            repository.pipelineDetailResult = Result.success(parallelPipeline())
+            repository.parallelPipelinesResult = Result.success(FakePipelineMonitorRepository.defaultParallelGroup())
+            viewModel.loadPipeline()
+            viewModel.startObserving()
+            advanceUntilIdle()
+
+            repository.eventsFlow.emit(
+                PipelineEventDto(type = "pipeline.completed", pipelineId = "p1", laneId = "lane-1"),
+            )
+            advanceUntilIdle()
+
+            val lane1 = viewModel.uiState.value.parallelPipelines.first { it.id == "lane-1" }
+            assertEquals(PipelineRunStatus.PASSED, lane1.status)
+        }
+
+    @Test
+    fun `pipeline failed event with laneId updates lane status to FAILED`() =
+        runTest {
+            repository.pipelineDetailResult = Result.success(parallelPipeline())
+            repository.parallelPipelinesResult = Result.success(FakePipelineMonitorRepository.defaultParallelGroup())
+            viewModel.loadPipeline()
+            viewModel.startObserving()
+            advanceUntilIdle()
+
+            repository.eventsFlow.emit(
+                PipelineEventDto(type = "pipeline.failed", pipelineId = "p1", laneId = "lane-2"),
+            )
+            advanceUntilIdle()
+
+            val lane2 = viewModel.uiState.value.parallelPipelines.first { it.id == "lane-2" }
+            assertEquals(PipelineRunStatus.FAILED, lane2.status)
+        }
+
+    @Test
+    fun `all parallel lanes completed sets group overallStatus PASSED`() =
+        runTest {
+            repository.pipelineDetailResult = Result.success(parallelPipeline())
+            repository.parallelPipelinesResult = Result.success(FakePipelineMonitorRepository.defaultParallelGroup())
+            viewModel.loadPipeline()
+            viewModel.startObserving()
+            advanceUntilIdle()
+
+            repository.eventsFlow.emit(
+                PipelineEventDto(type = "pipeline.completed", pipelineId = "p1", laneId = "lane-1"),
+            )
+            repository.eventsFlow.emit(
+                PipelineEventDto(type = "pipeline.completed", pipelineId = "p1", laneId = "lane-2"),
+            )
+            advanceUntilIdle()
+
+            val group = viewModel.uiState.value.parallelGroup
+            assertNotNull(group)
+            assertEquals(PipelineRunStatus.PASSED, group.overallStatus)
+        }
+
+    // ─── Dependency data ─────────────────────────────────────────────────────
+
+    @Test
+    fun `loadParallelPipelines includes dependency data`() =
+        runTest {
+            repository.pipelineDetailResult = Result.success(parallelPipeline())
+            repository.parallelPipelinesResult = Result.success(FakePipelineMonitorRepository.defaultParallelGroup())
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            assertEquals(1, viewModel.uiState.value.dependencies.size)
+        }
+
+    @Test
+    fun `dependencies are accessible from state after load`() =
+        runTest {
+            repository.pipelineDetailResult = Result.success(parallelPipeline())
+            repository.parallelPipelinesResult = Result.success(FakePipelineMonitorRepository.defaultParallelGroup())
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            val dep = viewModel.uiState.value.dependencies.first()
+            assertEquals("lane-1", dep.sourceLaneId)
+            assertEquals("lane-2", dep.targetLaneId)
+            assertEquals(DependencyType.BLOCKS_START, dep.type)
+        }
+
+    // ─── Refresh ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `refresh reloads both main pipeline and parallel pipelines when isParallel`() =
+        runTest {
+            repository.pipelineDetailResult = Result.success(parallelPipeline())
+            repository.parallelPipelinesResult = Result.success(FakePipelineMonitorRepository.defaultParallelGroup())
+            viewModel.loadPipeline()
+            advanceUntilIdle()
+
+            val callsBefore = repository.getParallelPipelinesCallCount
+
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            assertTrue(repository.getParallelPipelinesCallCount > callsBefore)
+        }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private fun parallelPipeline() =
+        MonitoredPipeline(
+            id = "p1",
+            projectName = "test-project",
+            issueNum = 1,
+            issueTitle = "Test Issue",
+            mode = "parallel",
+            status = PipelineRunStatus.RUNNING,
+            steps = emptyList(),
+            startedAtMs = 1718447400000L,
+            elapsedTotalSec = 0.0,
+        )
+}

--- a/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/data/repository/ProjectRepositoryImplTest.kt
+++ b/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/data/repository/ProjectRepositoryImplTest.kt
@@ -6,6 +6,7 @@ import com.orchestradashboard.shared.data.api.OrchestratorNotFoundException
 import com.orchestradashboard.shared.data.dto.orchestrator.CheckpointDto
 import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorIssueDto
 import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorPipelineDto
+import com.orchestradashboard.shared.data.dto.orchestrator.ParallelPipelineGroupDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineHistoryDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ProjectDetailDto
@@ -63,6 +64,8 @@ class FakeOrchestratorApi(
     override suspend fun retryCheckpoint(checkpointId: String): CheckpointDto = throw NotImplementedError()
 
     override suspend fun getPipelineHistory(): List<PipelineHistoryDto> = throw NotImplementedError()
+
+    override suspend fun getParallelPipelines(parentId: String): ParallelPipelineGroupDto = throw NotImplementedError()
 
     override fun connectEvents(): Flow<PipelineEventDto> = emptyFlow()
 

--- a/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/StepNodeTest.kt
+++ b/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/StepNodeTest.kt
@@ -80,12 +80,14 @@ class StepNodeTest {
     @Test
     fun `StepNode RUNNING step with startedAtMs shows live timer`() =
         runComposeUiTest {
+            mainClock.autoAdvance = false
             val startedAt = Clock.System.now().toEpochMilliseconds() - 90_000L
             setContent {
                 DashboardTheme {
                     StepNode(step = makeStep("running-step", StepStatus.RUNNING, startedAtMs = startedAt))
                 }
             }
+            mainClock.advanceTimeByFrame()
             onNodeWithText("running-step").assertIsDisplayed()
             onNodeWithText("1m 30s").assertIsDisplayed()
         }


### PR DESCRIPTION
## Summary
- Parallel View를 위한 shared 모듈 로직 구현 (#91, split from #87)
- `isParallel`, `parallelPipelines` 상태 모델 정의
- ViewModel에서 병렬 파이프라인 상태 관리
- Unit tests 포함

## Test plan
- [x] `./gradlew :shared:desktopTest` 통과
- [x] CI auto-fix 후 테스트 통과 확인
- [ ] CI 파이프라인 통과 확인

Closes #91