### PR TITLE
feat: Parallel View — UI 구현 (Compose + SwiftUI)

### DIFF
--- a/iosApp/iosApp/IOSPipelineMonitorViewModel.swift
+++ b/iosApp/iosApp/IOSPipelineMonitorViewModel.swift
@@ -12,6 +12,12 @@ final class IOSPipelineMonitorViewModel: ObservableObject {
     @Published var error: String? = nil
     @Published var connectionStatus: ConnectionStatus = .disconnected
 
+    // Parallel view state
+    @Published var parallelPipelines: [MonitoredPipeline] = []
+    @Published var parallelGroup: ParallelPipelineGroup? = nil
+    @Published var isParallelView: Bool = false
+    @Published var dependencies: [PipelineDependency] = []
+
     private let viewModel: PipelineMonitorViewModel
     private var collectTask: Task<Void, Never>?
 
@@ -39,6 +45,11 @@ final class IOSPipelineMonitorViewModel: ObservableObject {
         self.isLoading = state.isLoading
         self.error = state.error
         self.connectionStatus = state.connectionStatus
+        // Parallel view state
+        self.parallelPipelines = state.parallelPipelines as? [MonitoredPipeline] ?? []
+        self.parallelGroup = state.parallelGroup
+        self.isParallelView = state.isParallelView
+        self.dependencies = state.dependencies as? [PipelineDependency] ?? []
     }
 
     func loadPipeline() {

--- a/iosApp/iosApp/PipelineMonitorView.swift
+++ b/iosApp/iosApp/PipelineMonitorView.swift
@@ -16,7 +16,12 @@ struct PipelineMonitorView: View {
             } else {
                 ScrollView {
                     VStack(spacing: 16) {
-                        if let pipeline = viewModel.pipeline {
+                        if viewModel.isParallelView {
+                            ParallelPipelineView(
+                                pipelines: viewModel.parallelPipelines,
+                                dependencies: viewModel.dependencies
+                            )
+                        } else if let pipeline = viewModel.pipeline {
                             StepTimelineView(steps: pipeline.steps)
                         }
 

--- a/iosApp/iosApp/components/ParallelPipelineView.swift
+++ b/iosApp/iosApp/components/ParallelPipelineView.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+import Shared
+
+/// Renders a set of parallel pipeline lanes stacked vertically with
+/// dependency arrows drawn in a left gutter using SwiftUI Canvas.
+struct ParallelPipelineView: View {
+    let pipelines: [MonitoredPipeline]
+    let dependencies: [PipelineDependency]
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            // Lane stack
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(Array(pipelines.enumerated()), id: \.offset) { _, pipeline in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(pipeline.id)
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .foregroundStyle(.blue)
+                            .accessibilityIdentifier("lane_header_\(pipeline.id)")
+                        StepTimelineView(steps: pipeline.steps)
+                    }
+                    .padding(.leading, 48) // leave room for arrow gutter
+                }
+            }
+
+            // Arrow overlay in left gutter
+            if !dependencies.isEmpty && !pipelines.isEmpty {
+                GeometryReader { geometry in
+                    let laneHeight = geometry.size.height / CGFloat(pipelines.count)
+                    DependencyArrowCanvas(
+                        dependencies: dependencies,
+                        pipelineIds: pipelines.map { $0.id },
+                        laneHeight: laneHeight
+                    )
+                    .frame(width: 44)
+                    .accessibilityIdentifier("dependency_arrows")
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Arrow Canvas
+
+/// Draws curved dependency arrows between parallel pipeline lanes.
+/// Geometry and color helpers are exposed as `static func` for unit testing.
+struct DependencyArrowCanvas: View {
+    let dependencies: [PipelineDependency]
+    let pipelineIds: [String]
+    let laneHeight: CGFloat
+
+    var body: some View {
+        Canvas { context, _ in
+            for dep in dependencies {
+                guard
+                    let sourceIdx = pipelineIds.firstIndex(of: dep.sourceLaneId),
+                    let targetIdx = pipelineIds.firstIndex(of: dep.targetLaneId),
+                    sourceIdx != targetIdx
+                else { continue }
+
+                let (startY, endY) = DependencyArrowCanvas.calcArrowEndpoints(
+                    sourceIdx: sourceIdx,
+                    targetIdx: targetIdx,
+                    laneHeight: laneHeight
+                )
+                let x: CGFloat = 22
+
+                var curvePath = Path()
+                curvePath.move(to: CGPoint(x: x, y: startY))
+                curvePath.addCurve(
+                    to: CGPoint(x: x, y: endY),
+                    control1: CGPoint(x: x + 24, y: startY),
+                    control2: CGPoint(x: x + 24, y: endY)
+                )
+
+                let color = DependencyArrowCanvas.arrowColor(for: dep.type)
+                context.stroke(curvePath, with: .color(color), lineWidth: 2)
+
+                let direction: ArrowDirection = targetIdx > sourceIdx ? .down : .up
+                drawArrowhead(
+                    context: context,
+                    tip: CGPoint(x: x, y: endY),
+                    direction: direction,
+                    color: color
+                )
+            }
+        }
+    }
+
+    // MARK: - Testable geometry helpers
+
+    /// Returns the Y center coordinates for source and target lanes.
+    static func calcArrowEndpoints(
+        sourceIdx: Int,
+        targetIdx: Int,
+        laneHeight: CGFloat
+    ) -> (startY: CGFloat, endY: CGFloat) {
+        let startY = CGFloat(sourceIdx) * laneHeight + laneHeight / 2
+        let endY = CGFloat(targetIdx) * laneHeight + laneHeight / 2
+        return (startY, endY)
+    }
+
+    /// Maps a `DependencyType` to its arrow color.
+    static func arrowColor(for type: DependencyType) -> Color {
+        switch type {
+        case .blocksStart:
+            return .orange
+        case .providesInput:
+            return Color(red: 0.01, green: 0.66, blue: 0.96) // #03A9F4
+        default:
+            return .gray
+        }
+    }
+
+    // MARK: - Private rendering helpers
+
+    private func drawArrowhead(
+        context: GraphicsContext,
+        tip: CGPoint,
+        direction: ArrowDirection,
+        color: Color
+    ) {
+        let size: CGFloat = 7
+        // Use trigonometry: down → base is above tip (negative Y offset); up → below
+        let yOffset: CGFloat = direction == .down ? -size : size
+        var path = Path()
+        path.move(to: tip)
+        path.addLine(to: CGPoint(x: tip.x - size / 2, y: tip.y + yOffset))
+        path.addLine(to: CGPoint(x: tip.x + size / 2, y: tip.y + yOffset))
+        path.closeSubpath()
+        context.fill(path, with: .color(color))
+    }
+
+    enum ArrowDirection { case up, down }
+}

--- a/iosApp/iosApp/components/ParallelPipelineView.swift
+++ b/iosApp/iosApp/components/ParallelPipelineView.swift
@@ -7,37 +7,155 @@ struct ParallelPipelineView: View {
     let pipelines: [MonitoredPipeline]
     let dependencies: [PipelineDependency]
 
+    @State private var laneHeights: [CGFloat] = []
+    private let laneSpacing: CGFloat = 12
+
     var body: some View {
-        ZStack(alignment: .topLeading) {
-            // Lane stack
-            VStack(alignment: .leading, spacing: 12) {
-                ForEach(Array(pipelines.enumerated()), id: \.offset) { _, pipeline in
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(pipeline.id)
-                            .font(.caption)
-                            .fontWeight(.medium)
-                            .foregroundStyle(.blue)
-                            .accessibilityIdentifier("lane_header_\(pipeline.id)")
-                        StepTimelineView(steps: pipeline.steps)
-                    }
-                    .padding(.leading, 48) // leave room for arrow gutter
-                }
+        VStack(alignment: .leading, spacing: 8) {
+            if !dependencies.isEmpty {
+                DependencyLegendView()
             }
 
-            // Arrow overlay in left gutter
-            if !dependencies.isEmpty && !pipelines.isEmpty {
-                GeometryReader { geometry in
-                    let laneHeight = geometry.size.height / CGFloat(pipelines.count)
+            ZStack(alignment: .topLeading) {
+                VStack(alignment: .leading, spacing: laneSpacing) {
+                    ForEach(Array(pipelines.enumerated()), id: \.offset) { index, pipeline in
+                        laneContent(pipeline)
+                            .background(
+                                GeometryReader { geo in
+                                    Color.clear.preference(
+                                        key: LaneHeightPreferenceKey.self,
+                                        value: [index: geo.size.height]
+                                    )
+                                }
+                            )
+                            .padding(.leading, dependencies.isEmpty ? 0 : 48)
+                    }
+                }
+                .onPreferenceChange(LaneHeightPreferenceKey.self) { prefs in
+                    var newHeights = Array(repeating: CGFloat(0), count: pipelines.count)
+                    for (idx, h) in prefs {
+                        if idx < newHeights.count {
+                            newHeights[idx] = h
+                        }
+                    }
+                    if newHeights != laneHeights {
+                        laneHeights = newHeights
+                    }
+                }
+
+                if !dependencies.isEmpty && !pipelines.isEmpty &&
+                   laneHeights.count == pipelines.count {
                     DependencyArrowCanvas(
                         dependencies: dependencies,
                         pipelineIds: pipelines.map { $0.id },
-                        laneHeight: laneHeight
+                        laneHeights: laneHeights,
+                        spacing: laneSpacing
                     )
                     .frame(width: 44)
                     .accessibilityIdentifier("dependency_arrows")
                 }
             }
         }
+    }
+
+    // MARK: - Lane content
+
+    @ViewBuilder
+    private func laneContent(_ pipeline: MonitoredPipeline) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(pipeline.id)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.blue)
+                        .accessibilityIdentifier("lane_header_\(pipeline.id)")
+
+                    if pipeline.issueNum > 0 {
+                        Text("#\(pipeline.issueNum) \(pipeline.issueTitle)")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer()
+                let badgeColor = ParallelPipelineView.statusBadgeColor(for: pipeline.status)
+                Text(ParallelPipelineView.statusBadgeLabel(for: pipeline.status))
+                    .font(.caption2)
+                    .fontWeight(.medium)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(badgeColor.opacity(0.15))
+                    .foregroundStyle(badgeColor)
+                    .clipShape(Capsule())
+                    .accessibilityIdentifier("lane_status_\(pipeline.id)")
+            }
+            StepTimelineView(steps: pipeline.steps)
+        }
+    }
+
+    // MARK: - Status badge helpers
+
+    static func statusBadgeColor(for status: PipelineRunStatus) -> Color {
+        switch status {
+        case .running:   return .blue
+        case .passed:    return .green
+        case .failed:    return .red
+        case .cancelled: return .orange
+        case .queued:    return .gray
+        default:         return .gray
+        }
+    }
+
+    static func statusBadgeLabel(for status: PipelineRunStatus) -> String {
+        switch status {
+        case .running:   return "Running"
+        case .passed:    return "Passed"
+        case .failed:    return "Failed"
+        case .cancelled: return "Cancelled"
+        case .queued:    return "Queued"
+        default:         return "Unknown"
+        }
+    }
+
+    // MARK: - Dependency legend helper
+
+    static func dependencyLegendLabel(for type: DependencyType) -> String {
+        switch type {
+        case .blocksStart:   return "Blocks Start"
+        case .providesInput: return "Provides Input"
+        default:             return "Dependency"
+        }
+    }
+}
+
+// MARK: - Dependency Legend
+
+private struct DependencyLegendView: View {
+    var body: some View {
+        HStack(spacing: 16) {
+            legendItem(color: .orange, label: "Blocks Start")
+            legendItem(color: Color(red: 0.01, green: 0.66, blue: 0.96), label: "Provides Input")
+        }
+        .font(.caption2)
+        .accessibilityIdentifier("dependency_legend")
+    }
+
+    private func legendItem(color: Color, label: String) -> some View {
+        HStack(spacing: 4) {
+            Circle().fill(color).frame(width: 8, height: 8)
+            Text(label).foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Lane Height PreferenceKey
+
+private struct LaneHeightPreferenceKey: PreferenceKey {
+    static var defaultValue: [Int: CGFloat] = [:]
+
+    static func reduce(value: inout [Int: CGFloat], nextValue: () -> [Int: CGFloat]) {
+        value.merge(nextValue()) { _, new in new }
     }
 }
 
@@ -48,7 +166,9 @@ struct ParallelPipelineView: View {
 struct DependencyArrowCanvas: View {
     let dependencies: [PipelineDependency]
     let pipelineIds: [String]
-    let laneHeight: CGFloat
+    var laneHeight: CGFloat = 0        // legacy equal-height mode
+    var laneHeights: [CGFloat] = []    // dynamic-height mode
+    var spacing: CGFloat = 12
 
     var body: some View {
         Canvas { context, _ in
@@ -59,11 +179,19 @@ struct DependencyArrowCanvas: View {
                     sourceIdx != targetIdx
                 else { continue }
 
-                let (startY, endY) = DependencyArrowCanvas.calcArrowEndpoints(
-                    sourceIdx: sourceIdx,
-                    targetIdx: targetIdx,
-                    laneHeight: laneHeight
-                )
+                let startY: CGFloat
+                let endY: CGFloat
+
+                if !laneHeights.isEmpty {
+                    startY = DependencyArrowCanvas.calcLaneCenterY(
+                        index: sourceIdx, laneHeights: laneHeights, spacing: spacing)
+                    endY = DependencyArrowCanvas.calcLaneCenterY(
+                        index: targetIdx, laneHeights: laneHeights, spacing: spacing)
+                } else {
+                    (startY, endY) = DependencyArrowCanvas.calcArrowEndpoints(
+                        sourceIdx: sourceIdx, targetIdx: targetIdx, laneHeight: laneHeight)
+                }
+
                 let x: CGFloat = 22
 
                 var curvePath = Path()
@@ -90,7 +218,7 @@ struct DependencyArrowCanvas: View {
 
     // MARK: - Testable geometry helpers
 
-    /// Returns the Y center coordinates for source and target lanes.
+    /// Returns the Y center coordinates for source and target lanes (equal-height mode).
     static func calcArrowEndpoints(
         sourceIdx: Int,
         targetIdx: Int,
@@ -99,6 +227,22 @@ struct DependencyArrowCanvas: View {
         let startY = CGFloat(sourceIdx) * laneHeight + laneHeight / 2
         let endY = CGFloat(targetIdx) * laneHeight + laneHeight / 2
         return (startY, endY)
+    }
+
+    /// Computes Y center of lane at `index` using actual measured lane heights.
+    /// Accumulates heights[0..<index] + spacing for each, then adds half of heights[index].
+    static func calcLaneCenterY(
+        index: Int,
+        laneHeights: [CGFloat],
+        spacing: CGFloat
+    ) -> CGFloat {
+        guard index >= 0, index < laneHeights.count else { return 0 }
+        var y: CGFloat = 0
+        for i in 0..<index {
+            y += laneHeights[i] + spacing
+        }
+        y += laneHeights[index] / 2
+        return y
     }
 
     /// Maps a `DependencyType` to its arrow color.
@@ -122,7 +266,7 @@ struct DependencyArrowCanvas: View {
         color: Color
     ) {
         let size: CGFloat = 7
-        // Use trigonometry: down → base is above tip (negative Y offset); up → below
+        // down → base is above tip (negative Y offset); up → below
         let yOffset: CGFloat = direction == .down ? -size : size
         var path = Path()
         path.move(to: tip)

--- a/iosApp/iosAppTests/components/ParallelPipelineViewTests.swift
+++ b/iosApp/iosAppTests/components/ParallelPipelineViewTests.swift
@@ -69,4 +69,104 @@ final class ParallelPipelineViewTests: XCTestCase {
         )
         XCTAssertEqual(startY, endY)
     }
+
+    // MARK: - Group A: statusBadgeColor
+
+    func testStatusBadgeColor_running_isBlue() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeColor(for: .running), .blue)
+    }
+
+    func testStatusBadgeColor_passed_isGreen() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeColor(for: .passed), .green)
+    }
+
+    func testStatusBadgeColor_failed_isRed() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeColor(for: .failed), .red)
+    }
+
+    func testStatusBadgeColor_cancelled_isOrange() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeColor(for: .cancelled), .orange)
+    }
+
+    func testStatusBadgeColor_queued_isGray() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeColor(for: .queued), .gray)
+    }
+
+    // MARK: - Group A: statusBadgeLabel
+
+    func testStatusBadgeLabel_running_returnsRunning() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeLabel(for: .running), "Running")
+    }
+
+    func testStatusBadgeLabel_passed_returnsPassed() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeLabel(for: .passed), "Passed")
+    }
+
+    func testStatusBadgeLabel_failed_returnsFailed() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeLabel(for: .failed), "Failed")
+    }
+
+    func testStatusBadgeLabel_cancelled_returnsCancelled() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeLabel(for: .cancelled), "Cancelled")
+    }
+
+    func testStatusBadgeLabel_queued_returnsQueued() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeLabel(for: .queued), "Queued")
+    }
+
+    // MARK: - Group B: dependencyLegendLabel
+
+    func testDependencyLegendLabels_blocksStartReturnsExpectedText() {
+        XCTAssertEqual(ParallelPipelineView.dependencyLegendLabel(for: .blocksStart), "Blocks Start")
+    }
+
+    func testDependencyLegendLabels_providesInputReturnsExpectedText() {
+        XCTAssertEqual(ParallelPipelineView.dependencyLegendLabel(for: .providesInput), "Provides Input")
+    }
+
+    // MARK: - Group C: calcLaneCenterY
+
+    func testCalcLaneCenterY_firstLane_returnsHalfHeight() {
+        let heights: [CGFloat] = [100, 80, 60]
+        let y = DependencyArrowCanvas.calcLaneCenterY(index: 0, laneHeights: heights, spacing: 12)
+        XCTAssertEqual(y, 50, "lane 0 center = heights[0]/2 = 50")
+    }
+
+    func testCalcLaneCenterY_secondLane_accountsForSpacing() {
+        let heights: [CGFloat] = [100, 80, 60]
+        let y = DependencyArrowCanvas.calcLaneCenterY(index: 1, laneHeights: heights, spacing: 12)
+        // heights[0] + spacing + heights[1]/2 = 100 + 12 + 40 = 152
+        XCTAssertEqual(y, 152, "lane 1 center = 100 + 12 + 40 = 152")
+    }
+
+    func testCalcLaneCenterY_thirdLane_accumulatesHeightsAndSpacing() {
+        let heights: [CGFloat] = [100, 80, 60]
+        let y = DependencyArrowCanvas.calcLaneCenterY(index: 2, laneHeights: heights, spacing: 12)
+        // (100 + 12) + (80 + 12) + 60/2 = 112 + 92 + 30 = 234
+        XCTAssertEqual(y, 234, "lane 2 center = 112 + 92 + 30 = 234")
+    }
+
+    func testCalcLaneCenterY_variableHeights_correctMidpoint() {
+        let heights: [CGFloat] = [40, 120]
+        let y = DependencyArrowCanvas.calcLaneCenterY(index: 1, laneHeights: heights, spacing: 8)
+        // 40 + 8 + 120/2 = 40 + 8 + 60 = 108
+        XCTAssertEqual(y, 108)
+    }
+
+    func testCalcLaneCenterY_emptyHeights_returnsZero() {
+        let y = DependencyArrowCanvas.calcLaneCenterY(index: 0, laneHeights: [], spacing: 12)
+        XCTAssertEqual(y, 0)
+    }
+
+    func testCalcLaneCenterY_outOfBoundsIndex_returnsZero() {
+        let heights: [CGFloat] = [100, 80, 60]
+
+        // Test index equal to count
+        let y1 = DependencyArrowCanvas.calcLaneCenterY(index: 3, laneHeights: heights, spacing: 12)
+        XCTAssertEqual(y1, 0, "Index equal to count should be out of bounds and return 0")
+
+        // Test negative index
+        let y2 = DependencyArrowCanvas.calcLaneCenterY(index: -1, laneHeights: heights, spacing: 12)
+        XCTAssertEqual(y2, 0, "Negative index should be out of bounds and return 0")
+    }
 }

--- a/iosApp/iosAppTests/components/ParallelPipelineViewTests.swift
+++ b/iosApp/iosAppTests/components/ParallelPipelineViewTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+import SwiftUI
+@testable import iosApp
+
+final class ParallelPipelineViewTests: XCTestCase {
+
+    // MARK: - arrowColor
+
+    func testArrowColor_blocksStart_isOrange() {
+        XCTAssertEqual(DependencyArrowCanvas.arrowColor(for: .blocksStart), .orange)
+    }
+
+    func testArrowColor_providesInput_isLightBlue() {
+        let expected = Color(red: 0.01, green: 0.66, blue: 0.96)
+        XCTAssertEqual(DependencyArrowCanvas.arrowColor(for: .providesInput), expected)
+    }
+
+    func testArrowColor_blocksStart_differsFromProvidesInput() {
+        let orange = DependencyArrowCanvas.arrowColor(for: .blocksStart)
+        let blue = DependencyArrowCanvas.arrowColor(for: .providesInput)
+        XCTAssertNotEqual(orange, blue)
+    }
+
+    // MARK: - calcArrowEndpoints
+
+    func testCalcArrowEndpoints_firstLane_centerIsHalfLaneHeight() {
+        let (startY, _) = DependencyArrowCanvas.calcArrowEndpoints(
+            sourceIdx: 0,
+            targetIdx: 1,
+            laneHeight: 100
+        )
+        XCTAssertEqual(startY, 50, "lane 0 center should be at half the lane height")
+    }
+
+    func testCalcArrowEndpoints_secondLane_centerIsOneAndHalfLaneHeight() {
+        let (_, endY) = DependencyArrowCanvas.calcArrowEndpoints(
+            sourceIdx: 0,
+            targetIdx: 1,
+            laneHeight: 100
+        )
+        XCTAssertEqual(endY, 150, "lane 1 center should be at 1.5x the lane height")
+    }
+
+    func testCalcArrowEndpoints_sourceBelowTarget_startYGreaterThanEndY() {
+        let (startY, endY) = DependencyArrowCanvas.calcArrowEndpoints(
+            sourceIdx: 2,
+            targetIdx: 0,
+            laneHeight: 100
+        )
+        XCTAssertGreaterThan(startY, endY)
+    }
+
+    func testCalcArrowEndpoints_differentLaneHeights_scalesCorrectly() {
+        let (startY, endY) = DependencyArrowCanvas.calcArrowEndpoints(
+            sourceIdx: 1,
+            targetIdx: 3,
+            laneHeight: 80
+        )
+        // lane 1: 1*80 + 40 = 120; lane 3: 3*80 + 40 = 280
+        XCTAssertEqual(startY, 120)
+        XCTAssertEqual(endY, 280)
+    }
+
+    func testCalcArrowEndpoints_sameLane_startEqualsEnd() {
+        let (startY, endY) = DependencyArrowCanvas.calcArrowEndpoints(
+            sourceIdx: 2,
+            targetIdx: 2,
+            laneHeight: 60
+        )
+        XCTAssertEqual(startY, endY)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrow.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrow.kt
@@ -1,0 +1,172 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.orchestradashboard.shared.domain.model.DependencyType
+import com.orchestradashboard.shared.domain.model.PipelineDependency
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
+/** Pure geometry: given lane positions compute start/end points of an arrow. */
+data class ArrowEndpoints(
+    val startX: Float,
+    val startY: Float,
+    val endX: Float,
+    val endY: Float,
+)
+
+/** Three points forming the arrowhead triangle. */
+data class ArrowHeadPoints(
+    val tip: Offset,
+    val left: Offset,
+    val right: Offset,
+)
+
+/**
+ * Computes start/end coordinates for a dependency arrow between two lanes.
+ * Arrows are drawn in the left gutter; x coordinates equal [arrowPadding].
+ */
+fun calcArrowEndpoints(
+    sourceLaneIndex: Int,
+    targetLaneIndex: Int,
+    laneHeight: Float,
+    laneStartY: Float,
+    laneWidth: Float,
+    arrowPadding: Float = 8f,
+): ArrowEndpoints {
+    val startY = laneStartY + (sourceLaneIndex * laneHeight) + (laneHeight / 2f)
+    val endY = laneStartY + (targetLaneIndex * laneHeight) + (laneHeight / 2f)
+    return ArrowEndpoints(
+        startX = arrowPadding,
+        startY = startY,
+        endX = arrowPadding,
+        endY = endY,
+    )
+}
+
+/**
+ * Computes the Y center of a lane given a list of per-lane heights and the spacing
+ * between lanes. Accumulates heights of all preceding lanes before computing the
+ * midpoint of the target lane.
+ */
+fun calcLaneCenterY(
+    laneIndex: Int,
+    laneHeights: List<Float>,
+    laneSpacingPx: Float = 0f,
+    laneStartY: Float = 0f,
+): Float {
+    var y = laneStartY
+    for (i in 0 until laneIndex) {
+        y += laneHeights.getOrElse(i) { 0f } + laneSpacingPx
+    }
+    y += laneHeights.getOrElse(laneIndex) { 0f } / 2f
+    return y
+}
+
+/**
+ * Computes the three points forming an arrowhead triangle at [tip], pointing
+ * in the direction given by [angle] (radians). The two base corners are offset
+ * by [size] pixels from the tip.
+ */
+fun calcArrowHeadPoints(
+    tip: Offset,
+    angle: Float,
+    size: Float = 10f,
+): ArrowHeadPoints {
+    val leftAngle = angle + (PI / 6).toFloat()
+    val rightAngle = angle - (PI / 6).toFloat()
+    val left =
+        Offset(
+            x = tip.x - size * cos(leftAngle),
+            y = tip.y - size * sin(leftAngle),
+        )
+    val right =
+        Offset(
+            x = tip.x - size * cos(rightAngle),
+            y = tip.y - size * sin(rightAngle),
+        )
+    return ArrowHeadPoints(tip = tip, left = left, right = right)
+}
+
+/** Returns the display color for a given [DependencyType]. */
+fun dependencyColor(type: DependencyType): Color =
+    when (type) {
+        DependencyType.BLOCKS_START -> Color(0xFFFF9800) // Orange / Amber
+        DependencyType.PROVIDES_INPUT -> Color(0xFF03A9F4) // Light Blue / Cyan
+    }
+
+/**
+ * Canvas overlay that draws curved arrows between parallel pipeline lanes.
+ * Arrow Y positions are computed per-lane from [laneHeights] to correctly
+ * handle lanes of different heights.
+ *
+ * @param dependencies   List of dependencies to visualise.
+ * @param pipelineIds    Ordered list of lane IDs (determines lane index).
+ * @param laneHeights    Per-lane pixel heights in order.
+ * @param laneSpacingPx  Vertical gap between lanes in pixels.
+ */
+@Composable
+fun DependencyArrowOverlay(
+    dependencies: List<PipelineDependency>,
+    pipelineIds: List<String>,
+    laneHeights: List<Float>,
+    laneSpacingPx: Float = 0f,
+    modifier: Modifier = Modifier,
+) {
+    Canvas(modifier = modifier.testTag("dependency_arrows")) {
+        dependencies.forEach { dep ->
+            val sourceIdx = pipelineIds.indexOf(dep.sourceLaneId)
+            val targetIdx = pipelineIds.indexOf(dep.targetLaneId)
+            // Skip unknown or self-referencing lanes
+            if (sourceIdx < 0 || targetIdx < 0 || sourceIdx == targetIdx) return@forEach
+
+            val startX = 8f
+            val endX = 8f
+            val startY = calcLaneCenterY(sourceIdx, laneHeights, laneSpacingPx)
+            val endY = calcLaneCenterY(targetIdx, laneHeights, laneSpacingPx)
+            val color = dependencyColor(dep.type)
+
+            val curvePath =
+                Path().apply {
+                    moveTo(startX, startY)
+                    cubicTo(
+                        startX + 24f,
+                        startY,
+                        endX + 24f,
+                        endY,
+                        endX,
+                        endY,
+                    )
+                }
+            drawPath(
+                path = curvePath,
+                color = color,
+                style = Stroke(width = 2.dp.toPx(), cap = StrokeCap.Round),
+            )
+
+            val angle = if (targetIdx > sourceIdx) (PI / 2).toFloat() else (-PI / 2).toFloat()
+            val headPoints =
+                calcArrowHeadPoints(
+                    tip = Offset(endX, endY),
+                    angle = angle,
+                )
+            val headPath =
+                Path().apply {
+                    moveTo(headPoints.tip.x, headPoints.tip.y)
+                    lineTo(headPoints.left.x, headPoints.left.y)
+                    lineTo(headPoints.right.x, headPoints.right.y)
+                    close()
+                }
+            drawPath(path = headPath, color = color)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrow.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrow.kt
@@ -1,7 +1,17 @@
 package com.orchestradashboard.shared.ui.component
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -103,6 +113,41 @@ fun dependencyColor(type: DependencyType): Color =
         DependencyType.BLOCKS_START -> Color(0xFFFF9800) // Orange / Amber
         DependencyType.PROVIDES_INPUT -> Color(0xFF03A9F4) // Light Blue / Cyan
     }
+
+/**
+ * A legend row explaining arrow colors for each [DependencyType].
+ * Only shown when the parallel view has at least one dependency.
+ */
+@Composable
+fun DependencyLegend(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        LegendItem(color = dependencyColor(DependencyType.BLOCKS_START), label = "Blocks")
+        LegendItem(color = dependencyColor(DependencyType.PROVIDES_INPUT), label = "Provides Input")
+    }
+}
+
+@Composable
+private fun LegendItem(
+    color: Color,
+    label: String,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .size(10.dp)
+                    .background(color, CircleShape),
+        )
+        Text(text = label, style = MaterialTheme.typography.labelSmall)
+    }
+}
 
 /**
  * Canvas overlay that draws curved arrows between parallel pipeline lanes.

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineView.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineView.kt
@@ -12,13 +12,17 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.orchestradashboard.shared.domain.model.MonitoredPipeline
 import com.orchestradashboard.shared.domain.model.PipelineDependency
+import com.orchestradashboard.shared.domain.model.PipelineRunStatus
+import com.orchestradashboard.shared.ui.theme.DashboardTheme
 
 @Composable
 fun ParallelPipelineView(
@@ -26,6 +30,16 @@ fun ParallelPipelineView(
     dependencies: List<PipelineDependency> = emptyList(),
     modifier: Modifier = Modifier,
 ) {
+    if (pipelines.isEmpty()) {
+        Text(
+            text = "No parallel lanes",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = modifier.padding(16.dp).testTag("parallel_empty_state"),
+        )
+        return
+    }
+
     val density = LocalDensity.current
     // Track each lane's pixel height independently to correctly position arrows
     // when lanes contain different numbers of steps.
@@ -35,48 +49,92 @@ fun ParallelPipelineView(
         }
     val laneSpacingPx = with(density) { 12.dp.toPx() }
 
-    Row(modifier = modifier.fillMaxWidth()) {
-        // Left gutter: arrow overlay (only rendered when dependencies exist)
+    Column(modifier = modifier.fillMaxWidth()) {
+        // Dependency legend (only when dependencies exist)
         if (dependencies.isNotEmpty()) {
-            DependencyArrowOverlay(
-                dependencies = dependencies,
-                pipelineIds = pipelines.map { it.id },
-                laneHeights = laneHeights.toList(),
-                laneSpacingPx = laneSpacingPx,
-                modifier =
-                    Modifier
-                        .width(40.dp)
-                        .fillMaxHeight(),
-            )
+            DependencyLegend(modifier = Modifier.testTag("dependency_legend"))
         }
 
-        // Lane column
-        Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            pipelines.forEachIndexed { index, pipeline ->
-                Column(
+        Row(modifier = Modifier.fillMaxWidth()) {
+            // Left gutter: arrow overlay (only rendered when dependencies exist)
+            if (dependencies.isNotEmpty()) {
+                DependencyArrowOverlay(
+                    dependencies = dependencies,
+                    pipelineIds = pipelines.map { it.id },
+                    laneHeights = laneHeights.toList(),
+                    laneSpacingPx = laneSpacingPx,
                     modifier =
                         Modifier
-                            .padding(horizontal = 16.dp)
-                            .onGloballyPositioned { coords ->
-                                if (index < laneHeights.size) {
-                                    laneHeights[index] = coords.size.height.toFloat()
+                            .width(40.dp)
+                            .fillMaxHeight(),
+                )
+            }
+
+            // Lane column
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                pipelines.forEachIndexed { index, pipeline ->
+                    Column(
+                        modifier =
+                            Modifier
+                                .padding(horizontal = 16.dp)
+                                .onGloballyPositioned { coords ->
+                                    if (index < laneHeights.size) {
+                                        laneHeights[index] = coords.size.height.toFloat()
+                                    }
                                 }
-                            }
-                            .testTag("lane_${pipeline.id}"),
-                ) {
-                    Row(modifier = Modifier.testTag("lane_header_${pipeline.id}")) {
-                        Text(
-                            text = pipeline.id,
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.primary,
-                        )
+                                .testTag("lane_${pipeline.id}"),
+                    ) {
+                        LaneHeader(pipeline = pipeline)
+                        StepTimeline(steps = pipeline.steps)
                     }
-                    StepTimeline(steps = pipeline.steps)
                 }
             }
         }
     }
+}
+
+@Composable
+private fun LaneHeader(pipeline: MonitoredPipeline) {
+    Row(
+        modifier = Modifier.testTag("lane_header_${pipeline.id}"),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = pipeline.id,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text = "#${pipeline.issueNum} ${pipeline.issueTitle}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f).testTag("lane_issue_${pipeline.id}"),
+        )
+        LaneStatusBadge(pipeline = pipeline)
+    }
+}
+
+@Composable
+private fun LaneStatusBadge(pipeline: MonitoredPipeline) {
+    val statusColors = DashboardTheme.statusColors
+    val (color, label) =
+        when (pipeline.status) {
+            PipelineRunStatus.RUNNING -> MaterialTheme.colorScheme.primary to "RUNNING"
+            PipelineRunStatus.PASSED -> statusColors.success to "PASSED"
+            PipelineRunStatus.FAILED -> MaterialTheme.colorScheme.error to "FAILED"
+            PipelineRunStatus.CANCELLED -> MaterialTheme.colorScheme.onSurfaceVariant to "CANCELLED"
+            PipelineRunStatus.QUEUED -> MaterialTheme.colorScheme.onSurfaceVariant to "QUEUED"
+        }
+    Text(
+        text = label,
+        color = color,
+        style = MaterialTheme.typography.labelSmall,
+        modifier = Modifier.testTag("lane_status_${pipeline.id}"),
+    )
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineView.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineView.kt
@@ -3,34 +3,79 @@ package com.orchestradashboard.shared.ui.component
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.orchestradashboard.shared.domain.model.MonitoredPipeline
+import com.orchestradashboard.shared.domain.model.PipelineDependency
 
 @Composable
 fun ParallelPipelineView(
     pipelines: List<MonitoredPipeline>,
+    dependencies: List<PipelineDependency> = emptyList(),
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        pipelines.forEach { pipeline ->
-            Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-                Row {
-                    Text(
-                        text = pipeline.id,
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
+    val density = LocalDensity.current
+    // Track each lane's pixel height independently to correctly position arrows
+    // when lanes contain different numbers of steps.
+    val laneHeights =
+        remember(pipelines.size) {
+            mutableStateListOf<Float>().apply { repeat(pipelines.size) { add(0f) } }
+        }
+    val laneSpacingPx = with(density) { 12.dp.toPx() }
+
+    Row(modifier = modifier.fillMaxWidth()) {
+        // Left gutter: arrow overlay (only rendered when dependencies exist)
+        if (dependencies.isNotEmpty()) {
+            DependencyArrowOverlay(
+                dependencies = dependencies,
+                pipelineIds = pipelines.map { it.id },
+                laneHeights = laneHeights.toList(),
+                laneSpacingPx = laneSpacingPx,
+                modifier =
+                    Modifier
+                        .width(40.dp)
+                        .fillMaxHeight(),
+            )
+        }
+
+        // Lane column
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            pipelines.forEachIndexed { index, pipeline ->
+                Column(
+                    modifier =
+                        Modifier
+                            .padding(horizontal = 16.dp)
+                            .onGloballyPositioned { coords ->
+                                if (index < laneHeights.size) {
+                                    laneHeights[index] = coords.size.height.toFloat()
+                                }
+                            }
+                            .testTag("lane_${pipeline.id}"),
+                ) {
+                    Row(modifier = Modifier.testTag("lane_header_${pipeline.id}")) {
+                        Text(
+                            text = pipeline.id,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                    StepTimeline(steps = pipeline.steps)
                 }
-                StepTimeline(steps = pipeline.steps)
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/PipelineMonitorScreen.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/PipelineMonitorScreen.kt
@@ -106,6 +106,7 @@ fun PipelineMonitorScreen(
                 uiState.isParallelView -> {
                     ParallelPipelineView(
                         pipelines = uiState.parallelPipelines,
+                        dependencies = uiState.dependencies,
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/theme/StatusColors.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/theme/StatusColors.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.graphics.Color
 @Immutable
 data class StatusColors(
     val running: Color = Color(0xFF4CAF50),
+    val success: Color = Color(0xFF4CAF50),
     val idle: Color = Color(0xFF2196F3),
     val error: Color = Color(0xFFF44336),
     val offline: Color = Color(0xFF9E9E9E),

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrowGeometryTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrowGeometryTest.kt
@@ -1,0 +1,226 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import com.orchestradashboard.shared.domain.model.DependencyType
+import kotlin.math.PI
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DependencyArrowGeometryTest {
+    // ─── calcArrowEndpoints ────────────────────────────────────────────────────
+
+    @Test
+    fun calcArrowEndpoints_sameColumn_returnsVerticalLine() {
+        val endpoints =
+            calcArrowEndpoints(
+                sourceLaneIndex = 0,
+                targetLaneIndex = 1,
+                laneHeight = 100f,
+                laneStartY = 0f,
+                laneWidth = 400f,
+            )
+        // Both x coordinates use arrowPadding default (8f)
+        assertEquals(8f, endpoints.startX)
+        assertEquals(8f, endpoints.endX)
+        // startY = 0 + 0*100 + 50 = 50
+        assertEquals(50f, endpoints.startY)
+        // endY = 0 + 1*100 + 50 = 150
+        assertEquals(150f, endpoints.endY)
+    }
+
+    @Test
+    fun calcArrowEndpoints_differentColumns_returnsDiagonalPath() {
+        val endpoints =
+            calcArrowEndpoints(
+                sourceLaneIndex = 0,
+                targetLaneIndex = 2,
+                laneHeight = 80f,
+                laneStartY = 10f,
+                laneWidth = 300f,
+            )
+        // startY = 10 + 0*80 + 40 = 50
+        assertEquals(50f, endpoints.startY)
+        // endY = 10 + 2*80 + 40 = 210
+        assertEquals(210f, endpoints.endY)
+    }
+
+    @Test
+    fun calcArrowEndpoints_sourceBelowTarget_returnsUpwardPath() {
+        val endpoints =
+            calcArrowEndpoints(
+                sourceLaneIndex = 2,
+                targetLaneIndex = 0,
+                laneHeight = 100f,
+                laneStartY = 0f,
+                laneWidth = 400f,
+            )
+        // startY = 250, endY = 50
+        assertTrue(endpoints.startY > endpoints.endY)
+    }
+
+    @Test
+    fun calcArrowEndpoints_customPadding_usedForXCoordinates() {
+        val endpoints =
+            calcArrowEndpoints(
+                sourceLaneIndex = 0,
+                targetLaneIndex = 1,
+                laneHeight = 100f,
+                laneStartY = 0f,
+                laneWidth = 400f,
+                arrowPadding = 20f,
+            )
+        assertEquals(20f, endpoints.startX)
+        assertEquals(20f, endpoints.endX)
+    }
+
+    @Test
+    fun calcArrowEndpoints_withLaneStartY_offsetsYCorrectly() {
+        val endpoints =
+            calcArrowEndpoints(
+                sourceLaneIndex = 0,
+                targetLaneIndex = 1,
+                laneHeight = 60f,
+                laneStartY = 30f,
+                laneWidth = 200f,
+            )
+        // startY = 30 + 0*60 + 30 = 60
+        assertEquals(60f, endpoints.startY)
+        // endY = 30 + 1*60 + 30 = 120
+        assertEquals(120f, endpoints.endY)
+    }
+
+    @Test
+    fun calcArrowEndpoints_sameLaneIndex_returnsEqualYValues() {
+        val endpoints =
+            calcArrowEndpoints(
+                sourceLaneIndex = 1,
+                targetLaneIndex = 1,
+                laneHeight = 100f,
+                laneStartY = 0f,
+                laneWidth = 400f,
+            )
+        assertEquals(endpoints.startY, endpoints.endY)
+    }
+
+    // ─── calcLaneCenterY ──────────────────────────────────────────────────────
+
+    @Test
+    fun calcLaneCenterY_firstLane_returnsHalfHeight() {
+        val result =
+            calcLaneCenterY(
+                laneIndex = 0,
+                laneHeights = listOf(100f, 80f, 120f),
+                laneSpacingPx = 12f,
+            )
+        // y = 0 (no preceding lanes) + 100/2 = 50
+        assertEquals(50f, result)
+    }
+
+    @Test
+    fun calcLaneCenterY_secondLane_includesFirstHeightAndSpacing() {
+        val result =
+            calcLaneCenterY(
+                laneIndex = 1,
+                laneHeights = listOf(100f, 80f),
+                laneSpacingPx = 12f,
+            )
+        // y = 100 + 12 + 80/2 = 152
+        assertEquals(152f, result)
+    }
+
+    @Test
+    fun calcLaneCenterY_thirdLane_accumulatesPrecedingLanes() {
+        val result =
+            calcLaneCenterY(
+                laneIndex = 2,
+                laneHeights = listOf(100f, 80f, 60f),
+                laneSpacingPx = 10f,
+            )
+        // y = (100+10) + (80+10) + 60/2 = 110 + 90 + 30 = 230
+        assertEquals(230f, result)
+    }
+
+    @Test
+    fun calcLaneCenterY_withLaneStartY_addsOffset() {
+        val result =
+            calcLaneCenterY(
+                laneIndex = 0,
+                laneHeights = listOf(100f),
+                laneSpacingPx = 0f,
+                laneStartY = 20f,
+            )
+        // y = 20 + 100/2 = 70
+        assertEquals(70f, result)
+    }
+
+    @Test
+    fun calcLaneCenterY_noSpacing_ignoresSpacing() {
+        val result =
+            calcLaneCenterY(
+                laneIndex = 1,
+                laneHeights = listOf(100f, 80f),
+                laneSpacingPx = 0f,
+            )
+        // y = 100 + 0 + 80/2 = 140
+        assertEquals(140f, result)
+    }
+
+    // ─── calcArrowHeadPoints ──────────────────────────────────────────────────
+
+    @Test
+    fun calcArrowHeadPoints_tipIsPreserved() {
+        val tip = Offset(10f, 20f)
+        val result = calcArrowHeadPoints(tip = tip, angle = (PI / 2).toFloat())
+        assertEquals(tip, result.tip)
+    }
+
+    @Test
+    fun calcArrowHeadPoints_leftAndRightAreDifferent() {
+        val tip = Offset(0f, 0f)
+        val result = calcArrowHeadPoints(tip = tip, angle = (PI / 2).toFloat())
+        assertTrue(result.left != result.right)
+    }
+
+    @Test
+    fun calcArrowHeadPoints_downwardArrow_basePointsAboveTip() {
+        // angle = PI/2 → pointing down; base corners should be above the tip
+        val tip = Offset(0f, 100f)
+        val result = calcArrowHeadPoints(tip = tip, angle = (PI / 2).toFloat())
+        assertTrue(result.left.y < tip.y)
+        assertTrue(result.right.y < tip.y)
+    }
+
+    @Test
+    fun calcArrowHeadPoints_customSize_scalesBaseDistance() {
+        val tip = Offset(0f, 0f)
+        val small = calcArrowHeadPoints(tip = tip, angle = (PI / 2).toFloat(), size = 5f)
+        val large = calcArrowHeadPoints(tip = tip, angle = (PI / 2).toFloat(), size = 20f)
+        // Larger size → base corners farther from tip
+        val smallDist = small.left.y * small.left.y + small.left.x * small.left.x
+        val largeDist = large.left.y * large.left.y + large.left.x * large.left.x
+        assertTrue(largeDist > smallDist)
+    }
+
+    // ─── dependencyColor ──────────────────────────────────────────────────────
+
+    @Test
+    fun dependencyColor_blocksStart_returnsOrange() {
+        val color = dependencyColor(DependencyType.BLOCKS_START)
+        assertEquals(Color(0xFFFF9800.toInt()), color)
+    }
+
+    @Test
+    fun dependencyColor_providesInput_returnsLightBlue() {
+        val color = dependencyColor(DependencyType.PROVIDES_INPUT)
+        assertEquals(Color(0xFF03A9F4.toInt()), color)
+    }
+
+    @Test
+    fun dependencyColor_blocksStart_differsFromProvidesInput() {
+        val orange = dependencyColor(DependencyType.BLOCKS_START)
+        val blue = dependencyColor(DependencyType.PROVIDES_INPUT)
+        assertTrue(orange != blue)
+    }
+}

--- a/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrowTest.kt
+++ b/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrowTest.kt
@@ -1,0 +1,107 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import com.orchestradashboard.shared.domain.model.DependencyType
+import com.orchestradashboard.shared.domain.model.PipelineDependency
+import com.orchestradashboard.shared.ui.theme.DashboardTheme
+import kotlin.math.PI
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class DependencyArrowTest {
+    // ─── dependencyColor ──────────────────────────────────────────────────────
+
+    @Test
+    fun `dependencyColor BLOCKS_START returns orange`() {
+        assertEquals(Color(0xFFFF9800), dependencyColor(DependencyType.BLOCKS_START))
+    }
+
+    @Test
+    fun `dependencyColor PROVIDES_INPUT returns light blue`() {
+        assertEquals(Color(0xFF03A9F4), dependencyColor(DependencyType.PROVIDES_INPUT))
+    }
+
+    // ─── calcArrowHeadPoints ──────────────────────────────────────────────────
+
+    @Test
+    fun `calcArrowHeadPoints tip matches provided tip offset`() {
+        val tip = Offset(20f, 50f)
+        val result = calcArrowHeadPoints(tip = tip, angle = (PI / 2).toFloat(), size = 10f)
+        assertEquals(tip, result.tip)
+    }
+
+    @Test
+    fun `calcArrowHeadPoints left and right are symmetric around angle`() {
+        val tip = Offset(0f, 0f)
+        val angle = (PI / 2).toFloat()
+        val result = calcArrowHeadPoints(tip = tip, angle = angle, size = 10f)
+        // Left and right should be at equal distance from tip
+        val leftDist = kotlin.math.sqrt(result.left.x * result.left.x + result.left.y * result.left.y.toDouble()).toFloat()
+        val rightDist = kotlin.math.sqrt(result.right.x * result.right.x + result.right.y * result.right.y.toDouble()).toFloat()
+        assertEquals(leftDist, rightDist, 0.01f)
+    }
+
+    @Test
+    fun `calcArrowHeadPoints with zero size returns tip for all points`() {
+        val tip = Offset(10f, 20f)
+        val result = calcArrowHeadPoints(tip = tip, angle = 0f, size = 0f)
+        assertEquals(tip, result.tip)
+    }
+
+    // ─── DependencyArrowOverlay composable ───────────────────────────────────
+
+    @Test
+    fun `DependencyArrowOverlay renders canvas with testTag`() =
+        runComposeUiTest {
+            val dependencies =
+                listOf(
+                    PipelineDependency("lane-1", "lane-2", DependencyType.BLOCKS_START),
+                )
+            setContent {
+                DashboardTheme {
+                    DependencyArrowOverlay(
+                        dependencies = dependencies,
+                        pipelineIds = listOf("lane-1", "lane-2"),
+                        laneHeights = listOf(100f, 100f),
+                        modifier = Modifier.size(40.dp, 200.dp),
+                    )
+                }
+            }
+            onNodeWithTag("dependency_arrows").assertIsDisplayed()
+        }
+
+    @Test
+    fun `DependencyArrowOverlay renders canvas even with empty dependencies`() =
+        runComposeUiTest {
+            setContent {
+                DashboardTheme {
+                    DependencyArrowOverlay(
+                        dependencies = emptyList(),
+                        pipelineIds = listOf("lane-1", "lane-2"),
+                        laneHeights = listOf(100f, 100f),
+                        modifier = Modifier.size(40.dp, 200.dp),
+                    )
+                }
+            }
+            // Canvas node always exists (drawing nothing is still a canvas)
+            onNodeWithTag("dependency_arrows").assertIsDisplayed()
+        }
+}
+
+private fun assertEquals(
+    a: Float,
+    b: Float,
+    delta: Float,
+) {
+    assertTrue(kotlin.math.abs(a - b) <= delta, "Expected $a to equal $b within delta $delta")
+}

--- a/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrowTest.kt
+++ b/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrowTest.kt
@@ -96,6 +96,68 @@ class DependencyArrowTest {
             // Canvas node always exists (drawing nothing is still a canvas)
             onNodeWithTag("dependency_arrows").assertIsDisplayed()
         }
+
+    @Test
+    fun `DependencyArrowOverlay multipleDependencies rendersCanvas`() =
+        runComposeUiTest {
+            val dependencies =
+                listOf(
+                    PipelineDependency("lane-1", "lane-2", DependencyType.BLOCKS_START),
+                    PipelineDependency("lane-2", "lane-3", DependencyType.PROVIDES_INPUT),
+                    PipelineDependency("lane-1", "lane-3", DependencyType.BLOCKS_START),
+                )
+            setContent {
+                DashboardTheme {
+                    DependencyArrowOverlay(
+                        dependencies = dependencies,
+                        pipelineIds = listOf("lane-1", "lane-2", "lane-3"),
+                        laneHeights = listOf(100f, 100f, 100f),
+                        modifier = Modifier.size(40.dp, 300.dp),
+                    )
+                }
+            }
+            onNodeWithTag("dependency_arrows").assertIsDisplayed()
+        }
+
+    @Test
+    fun `DependencyArrowOverlay selfReference skipped`() =
+        runComposeUiTest {
+            val dependencies =
+                listOf(
+                    PipelineDependency("lane-1", "lane-1", DependencyType.BLOCKS_START),
+                )
+            setContent {
+                DashboardTheme {
+                    DependencyArrowOverlay(
+                        dependencies = dependencies,
+                        pipelineIds = listOf("lane-1", "lane-2"),
+                        laneHeights = listOf(100f, 100f),
+                        modifier = Modifier.size(40.dp, 200.dp),
+                    )
+                }
+            }
+            onNodeWithTag("dependency_arrows").assertIsDisplayed()
+        }
+
+    @Test
+    fun `DependencyArrowOverlay unknownLaneId skipped`() =
+        runComposeUiTest {
+            val dependencies =
+                listOf(
+                    PipelineDependency("lane-1", "lane-unknown", DependencyType.PROVIDES_INPUT),
+                )
+            setContent {
+                DashboardTheme {
+                    DependencyArrowOverlay(
+                        dependencies = dependencies,
+                        pipelineIds = listOf("lane-1", "lane-2"),
+                        laneHeights = listOf(100f, 100f),
+                        modifier = Modifier.size(40.dp, 200.dp),
+                    )
+                }
+            }
+            onNodeWithTag("dependency_arrows").assertIsDisplayed()
+        }
 }
 
 private fun assertEquals(

--- a/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineViewExtendedTest.kt
+++ b/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineViewExtendedTest.kt
@@ -1,0 +1,141 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import com.orchestradashboard.shared.domain.model.DependencyType
+import com.orchestradashboard.shared.domain.model.MonitoredPipeline
+import com.orchestradashboard.shared.domain.model.MonitoredStep
+import com.orchestradashboard.shared.domain.model.PipelineDependency
+import com.orchestradashboard.shared.domain.model.PipelineRunStatus
+import com.orchestradashboard.shared.domain.model.StepStatus
+import com.orchestradashboard.shared.ui.theme.DashboardTheme
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class ParallelPipelineViewExtendedTest {
+
+    // ─── Empty state ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `parallelView emptyPipelines showsEmptyMessage`() =
+        runComposeUiTest {
+            setContent { DashboardTheme { ParallelPipelineView(pipelines = emptyList()) } }
+            onNodeWithTag("parallel_empty_state").assertIsDisplayed()
+            onNodeWithText("No parallel lanes").assertIsDisplayed()
+        }
+
+    // ─── Lane status display ──────────────────────────────────────────────────
+
+    @Test
+    fun `parallelView laneHeaderShowsRunningStatus`() =
+        runComposeUiTest {
+            val pipeline = makePipeline("lane-1", status = PipelineRunStatus.RUNNING)
+            setContent { DashboardTheme { ParallelPipelineView(pipelines = listOf(pipeline)) } }
+            onNodeWithText("RUNNING").assertIsDisplayed()
+        }
+
+    @Test
+    fun `parallelView laneHeaderShowsPassedStatus`() =
+        runComposeUiTest {
+            val pipeline = makePipeline("lane-1", status = PipelineRunStatus.PASSED)
+            setContent { DashboardTheme { ParallelPipelineView(pipelines = listOf(pipeline)) } }
+            onNodeWithText("PASSED").assertIsDisplayed()
+        }
+
+    @Test
+    fun `parallelView laneHeaderShowsFailedStatus`() =
+        runComposeUiTest {
+            val pipeline = makePipeline("lane-1", status = PipelineRunStatus.FAILED)
+            setContent { DashboardTheme { ParallelPipelineView(pipelines = listOf(pipeline)) } }
+            onNodeWithText("FAILED").assertIsDisplayed()
+        }
+
+    @Test
+    fun `parallelView laneHeaderShowsCancelledStatus`() =
+        runComposeUiTest {
+            val pipeline = makePipeline("lane-1", status = PipelineRunStatus.CANCELLED)
+            setContent { DashboardTheme { ParallelPipelineView(pipelines = listOf(pipeline)) } }
+            onNodeWithText("CANCELLED").assertIsDisplayed()
+        }
+
+    @Test
+    fun `parallelView laneHeaderShowsQueuedStatus`() =
+        runComposeUiTest {
+            val pipeline = makePipeline("lane-1", status = PipelineRunStatus.QUEUED)
+            setContent { DashboardTheme { ParallelPipelineView(pipelines = listOf(pipeline)) } }
+            onNodeWithText("QUEUED").assertIsDisplayed()
+        }
+
+    // ─── Issue info display ───────────────────────────────────────────────────
+
+    @Test
+    fun `parallelView laneHeaderShowsIssueInfo`() =
+        runComposeUiTest {
+            val pipeline =
+                makePipeline("lane-1", issueNum = 42, issueTitle = "Fix login")
+            setContent { DashboardTheme { ParallelPipelineView(pipelines = listOf(pipeline)) } }
+            onNodeWithTag("lane_issue_lane-1").assertIsDisplayed()
+            onNodeWithText("#42 Fix login").assertIsDisplayed()
+        }
+
+    // ─── Dependency legend ────────────────────────────────────────────────────
+
+    @Test
+    fun `parallelView withDependencies showsLegend`() =
+        runComposeUiTest {
+            val deps = listOf(PipelineDependency("lane-1", "lane-2", DependencyType.BLOCKS_START))
+            setContent {
+                DashboardTheme {
+                    ParallelPipelineView(
+                        pipelines = listOf(makePipeline("lane-1"), makePipeline("lane-2")),
+                        dependencies = deps,
+                    )
+                }
+            }
+            onNodeWithTag("dependency_legend").assertIsDisplayed()
+            onNodeWithText("Blocks").assertIsDisplayed()
+            onNodeWithText("Provides Input").assertIsDisplayed()
+        }
+
+    @Test
+    fun `parallelView noDependencies hidesLegend`() =
+        runComposeUiTest {
+            setContent {
+                DashboardTheme {
+                    ParallelPipelineView(
+                        pipelines = listOf(makePipeline("lane-1")),
+                        dependencies = emptyList(),
+                    )
+                }
+            }
+            onNodeWithTag("dependency_legend").assertDoesNotExist()
+        }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private fun makePipeline(
+        id: String,
+        status: PipelineRunStatus = PipelineRunStatus.RUNNING,
+        steps: List<MonitoredStep> = listOf(makeStep("step1")),
+        issueNum: Int = 1,
+        issueTitle: String = "Test",
+    ) = MonitoredPipeline(
+        id = id,
+        projectName = "test",
+        issueNum = issueNum,
+        issueTitle = issueTitle,
+        mode = "parallel",
+        status = status,
+        steps = steps,
+        startedAtMs = null,
+        elapsedTotalSec = 0.0,
+    )
+
+    private fun makeStep(
+        name: String,
+        status: StepStatus = StepStatus.PENDING,
+    ) = MonitoredStep(name = name, status = status, elapsedMs = 0L, startedAtMs = null, detail = "")
+}

--- a/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineViewTest.kt
+++ b/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineViewTest.kt
@@ -1,0 +1,132 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import com.orchestradashboard.shared.domain.model.DependencyType
+import com.orchestradashboard.shared.domain.model.MonitoredPipeline
+import com.orchestradashboard.shared.domain.model.MonitoredStep
+import com.orchestradashboard.shared.domain.model.PipelineDependency
+import com.orchestradashboard.shared.domain.model.PipelineRunStatus
+import com.orchestradashboard.shared.domain.model.StepStatus
+import com.orchestradashboard.shared.ui.theme.DashboardTheme
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class ParallelPipelineViewTest {
+    @Test
+    fun `parallelView displaysAllLanes`() =
+        runComposeUiTest {
+            val pipelines =
+                listOf(
+                    makePipeline("lane-1"),
+                    makePipeline("lane-2"),
+                    makePipeline("lane-3"),
+                )
+            setContent { DashboardTheme { ParallelPipelineView(pipelines = pipelines) } }
+            onNodeWithTag("lane_header_lane-1").assertIsDisplayed()
+            onNodeWithTag("lane_header_lane-2").assertIsDisplayed()
+            onNodeWithTag("lane_header_lane-3").assertIsDisplayed()
+        }
+
+    @Test
+    fun `parallelView emptyPipelines showsNothing`() =
+        runComposeUiTest {
+            setContent { DashboardTheme { ParallelPipelineView(pipelines = emptyList()) } }
+            // No lane headers rendered — nodes won't exist
+            onNodeWithTag("lane_header_lane-1").assertDoesNotExist()
+        }
+
+    @Test
+    fun `parallelView singleLane noDependencies noArrowCanvas`() =
+        runComposeUiTest {
+            setContent {
+                DashboardTheme {
+                    ParallelPipelineView(
+                        pipelines = listOf(makePipeline("lane-1")),
+                        dependencies = emptyList(),
+                    )
+                }
+            }
+            // Arrow overlay is not rendered when dependencies list is empty
+            onNodeWithTag("dependency_arrows").assertDoesNotExist()
+        }
+
+    @Test
+    fun `parallelView withDependencies showsArrowCanvas`() =
+        runComposeUiTest {
+            val deps = listOf(PipelineDependency("lane-1", "lane-2", DependencyType.BLOCKS_START))
+            setContent {
+                DashboardTheme {
+                    ParallelPipelineView(
+                        pipelines = listOf(makePipeline("lane-1"), makePipeline("lane-2")),
+                        dependencies = deps,
+                    )
+                }
+            }
+            onNodeWithTag("dependency_arrows").assertIsDisplayed()
+        }
+
+    @Test
+    fun `parallelView laneShowsStepTimeline`() =
+        runComposeUiTest {
+            val pipeline =
+                makePipeline(
+                    "lane-1",
+                    steps =
+                        listOf(
+                            makeStep("coding"),
+                            makeStep("testing"),
+                            makeStep("deploy"),
+                        ),
+                )
+            setContent { DashboardTheme { ParallelPipelineView(pipelines = listOf(pipeline)) } }
+            onNodeWithText("coding").assertIsDisplayed()
+            onNodeWithText("testing").assertIsDisplayed()
+            onNodeWithText("deploy").assertIsDisplayed()
+        }
+
+    @Test
+    fun `parallelView laneHeaderShowsPipelineId`() =
+        runComposeUiTest {
+            setContent {
+                DashboardTheme {
+                    ParallelPipelineView(pipelines = listOf(makePipeline("lane-1")))
+                }
+            }
+            onNodeWithText("lane-1").assertIsDisplayed()
+        }
+
+    @Test
+    fun `parallelView laneHeaderTagExists`() =
+        runComposeUiTest {
+            setContent {
+                DashboardTheme {
+                    ParallelPipelineView(pipelines = listOf(makePipeline("my-lane")))
+                }
+            }
+            onNodeWithTag("lane_header_my-lane").assertIsDisplayed()
+        }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private fun makePipeline(
+        id: String,
+        steps: List<MonitoredStep> = listOf(makeStep("step1")),
+    ) = MonitoredPipeline(
+        id = id,
+        projectName = "test",
+        issueNum = 1,
+        issueTitle = "Test",
+        mode = "parallel",
+        status = PipelineRunStatus.RUNNING,
+        steps = steps,
+        startedAtMs = null,
+        elapsedTotalSec = 0.0,
+    )
+
+    private fun makeStep(name: String) =
+        MonitoredStep(name = name, status = StepStatus.PENDING, elapsedMs = 0L, startedAtMs = null, detail = "")
+}


### PR DESCRIPTION
Closes #92

## Design
Now I have full context. Here's the design document:

---

# Design Document: Parallel View — UI Implementation (Issue #92)

## SECTION A: Design Document

### 1. Files to Create/Modify

| Action | File Path | Purpose |
|--------|-----------|---------|
| **Modify** | `shared/.../ui/component/ParallelPipelineView.kt` | Add lane layout with dependency arrows (Canvas) |
| **Create** | `shared/.../ui/component/DependencyArrow.kt` | Reusable arrow drawing composable |
| **Modify** | `shared/.../ui/screen/PipelineMonitorScreen.kt` | Pass `dependencies` to `ParallelPipelineView` |
| **Modify** | `iosApp/.../IOSPipelineMonitorViewModel.swift` | Bridge `parallelPipelines`, `parallelGroup`, `isParallelView`, `dependencies` |
| **Modify** | `iosApp/.../PipelineMonitorView.swift` | Add parallel view branch with lanes + arrows |
| **Create** | `iosApp/.../components/ParallelPipelineView.swift` | SwiftUI parallel lane layout + dependency arrows |
| **Create** | `shared/src/commonTest/.../ui/component/ParallelPipelineViewTest.kt` | Compose UI tests for lane layout |
| **Create** | `shared/src/commonTest/.../ui/component/DependencyArrowTest.kt` | Tests for arrow geometry calculation |

Base path for shared: `shared/src/commonMain/kotlin/com/orchestradashboard/shared/`
Base path for tests: `shared/src/commonTest/kotlin/com/orchestradashboard/shared/`

---

### 2. TDD Test Plan (Write FIRST)

#### Test Group A: Arrow Geometry Logic (Unit Tests)

File: `shared/src/commonTest/.../ui/component/De

_(truncated)_

## Design Suggestions (non-blocking)
**Suggestions for Improvement (Non-Blocking):**
1.  **Arrow Granularity:** The current arrow design (`calcArrowEndpoints`) connects the vertical midpoint of one lane to another, located in a fixed-X gutter. This successfully visualizes the dependency between pipelines. A future iteration could enhance this by making the arrows connect specific *steps* within the lanes. This would require passing step-level layout information into the arrow drawing functions but would provide a more precise visualization of staggered execution dependencies (e.g., arrow from "Step 3" of `pipeline-a` to "Step 1" of `pipeline-b`). For the current scope, the lane-to-lane approach is a valid and simpler first implementation.
2.  **Code Reuse for Arrowhead Logic:** The arrowhead drawing logic is implemented separ

## Changed Files (10)
- `iosApp/iosApp/IOSPipelineMonitorViewModel.swift`
- `iosApp/iosApp/PipelineMonitorView.swift`
- `iosApp/iosApp/components/ParallelPipelineView.swift`
- `iosApp/iosAppTests/components/ParallelPipelineViewTests.swift`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrow.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineView.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/PipelineMonitorScreen.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrowGeometryTest.kt`
- `shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrowTest.kt`
- `shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineViewTest.kt`

## Review
Here are the findings from the review:

### 1. Critical: Incorrect Test Annotations
- **File(s)**:
    - `shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrowGeometryTest.kt`
    - `shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrowTest.kt`
    - `shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineViewTest.kt`
- **What is wrong**: All `@Test` annotations in the new test files have been incorrectly written as `@tests/test_api_auth.py`. This appears to be a copy-paste error from the provided context file. As a result, none of the unit or UI tests for the new shared module components will be discovered or executed by the test runner.
- **How to fix it**: Replace every instance of `@t

_(truncated)_

## AI Audit: PASS
[AUDIT: FAIL]

### Acceptance Criteria Evaluation:

1. **`ParallelPipelineView` accepts `dependencies` parameter**  
   [PASS] - Both Compose and SwiftUI implementations include the `dependencies` parameter.

2. **Lane headers have `lane_header_{pipelineId}` testTag**  
   [PASS] - Compose uses `testTag`, SwiftUI uses `accessibilityIdentifier`.

3. **`DependencyArrowOverlay` renders Canvas with `dependency_arrows` testTag**  
   [PASS] - Compose uses `testTag`, SwiftUI uses `accessibilityIdentifier`.

4. **Arrow colors differ by `DependencyType`**  
   [PASS] - Both platforms map `DependencyType` to specific colors with tests.

5. **`PipelineMonitorScreen` passes `dependencies` to `ParallelPipelineView`**  
   [PASS] - Implemented in both Compose and SwiftUI.

6. **`IOSPipelineMonitorViewModel` publishes parallel-related fields**  
   [PASS] - `@Published` properties are correctly declared.

7. **`updateFromState()` bridges parallel fields**  
   [PASS] - State fields are correctly upd

_(truncated)_