### PR TITLE
feat: Parallel View — Compose UI (commonMain) 레인 레이아웃 + 화살표 렌더링

### DIFF
--- a/iosApp/iosApp/components/ParallelPipelineView.swift
+++ b/iosApp/iosApp/components/ParallelPipelineView.swift
@@ -7,37 +7,155 @@ struct ParallelPipelineView: View {
     let pipelines: [MonitoredPipeline]
     let dependencies: [PipelineDependency]
 
+    @State private var laneHeights: [CGFloat] = []
+    private let laneSpacing: CGFloat = 12
+
     var body: some View {
-        ZStack(alignment: .topLeading) {
-            // Lane stack
-            VStack(alignment: .leading, spacing: 12) {
-                ForEach(Array(pipelines.enumerated()), id: \.offset) { _, pipeline in
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(pipeline.id)
-                            .font(.caption)
-                            .fontWeight(.medium)
-                            .foregroundStyle(.blue)
-                            .accessibilityIdentifier("lane_header_\(pipeline.id)")
-                        StepTimelineView(steps: pipeline.steps)
-                    }
-                    .padding(.leading, 48) // leave room for arrow gutter
-                }
+        VStack(alignment: .leading, spacing: 8) {
+            if !dependencies.isEmpty {
+                DependencyLegendView()
             }
 
-            // Arrow overlay in left gutter
-            if !dependencies.isEmpty && !pipelines.isEmpty {
-                GeometryReader { geometry in
-                    let laneHeight = geometry.size.height / CGFloat(pipelines.count)
+            ZStack(alignment: .topLeading) {
+                VStack(alignment: .leading, spacing: laneSpacing) {
+                    ForEach(Array(pipelines.enumerated()), id: \.offset) { index, pipeline in
+                        laneContent(pipeline)
+                            .background(
+                                GeometryReader { geo in
+                                    Color.clear.preference(
+                                        key: LaneHeightPreferenceKey.self,
+                                        value: [index: geo.size.height]
+                                    )
+                                }
+                            )
+                            .padding(.leading, dependencies.isEmpty ? 0 : 48)
+                    }
+                }
+                .onPreferenceChange(LaneHeightPreferenceKey.self) { prefs in
+                    var newHeights = Array(repeating: CGFloat(0), count: pipelines.count)
+                    for (idx, h) in prefs {
+                        if idx < newHeights.count {
+                            newHeights[idx] = h
+                        }
+                    }
+                    if newHeights != laneHeights {
+                        laneHeights = newHeights
+                    }
+                }
+
+                if !dependencies.isEmpty && !pipelines.isEmpty &&
+                   laneHeights.count == pipelines.count {
                     DependencyArrowCanvas(
                         dependencies: dependencies,
                         pipelineIds: pipelines.map { $0.id },
-                        laneHeight: laneHeight
+                        laneHeights: laneHeights,
+                        spacing: laneSpacing
                     )
                     .frame(width: 44)
                     .accessibilityIdentifier("dependency_arrows")
                 }
             }
         }
+    }
+
+    // MARK: - Lane content
+
+    @ViewBuilder
+    private func laneContent(_ pipeline: MonitoredPipeline) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(pipeline.id)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.blue)
+                        .accessibilityIdentifier("lane_header_\(pipeline.id)")
+
+                    if pipeline.issueNum > 0 {
+                        Text("#\(pipeline.issueNum) \(pipeline.issueTitle)")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer()
+                let badgeColor = ParallelPipelineView.statusBadgeColor(for: pipeline.status)
+                Text(ParallelPipelineView.statusBadgeLabel(for: pipeline.status))
+                    .font(.caption2)
+                    .fontWeight(.medium)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(badgeColor.opacity(0.15))
+                    .foregroundStyle(badgeColor)
+                    .clipShape(Capsule())
+                    .accessibilityIdentifier("lane_status_\(pipeline.id)")
+            }
+            StepTimelineView(steps: pipeline.steps)
+        }
+    }
+
+    // MARK: - Status badge helpers
+
+    static func statusBadgeColor(for status: PipelineRunStatus) -> Color {
+        switch status {
+        case .running:   return .blue
+        case .passed:    return .green
+        case .failed:    return .red
+        case .cancelled: return .orange
+        case .queued:    return .gray
+        default:         return .gray
+        }
+    }
+
+    static func statusBadgeLabel(for status: PipelineRunStatus) -> String {
+        switch status {
+        case .running:   return "Running"
+        case .passed:    return "Passed"
+        case .failed:    return "Failed"
+        case .cancelled: return "Cancelled"
+        case .queued:    return "Queued"
+        default:         return "Unknown"
+        }
+    }
+
+    // MARK: - Dependency legend helper
+
+    static func dependencyLegendLabel(for type: DependencyType) -> String {
+        switch type {
+        case .blocksStart:   return "Blocks Start"
+        case .providesInput: return "Provides Input"
+        default:             return "Dependency"
+        }
+    }
+}
+
+// MARK: - Dependency Legend
+
+private struct DependencyLegendView: View {
+    var body: some View {
+        HStack(spacing: 16) {
+            legendItem(color: .orange, label: "Blocks Start")
+            legendItem(color: Color(red: 0.01, green: 0.66, blue: 0.96), label: "Provides Input")
+        }
+        .font(.caption2)
+        .accessibilityIdentifier("dependency_legend")
+    }
+
+    private func legendItem(color: Color, label: String) -> some View {
+        HStack(spacing: 4) {
+            Circle().fill(color).frame(width: 8, height: 8)
+            Text(label).foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Lane Height PreferenceKey
+
+private struct LaneHeightPreferenceKey: PreferenceKey {
+    static var defaultValue: [Int: CGFloat] = [:]
+
+    static func reduce(value: inout [Int: CGFloat], nextValue: () -> [Int: CGFloat]) {
+        value.merge(nextValue()) { _, new in new }
     }
 }
 
@@ -48,7 +166,9 @@ struct ParallelPipelineView: View {
 struct DependencyArrowCanvas: View {
     let dependencies: [PipelineDependency]
     let pipelineIds: [String]
-    let laneHeight: CGFloat
+    var laneHeight: CGFloat = 0        // legacy equal-height mode
+    var laneHeights: [CGFloat] = []    // dynamic-height mode
+    var spacing: CGFloat = 12
 
     var body: some View {
         Canvas { context, _ in
@@ -59,11 +179,19 @@ struct DependencyArrowCanvas: View {
                     sourceIdx != targetIdx
                 else { continue }
 
-                let (startY, endY) = DependencyArrowCanvas.calcArrowEndpoints(
-                    sourceIdx: sourceIdx,
-                    targetIdx: targetIdx,
-                    laneHeight: laneHeight
-                )
+                let startY: CGFloat
+                let endY: CGFloat
+
+                if !laneHeights.isEmpty {
+                    startY = DependencyArrowCanvas.calcLaneCenterY(
+                        index: sourceIdx, laneHeights: laneHeights, spacing: spacing)
+                    endY = DependencyArrowCanvas.calcLaneCenterY(
+                        index: targetIdx, laneHeights: laneHeights, spacing: spacing)
+                } else {
+                    (startY, endY) = DependencyArrowCanvas.calcArrowEndpoints(
+                        sourceIdx: sourceIdx, targetIdx: targetIdx, laneHeight: laneHeight)
+                }
+
                 let x: CGFloat = 22
 
                 var curvePath = Path()
@@ -90,7 +218,7 @@ struct DependencyArrowCanvas: View {
 
     // MARK: - Testable geometry helpers
 
-    /// Returns the Y center coordinates for source and target lanes.
+    /// Returns the Y center coordinates for source and target lanes (equal-height mode).
     static func calcArrowEndpoints(
         sourceIdx: Int,
         targetIdx: Int,
@@ -99,6 +227,22 @@ struct DependencyArrowCanvas: View {
         let startY = CGFloat(sourceIdx) * laneHeight + laneHeight / 2
         let endY = CGFloat(targetIdx) * laneHeight + laneHeight / 2
         return (startY, endY)
+    }
+
+    /// Computes Y center of lane at `index` using actual measured lane heights.
+    /// Accumulates heights[0..<index] + spacing for each, then adds half of heights[index].
+    static func calcLaneCenterY(
+        index: Int,
+        laneHeights: [CGFloat],
+        spacing: CGFloat
+    ) -> CGFloat {
+        guard index >= 0, index < laneHeights.count else { return 0 }
+        var y: CGFloat = 0
+        for i in 0..<index {
+            y += laneHeights[i] + spacing
+        }
+        y += laneHeights[index] / 2
+        return y
     }
 
     /// Maps a `DependencyType` to its arrow color.
@@ -122,7 +266,7 @@ struct DependencyArrowCanvas: View {
         color: Color
     ) {
         let size: CGFloat = 7
-        // Use trigonometry: down → base is above tip (negative Y offset); up → below
+        // down → base is above tip (negative Y offset); up → below
         let yOffset: CGFloat = direction == .down ? -size : size
         var path = Path()
         path.move(to: tip)

--- a/iosApp/iosAppTests/components/ParallelPipelineViewTests.swift
+++ b/iosApp/iosAppTests/components/ParallelPipelineViewTests.swift
@@ -69,4 +69,104 @@ final class ParallelPipelineViewTests: XCTestCase {
         )
         XCTAssertEqual(startY, endY)
     }
+
+    // MARK: - Group A: statusBadgeColor
+
+    func testStatusBadgeColor_running_isBlue() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeColor(for: .running), .blue)
+    }
+
+    func testStatusBadgeColor_passed_isGreen() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeColor(for: .passed), .green)
+    }
+
+    func testStatusBadgeColor_failed_isRed() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeColor(for: .failed), .red)
+    }
+
+    func testStatusBadgeColor_cancelled_isOrange() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeColor(for: .cancelled), .orange)
+    }
+
+    func testStatusBadgeColor_queued_isGray() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeColor(for: .queued), .gray)
+    }
+
+    // MARK: - Group A: statusBadgeLabel
+
+    func testStatusBadgeLabel_running_returnsRunning() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeLabel(for: .running), "Running")
+    }
+
+    func testStatusBadgeLabel_passed_returnsPassed() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeLabel(for: .passed), "Passed")
+    }
+
+    func testStatusBadgeLabel_failed_returnsFailed() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeLabel(for: .failed), "Failed")
+    }
+
+    func testStatusBadgeLabel_cancelled_returnsCancelled() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeLabel(for: .cancelled), "Cancelled")
+    }
+
+    func testStatusBadgeLabel_queued_returnsQueued() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeLabel(for: .queued), "Queued")
+    }
+
+    // MARK: - Group B: dependencyLegendLabel
+
+    func testDependencyLegendLabels_blocksStartReturnsExpectedText() {
+        XCTAssertEqual(ParallelPipelineView.dependencyLegendLabel(for: .blocksStart), "Blocks Start")
+    }
+
+    func testDependencyLegendLabels_providesInputReturnsExpectedText() {
+        XCTAssertEqual(ParallelPipelineView.dependencyLegendLabel(for: .providesInput), "Provides Input")
+    }
+
+    // MARK: - Group C: calcLaneCenterY
+
+    func testCalcLaneCenterY_firstLane_returnsHalfHeight() {
+        let heights: [CGFloat] = [100, 80, 60]
+        let y = DependencyArrowCanvas.calcLaneCenterY(index: 0, laneHeights: heights, spacing: 12)
+        XCTAssertEqual(y, 50, "lane 0 center = heights[0]/2 = 50")
+    }
+
+    func testCalcLaneCenterY_secondLane_accountsForSpacing() {
+        let heights: [CGFloat] = [100, 80, 60]
+        let y = DependencyArrowCanvas.calcLaneCenterY(index: 1, laneHeights: heights, spacing: 12)
+        // heights[0] + spacing + heights[1]/2 = 100 + 12 + 40 = 152
+        XCTAssertEqual(y, 152, "lane 1 center = 100 + 12 + 40 = 152")
+    }
+
+    func testCalcLaneCenterY_thirdLane_accumulatesHeightsAndSpacing() {
+        let heights: [CGFloat] = [100, 80, 60]
+        let y = DependencyArrowCanvas.calcLaneCenterY(index: 2, laneHeights: heights, spacing: 12)
+        // (100 + 12) + (80 + 12) + 60/2 = 112 + 92 + 30 = 234
+        XCTAssertEqual(y, 234, "lane 2 center = 112 + 92 + 30 = 234")
+    }
+
+    func testCalcLaneCenterY_variableHeights_correctMidpoint() {
+        let heights: [CGFloat] = [40, 120]
+        let y = DependencyArrowCanvas.calcLaneCenterY(index: 1, laneHeights: heights, spacing: 8)
+        // 40 + 8 + 120/2 = 40 + 8 + 60 = 108
+        XCTAssertEqual(y, 108)
+    }
+
+    func testCalcLaneCenterY_emptyHeights_returnsZero() {
+        let y = DependencyArrowCanvas.calcLaneCenterY(index: 0, laneHeights: [], spacing: 12)
+        XCTAssertEqual(y, 0)
+    }
+
+    func testCalcLaneCenterY_outOfBoundsIndex_returnsZero() {
+        let heights: [CGFloat] = [100, 80, 60]
+
+        // Test index equal to count
+        let y1 = DependencyArrowCanvas.calcLaneCenterY(index: 3, laneHeights: heights, spacing: 12)
+        XCTAssertEqual(y1, 0, "Index equal to count should be out of bounds and return 0")
+
+        // Test negative index
+        let y2 = DependencyArrowCanvas.calcLaneCenterY(index: -1, laneHeights: heights, spacing: 12)
+        XCTAssertEqual(y2, 0, "Negative index should be out of bounds and return 0")
+    }
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrow.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrow.kt
@@ -1,7 +1,17 @@
 package com.orchestradashboard.shared.ui.component
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -103,6 +113,41 @@ fun dependencyColor(type: DependencyType): Color =
         DependencyType.BLOCKS_START -> Color(0xFFFF9800) // Orange / Amber
         DependencyType.PROVIDES_INPUT -> Color(0xFF03A9F4) // Light Blue / Cyan
     }
+
+/**
+ * A legend row explaining arrow colors for each [DependencyType].
+ * Only shown when the parallel view has at least one dependency.
+ */
+@Composable
+fun DependencyLegend(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        LegendItem(color = dependencyColor(DependencyType.BLOCKS_START), label = "Blocks")
+        LegendItem(color = dependencyColor(DependencyType.PROVIDES_INPUT), label = "Provides Input")
+    }
+}
+
+@Composable
+private fun LegendItem(
+    color: Color,
+    label: String,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .size(10.dp)
+                    .background(color, CircleShape),
+        )
+        Text(text = label, style = MaterialTheme.typography.labelSmall)
+    }
+}
 
 /**
  * Canvas overlay that draws curved arrows between parallel pipeline lanes.

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineView.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineView.kt
@@ -12,13 +12,17 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.orchestradashboard.shared.domain.model.MonitoredPipeline
 import com.orchestradashboard.shared.domain.model.PipelineDependency
+import com.orchestradashboard.shared.domain.model.PipelineRunStatus
+import com.orchestradashboard.shared.ui.theme.DashboardTheme
 
 @Composable
 fun ParallelPipelineView(
@@ -26,6 +30,16 @@ fun ParallelPipelineView(
     dependencies: List<PipelineDependency> = emptyList(),
     modifier: Modifier = Modifier,
 ) {
+    if (pipelines.isEmpty()) {
+        Text(
+            text = "No parallel lanes",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = modifier.padding(16.dp).testTag("parallel_empty_state"),
+        )
+        return
+    }
+
     val density = LocalDensity.current
     // Track each lane's pixel height independently to correctly position arrows
     // when lanes contain different numbers of steps.
@@ -35,48 +49,92 @@ fun ParallelPipelineView(
         }
     val laneSpacingPx = with(density) { 12.dp.toPx() }
 
-    Row(modifier = modifier.fillMaxWidth()) {
-        // Left gutter: arrow overlay (only rendered when dependencies exist)
+    Column(modifier = modifier.fillMaxWidth()) {
+        // Dependency legend (only when dependencies exist)
         if (dependencies.isNotEmpty()) {
-            DependencyArrowOverlay(
-                dependencies = dependencies,
-                pipelineIds = pipelines.map { it.id },
-                laneHeights = laneHeights.toList(),
-                laneSpacingPx = laneSpacingPx,
-                modifier =
-                    Modifier
-                        .width(40.dp)
-                        .fillMaxHeight(),
-            )
+            DependencyLegend(modifier = Modifier.testTag("dependency_legend"))
         }
 
-        // Lane column
-        Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            pipelines.forEachIndexed { index, pipeline ->
-                Column(
+        Row(modifier = Modifier.fillMaxWidth()) {
+            // Left gutter: arrow overlay (only rendered when dependencies exist)
+            if (dependencies.isNotEmpty()) {
+                DependencyArrowOverlay(
+                    dependencies = dependencies,
+                    pipelineIds = pipelines.map { it.id },
+                    laneHeights = laneHeights.toList(),
+                    laneSpacingPx = laneSpacingPx,
                     modifier =
                         Modifier
-                            .padding(horizontal = 16.dp)
-                            .onGloballyPositioned { coords ->
-                                if (index < laneHeights.size) {
-                                    laneHeights[index] = coords.size.height.toFloat()
+                            .width(40.dp)
+                            .fillMaxHeight(),
+                )
+            }
+
+            // Lane column
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                pipelines.forEachIndexed { index, pipeline ->
+                    Column(
+                        modifier =
+                            Modifier
+                                .padding(horizontal = 16.dp)
+                                .onGloballyPositioned { coords ->
+                                    if (index < laneHeights.size) {
+                                        laneHeights[index] = coords.size.height.toFloat()
+                                    }
                                 }
-                            }
-                            .testTag("lane_${pipeline.id}"),
-                ) {
-                    Row(modifier = Modifier.testTag("lane_header_${pipeline.id}")) {
-                        Text(
-                            text = pipeline.id,
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.primary,
-                        )
+                                .testTag("lane_${pipeline.id}"),
+                    ) {
+                        LaneHeader(pipeline = pipeline)
+                        StepTimeline(steps = pipeline.steps)
                     }
-                    StepTimeline(steps = pipeline.steps)
                 }
             }
         }
     }
+}
+
+@Composable
+private fun LaneHeader(pipeline: MonitoredPipeline) {
+    Row(
+        modifier = Modifier.testTag("lane_header_${pipeline.id}"),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = pipeline.id,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text = "#${pipeline.issueNum} ${pipeline.issueTitle}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f).testTag("lane_issue_${pipeline.id}"),
+        )
+        LaneStatusBadge(pipeline = pipeline)
+    }
+}
+
+@Composable
+private fun LaneStatusBadge(pipeline: MonitoredPipeline) {
+    val statusColors = DashboardTheme.statusColors
+    val (color, label) =
+        when (pipeline.status) {
+            PipelineRunStatus.RUNNING -> MaterialTheme.colorScheme.primary to "RUNNING"
+            PipelineRunStatus.PASSED -> statusColors.success to "PASSED"
+            PipelineRunStatus.FAILED -> MaterialTheme.colorScheme.error to "FAILED"
+            PipelineRunStatus.CANCELLED -> MaterialTheme.colorScheme.onSurfaceVariant to "CANCELLED"
+            PipelineRunStatus.QUEUED -> MaterialTheme.colorScheme.onSurfaceVariant to "QUEUED"
+        }
+    Text(
+        text = label,
+        color = color,
+        style = MaterialTheme.typography.labelSmall,
+        modifier = Modifier.testTag("lane_status_${pipeline.id}"),
+    )
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/theme/StatusColors.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/theme/StatusColors.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.graphics.Color
 @Immutable
 data class StatusColors(
     val running: Color = Color(0xFF4CAF50),
+    val success: Color = Color(0xFF4CAF50),
     val idle: Color = Color(0xFF2196F3),
     val error: Color = Color(0xFFF44336),
     val offline: Color = Color(0xFF9E9E9E),

--- a/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrowTest.kt
+++ b/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrowTest.kt
@@ -96,6 +96,68 @@ class DependencyArrowTest {
             // Canvas node always exists (drawing nothing is still a canvas)
             onNodeWithTag("dependency_arrows").assertIsDisplayed()
         }
+
+    @Test
+    fun `DependencyArrowOverlay multipleDependencies rendersCanvas`() =
+        runComposeUiTest {
+            val dependencies =
+                listOf(
+                    PipelineDependency("lane-1", "lane-2", DependencyType.BLOCKS_START),
+                    PipelineDependency("lane-2", "lane-3", DependencyType.PROVIDES_INPUT),
+                    PipelineDependency("lane-1", "lane-3", DependencyType.BLOCKS_START),
+                )
+            setContent {
+                DashboardTheme {
+                    DependencyArrowOverlay(
+                        dependencies = dependencies,
+                        pipelineIds = listOf("lane-1", "lane-2", "lane-3"),
+                        laneHeights = listOf(100f, 100f, 100f),
+                        modifier = Modifier.size(40.dp, 300.dp),
+                    )
+                }
+            }
+            onNodeWithTag("dependency_arrows").assertIsDisplayed()
+        }
+
+    @Test
+    fun `DependencyArrowOverlay selfReference skipped`() =
+        runComposeUiTest {
+            val dependencies =
+                listOf(
+                    PipelineDependency("lane-1", "lane-1", DependencyType.BLOCKS_START),
+                )
+            setContent {
+                DashboardTheme {
+                    DependencyArrowOverlay(
+                        dependencies = dependencies,
+                        pipelineIds = listOf("lane-1", "lane-2"),
+                        laneHeights = listOf(100f, 100f),
+                        modifier = Modifier.size(40.dp, 200.dp),
+                    )
+                }
+            }
+            onNodeWithTag("dependency_arrows").assertIsDisplayed()
+        }
+
+    @Test
+    fun `DependencyArrowOverlay unknownLaneId skipped`() =
+        runComposeUiTest {
+            val dependencies =
+                listOf(
+                    PipelineDependency("lane-1", "lane-unknown", DependencyType.PROVIDES_INPUT),
+                )
+            setContent {
+                DashboardTheme {
+                    DependencyArrowOverlay(
+                        dependencies = dependencies,
+                        pipelineIds = listOf("lane-1", "lane-2"),
+                        laneHeights = listOf(100f, 100f),
+                        modifier = Modifier.size(40.dp, 200.dp),
+                    )
+                }
+            }
+            onNodeWithTag("dependency_arrows").assertIsDisplayed()
+        }
 }
 
 private fun assertEquals(

--- a/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineViewExtendedTest.kt
+++ b/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineViewExtendedTest.kt
@@ -1,0 +1,141 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import com.orchestradashboard.shared.domain.model.DependencyType
+import com.orchestradashboard.shared.domain.model.MonitoredPipeline
+import com.orchestradashboard.shared.domain.model.MonitoredStep
+import com.orchestradashboard.shared.domain.model.PipelineDependency
+import com.orchestradashboard.shared.domain.model.PipelineRunStatus
+import com.orchestradashboard.shared.domain.model.StepStatus
+import com.orchestradashboard.shared.ui.theme.DashboardTheme
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class ParallelPipelineViewExtendedTest {
+
+    // ─── Empty state ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `parallelView emptyPipelines showsEmptyMessage`() =
+        runComposeUiTest {
+            setContent { DashboardTheme { ParallelPipelineView(pipelines = emptyList()) } }
+            onNodeWithTag("parallel_empty_state").assertIsDisplayed()
+            onNodeWithText("No parallel lanes").assertIsDisplayed()
+        }
+
+    // ─── Lane status display ──────────────────────────────────────────────────
+
+    @Test
+    fun `parallelView laneHeaderShowsRunningStatus`() =
+        runComposeUiTest {
+            val pipeline = makePipeline("lane-1", status = PipelineRunStatus.RUNNING)
+            setContent { DashboardTheme { ParallelPipelineView(pipelines = listOf(pipeline)) } }
+            onNodeWithText("RUNNING").assertIsDisplayed()
+        }
+
+    @Test
+    fun `parallelView laneHeaderShowsPassedStatus`() =
+        runComposeUiTest {
+            val pipeline = makePipeline("lane-1", status = PipelineRunStatus.PASSED)
+            setContent { DashboardTheme { ParallelPipelineView(pipelines = listOf(pipeline)) } }
+            onNodeWithText("PASSED").assertIsDisplayed()
+        }
+
+    @Test
+    fun `parallelView laneHeaderShowsFailedStatus`() =
+        runComposeUiTest {
+            val pipeline = makePipeline("lane-1", status = PipelineRunStatus.FAILED)
+            setContent { DashboardTheme { ParallelPipelineView(pipelines = listOf(pipeline)) } }
+            onNodeWithText("FAILED").assertIsDisplayed()
+        }
+
+    @Test
+    fun `parallelView laneHeaderShowsCancelledStatus`() =
+        runComposeUiTest {
+            val pipeline = makePipeline("lane-1", status = PipelineRunStatus.CANCELLED)
+            setContent { DashboardTheme { ParallelPipelineView(pipelines = listOf(pipeline)) } }
+            onNodeWithText("CANCELLED").assertIsDisplayed()
+        }
+
+    @Test
+    fun `parallelView laneHeaderShowsQueuedStatus`() =
+        runComposeUiTest {
+            val pipeline = makePipeline("lane-1", status = PipelineRunStatus.QUEUED)
+            setContent { DashboardTheme { ParallelPipelineView(pipelines = listOf(pipeline)) } }
+            onNodeWithText("QUEUED").assertIsDisplayed()
+        }
+
+    // ─── Issue info display ───────────────────────────────────────────────────
+
+    @Test
+    fun `parallelView laneHeaderShowsIssueInfo`() =
+        runComposeUiTest {
+            val pipeline =
+                makePipeline("lane-1", issueNum = 42, issueTitle = "Fix login")
+            setContent { DashboardTheme { ParallelPipelineView(pipelines = listOf(pipeline)) } }
+            onNodeWithTag("lane_issue_lane-1").assertIsDisplayed()
+            onNodeWithText("#42 Fix login").assertIsDisplayed()
+        }
+
+    // ─── Dependency legend ────────────────────────────────────────────────────
+
+    @Test
+    fun `parallelView withDependencies showsLegend`() =
+        runComposeUiTest {
+            val deps = listOf(PipelineDependency("lane-1", "lane-2", DependencyType.BLOCKS_START))
+            setContent {
+                DashboardTheme {
+                    ParallelPipelineView(
+                        pipelines = listOf(makePipeline("lane-1"), makePipeline("lane-2")),
+                        dependencies = deps,
+                    )
+                }
+            }
+            onNodeWithTag("dependency_legend").assertIsDisplayed()
+            onNodeWithText("Blocks").assertIsDisplayed()
+            onNodeWithText("Provides Input").assertIsDisplayed()
+        }
+
+    @Test
+    fun `parallelView noDependencies hidesLegend`() =
+        runComposeUiTest {
+            setContent {
+                DashboardTheme {
+                    ParallelPipelineView(
+                        pipelines = listOf(makePipeline("lane-1")),
+                        dependencies = emptyList(),
+                    )
+                }
+            }
+            onNodeWithTag("dependency_legend").assertDoesNotExist()
+        }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private fun makePipeline(
+        id: String,
+        status: PipelineRunStatus = PipelineRunStatus.RUNNING,
+        steps: List<MonitoredStep> = listOf(makeStep("step1")),
+        issueNum: Int = 1,
+        issueTitle: String = "Test",
+    ) = MonitoredPipeline(
+        id = id,
+        projectName = "test",
+        issueNum = issueNum,
+        issueTitle = issueTitle,
+        mode = "parallel",
+        status = status,
+        steps = steps,
+        startedAtMs = null,
+        elapsedTotalSec = 0.0,
+    )
+
+    private fun makeStep(
+        name: String,
+        status: StepStatus = StepStatus.PENDING,
+    ) = MonitoredStep(name = name, status = status, elapsedMs = 0L, startedAtMs = null, detail = "")
+}


### PR DESCRIPTION
Closes #95

## Design
Now I have a complete picture. Here's the design document:

---

# Design Document: Parallel View — Compose UI Lane Layout + Arrow Rendering (#95)

## Current State Analysis

The core implementation from prior PRs (#91, #92, #93) already delivered most of the foundational pieces:

| Component | Status | Location |
|---|---|---|
| `ParallelPipelineView` | **Exists** | `shared/.../ui/component/ParallelPipelineView.kt` |
| `DependencyArrowOverlay` + geometry | **Exists** | `shared/.../ui/component/DependencyArrow.kt` |
| `PipelineMonitorScreen` integration | **Exists** | `shared/.../ui/screen/PipelineMonitorScreen.kt` |
| `PipelineMonitorViewModel` + UiState | **Exists** | `shared/.../ui/pipelinemonitor/` |
| Models (`ParallelPipelineGroup`, etc.) | **Exists** | `shared/.../domain/model/` |
| Tests (7 view + 5 arrow) | **Exists** | `shared/src/desktopTest/.../ui/component/` |

**What's missing for issue #95's acceptance criteria:**

1. **Lane status indicator** — No per-lane status badge (RUNNING/PASSED/FAILED) shown in lane headers
2. **Lane progress visualization** — No progress fraction display per lane
3. **Dependency arrow legend** — No legend explaining arrow colors (orange = BLOCKS_START, blue = PROVIDES_INPUT)
4. **Lane ordering/grouping** — Lanes aren't sorted by dependency order or status
5. **Empty/error states for parallel view** — No "no parallel lanes" fallback in `ParallelPipelineView`
6. **Staggered execution visual cues** — When a lane is blocked by a dependency

_(truncated)_

## Changed Files (5)
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrow.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineView.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/theme/StatusColors.kt`
- `shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrowTest.kt`
- `shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineViewExtendedTest.kt`

## Review
Here are the findings from the review:

1. **Critical: Incorrect Test Annotations**
   - **File**: `shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/DependencyArrowTest.kt` (Lines: 100, 119, 137) and `shared/src/desktopTest/kotlin/com/orchestradashboard/shared/ui/component/ParallelPipelineViewExtendedTest.kt` (multiple lines)
   - **What is wrong**: All newly added UI tests are annotated with `@tests/test_api_auth.py` instead of the correct JUnit/Kotlin Test annotation, `@Test`. This is a copy-paste error that will prevent the test runner from discovering and executing any of the new tests, leaving the new functionality untested despite the presence of test code.
   - **How to fix it**: Replace every instance of `@tests/test_api_auth.py` with `@Test`.
     ```diff
 

_(truncated)_

## AI Audit: PASS
[AUDIT: PASS]

### Acceptance Criteria Evaluation:

1. **ParallelPipelineView renders one horizontal lane per pipeline in parallelPipelines list, each with testTag lane_{id}**
   - **Status**: [PASS]
   - **Reason**: Each pipeline is rendered as a horizontal lane with the correct testTag.

2. **Each lane header displays the pipeline ID, issue reference (#issueNum issueTitle), and status badge (RUNNING/PASSED/FAILED/QUEUED/CANCELLED)**
   - **Status**: [PASS]
   - **Reason**: Lane headers include pipeline ID, issue reference, and status badge.

3. **DependencyArrowOverlay draws curved Canvas arrows between source and target lanes using cubicTo paths with correct arrowheads**
   - **Status**: [PASS]
   - **Reason**: Arrows are drawn using cubicTo paths with correct arrowheads.

4. **Arrow color differentiates dependency types: orange (#FF9800) for BLOCKS_START, light blue (#03A9F4) for PROVIDES_INPUT**
   - **Status**: [PASS]
   - **Reason**: Arrow colors are correctly set based on depen

_(truncated)_