### PR TITLE
feat: Parallel View — SwiftUI (iOS) 레인 레이아웃 + 화살표 렌더링

### DIFF
--- a/iosApp/iosApp/components/ParallelPipelineView.swift
+++ b/iosApp/iosApp/components/ParallelPipelineView.swift
@@ -7,37 +7,155 @@ struct ParallelPipelineView: View {
     let pipelines: [MonitoredPipeline]
     let dependencies: [PipelineDependency]
 
+    @State private var laneHeights: [CGFloat] = []
+    private let laneSpacing: CGFloat = 12
+
     var body: some View {
-        ZStack(alignment: .topLeading) {
-            // Lane stack
-            VStack(alignment: .leading, spacing: 12) {
-                ForEach(Array(pipelines.enumerated()), id: \.offset) { _, pipeline in
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(pipeline.id)
-                            .font(.caption)
-                            .fontWeight(.medium)
-                            .foregroundStyle(.blue)
-                            .accessibilityIdentifier("lane_header_\(pipeline.id)")
-                        StepTimelineView(steps: pipeline.steps)
-                    }
-                    .padding(.leading, 48) // leave room for arrow gutter
-                }
+        VStack(alignment: .leading, spacing: 8) {
+            if !dependencies.isEmpty {
+                DependencyLegendView()
             }
 
-            // Arrow overlay in left gutter
-            if !dependencies.isEmpty && !pipelines.isEmpty {
-                GeometryReader { geometry in
-                    let laneHeight = geometry.size.height / CGFloat(pipelines.count)
+            ZStack(alignment: .topLeading) {
+                VStack(alignment: .leading, spacing: laneSpacing) {
+                    ForEach(Array(pipelines.enumerated()), id: \.offset) { index, pipeline in
+                        laneContent(pipeline)
+                            .background(
+                                GeometryReader { geo in
+                                    Color.clear.preference(
+                                        key: LaneHeightPreferenceKey.self,
+                                        value: [index: geo.size.height]
+                                    )
+                                }
+                            )
+                            .padding(.leading, dependencies.isEmpty ? 0 : 48)
+                    }
+                }
+                .onPreferenceChange(LaneHeightPreferenceKey.self) { prefs in
+                    var newHeights = Array(repeating: CGFloat(0), count: pipelines.count)
+                    for (idx, h) in prefs {
+                        if idx < newHeights.count {
+                            newHeights[idx] = h
+                        }
+                    }
+                    if newHeights != laneHeights {
+                        laneHeights = newHeights
+                    }
+                }
+
+                if !dependencies.isEmpty && !pipelines.isEmpty &&
+                   laneHeights.count == pipelines.count {
                     DependencyArrowCanvas(
                         dependencies: dependencies,
                         pipelineIds: pipelines.map { $0.id },
-                        laneHeight: laneHeight
+                        laneHeights: laneHeights,
+                        spacing: laneSpacing
                     )
                     .frame(width: 44)
                     .accessibilityIdentifier("dependency_arrows")
                 }
             }
         }
+    }
+
+    // MARK: - Lane content
+
+    @ViewBuilder
+    private func laneContent(_ pipeline: MonitoredPipeline) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(pipeline.id)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.blue)
+                        .accessibilityIdentifier("lane_header_\(pipeline.id)")
+
+                    if pipeline.issueNum > 0 {
+                        Text("#\(pipeline.issueNum) \(pipeline.issueTitle)")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer()
+                let badgeColor = ParallelPipelineView.statusBadgeColor(for: pipeline.status)
+                Text(ParallelPipelineView.statusBadgeLabel(for: pipeline.status))
+                    .font(.caption2)
+                    .fontWeight(.medium)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(badgeColor.opacity(0.15))
+                    .foregroundStyle(badgeColor)
+                    .clipShape(Capsule())
+                    .accessibilityIdentifier("lane_status_\(pipeline.id)")
+            }
+            StepTimelineView(steps: pipeline.steps)
+        }
+    }
+
+    // MARK: - Status badge helpers
+
+    static func statusBadgeColor(for status: PipelineRunStatus) -> Color {
+        switch status {
+        case .running:   return .blue
+        case .passed:    return .green
+        case .failed:    return .red
+        case .cancelled: return .orange
+        case .queued:    return .gray
+        default:         return .gray
+        }
+    }
+
+    static func statusBadgeLabel(for status: PipelineRunStatus) -> String {
+        switch status {
+        case .running:   return "Running"
+        case .passed:    return "Passed"
+        case .failed:    return "Failed"
+        case .cancelled: return "Cancelled"
+        case .queued:    return "Queued"
+        default:         return "Unknown"
+        }
+    }
+
+    // MARK: - Dependency legend helper
+
+    static func dependencyLegendLabel(for type: DependencyType) -> String {
+        switch type {
+        case .blocksStart:   return "Blocks Start"
+        case .providesInput: return "Provides Input"
+        default:             return "Dependency"
+        }
+    }
+}
+
+// MARK: - Dependency Legend
+
+private struct DependencyLegendView: View {
+    var body: some View {
+        HStack(spacing: 16) {
+            legendItem(color: .orange, label: "Blocks Start")
+            legendItem(color: Color(red: 0.01, green: 0.66, blue: 0.96), label: "Provides Input")
+        }
+        .font(.caption2)
+        .accessibilityIdentifier("dependency_legend")
+    }
+
+    private func legendItem(color: Color, label: String) -> some View {
+        HStack(spacing: 4) {
+            Circle().fill(color).frame(width: 8, height: 8)
+            Text(label).foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Lane Height PreferenceKey
+
+private struct LaneHeightPreferenceKey: PreferenceKey {
+    static var defaultValue: [Int: CGFloat] = [:]
+
+    static func reduce(value: inout [Int: CGFloat], nextValue: () -> [Int: CGFloat]) {
+        value.merge(nextValue()) { _, new in new }
     }
 }
 
@@ -48,7 +166,9 @@ struct ParallelPipelineView: View {
 struct DependencyArrowCanvas: View {
     let dependencies: [PipelineDependency]
     let pipelineIds: [String]
-    let laneHeight: CGFloat
+    var laneHeight: CGFloat = 0        // legacy equal-height mode
+    var laneHeights: [CGFloat] = []    // dynamic-height mode
+    var spacing: CGFloat = 12
 
     var body: some View {
         Canvas { context, _ in
@@ -59,11 +179,19 @@ struct DependencyArrowCanvas: View {
                     sourceIdx != targetIdx
                 else { continue }
 
-                let (startY, endY) = DependencyArrowCanvas.calcArrowEndpoints(
-                    sourceIdx: sourceIdx,
-                    targetIdx: targetIdx,
-                    laneHeight: laneHeight
-                )
+                let startY: CGFloat
+                let endY: CGFloat
+
+                if !laneHeights.isEmpty {
+                    startY = DependencyArrowCanvas.calcLaneCenterY(
+                        index: sourceIdx, laneHeights: laneHeights, spacing: spacing)
+                    endY = DependencyArrowCanvas.calcLaneCenterY(
+                        index: targetIdx, laneHeights: laneHeights, spacing: spacing)
+                } else {
+                    (startY, endY) = DependencyArrowCanvas.calcArrowEndpoints(
+                        sourceIdx: sourceIdx, targetIdx: targetIdx, laneHeight: laneHeight)
+                }
+
                 let x: CGFloat = 22
 
                 var curvePath = Path()
@@ -90,7 +218,7 @@ struct DependencyArrowCanvas: View {
 
     // MARK: - Testable geometry helpers
 
-    /// Returns the Y center coordinates for source and target lanes.
+    /// Returns the Y center coordinates for source and target lanes (equal-height mode).
     static func calcArrowEndpoints(
         sourceIdx: Int,
         targetIdx: Int,
@@ -99,6 +227,22 @@ struct DependencyArrowCanvas: View {
         let startY = CGFloat(sourceIdx) * laneHeight + laneHeight / 2
         let endY = CGFloat(targetIdx) * laneHeight + laneHeight / 2
         return (startY, endY)
+    }
+
+    /// Computes Y center of lane at `index` using actual measured lane heights.
+    /// Accumulates heights[0..<index] + spacing for each, then adds half of heights[index].
+    static func calcLaneCenterY(
+        index: Int,
+        laneHeights: [CGFloat],
+        spacing: CGFloat
+    ) -> CGFloat {
+        guard index >= 0, index < laneHeights.count else { return 0 }
+        var y: CGFloat = 0
+        for i in 0..<index {
+            y += laneHeights[i] + spacing
+        }
+        y += laneHeights[index] / 2
+        return y
     }
 
     /// Maps a `DependencyType` to its arrow color.
@@ -122,7 +266,7 @@ struct DependencyArrowCanvas: View {
         color: Color
     ) {
         let size: CGFloat = 7
-        // Use trigonometry: down → base is above tip (negative Y offset); up → below
+        // down → base is above tip (negative Y offset); up → below
         let yOffset: CGFloat = direction == .down ? -size : size
         var path = Path()
         path.move(to: tip)

--- a/iosApp/iosAppTests/components/ParallelPipelineViewTests.swift
+++ b/iosApp/iosAppTests/components/ParallelPipelineViewTests.swift
@@ -69,4 +69,104 @@ final class ParallelPipelineViewTests: XCTestCase {
         )
         XCTAssertEqual(startY, endY)
     }
+
+    // MARK: - Group A: statusBadgeColor
+
+    func testStatusBadgeColor_running_isBlue() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeColor(for: .running), .blue)
+    }
+
+    func testStatusBadgeColor_passed_isGreen() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeColor(for: .passed), .green)
+    }
+
+    func testStatusBadgeColor_failed_isRed() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeColor(for: .failed), .red)
+    }
+
+    func testStatusBadgeColor_cancelled_isOrange() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeColor(for: .cancelled), .orange)
+    }
+
+    func testStatusBadgeColor_queued_isGray() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeColor(for: .queued), .gray)
+    }
+
+    // MARK: - Group A: statusBadgeLabel
+
+    func testStatusBadgeLabel_running_returnsRunning() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeLabel(for: .running), "Running")
+    }
+
+    func testStatusBadgeLabel_passed_returnsPassed() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeLabel(for: .passed), "Passed")
+    }
+
+    func testStatusBadgeLabel_failed_returnsFailed() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeLabel(for: .failed), "Failed")
+    }
+
+    func testStatusBadgeLabel_cancelled_returnsCancelled() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeLabel(for: .cancelled), "Cancelled")
+    }
+
+    func testStatusBadgeLabel_queued_returnsQueued() {
+        XCTAssertEqual(ParallelPipelineView.statusBadgeLabel(for: .queued), "Queued")
+    }
+
+    // MARK: - Group B: dependencyLegendLabel
+
+    func testDependencyLegendLabels_blocksStartReturnsExpectedText() {
+        XCTAssertEqual(ParallelPipelineView.dependencyLegendLabel(for: .blocksStart), "Blocks Start")
+    }
+
+    func testDependencyLegendLabels_providesInputReturnsExpectedText() {
+        XCTAssertEqual(ParallelPipelineView.dependencyLegendLabel(for: .providesInput), "Provides Input")
+    }
+
+    // MARK: - Group C: calcLaneCenterY
+
+    func testCalcLaneCenterY_firstLane_returnsHalfHeight() {
+        let heights: [CGFloat] = [100, 80, 60]
+        let y = DependencyArrowCanvas.calcLaneCenterY(index: 0, laneHeights: heights, spacing: 12)
+        XCTAssertEqual(y, 50, "lane 0 center = heights[0]/2 = 50")
+    }
+
+    func testCalcLaneCenterY_secondLane_accountsForSpacing() {
+        let heights: [CGFloat] = [100, 80, 60]
+        let y = DependencyArrowCanvas.calcLaneCenterY(index: 1, laneHeights: heights, spacing: 12)
+        // heights[0] + spacing + heights[1]/2 = 100 + 12 + 40 = 152
+        XCTAssertEqual(y, 152, "lane 1 center = 100 + 12 + 40 = 152")
+    }
+
+    func testCalcLaneCenterY_thirdLane_accumulatesHeightsAndSpacing() {
+        let heights: [CGFloat] = [100, 80, 60]
+        let y = DependencyArrowCanvas.calcLaneCenterY(index: 2, laneHeights: heights, spacing: 12)
+        // (100 + 12) + (80 + 12) + 60/2 = 112 + 92 + 30 = 234
+        XCTAssertEqual(y, 234, "lane 2 center = 112 + 92 + 30 = 234")
+    }
+
+    func testCalcLaneCenterY_variableHeights_correctMidpoint() {
+        let heights: [CGFloat] = [40, 120]
+        let y = DependencyArrowCanvas.calcLaneCenterY(index: 1, laneHeights: heights, spacing: 8)
+        // 40 + 8 + 120/2 = 40 + 8 + 60 = 108
+        XCTAssertEqual(y, 108)
+    }
+
+    func testCalcLaneCenterY_emptyHeights_returnsZero() {
+        let y = DependencyArrowCanvas.calcLaneCenterY(index: 0, laneHeights: [], spacing: 12)
+        XCTAssertEqual(y, 0)
+    }
+
+    func testCalcLaneCenterY_outOfBoundsIndex_returnsZero() {
+        let heights: [CGFloat] = [100, 80, 60]
+
+        // Test index equal to count
+        let y1 = DependencyArrowCanvas.calcLaneCenterY(index: 3, laneHeights: heights, spacing: 12)
+        XCTAssertEqual(y1, 0, "Index equal to count should be out of bounds and return 0")
+
+        // Test negative index
+        let y2 = DependencyArrowCanvas.calcLaneCenterY(index: -1, laneHeights: heights, spacing: 12)
+        XCTAssertEqual(y2, 0, "Negative index should be out of bounds and return 0")
+    }
 }


### PR DESCRIPTION
Closes #96

## Design
Now I have a complete picture. The iOS app already has a partial implementation — `ParallelPipelineView.swift` exists with basic lanes and arrows, and `PipelineMonitorView.swift` already integrates it. But compared to the Compose implementation, several features are missing. Let me produce the design document.

---

# Design Document — Issue #96: Parallel View SwiftUI (iOS) 레인 레이아웃 + 화살표 렌더링

## SECTION A: Design Document

### 1. Files to Create/Modify

| Action | Path | Purpose |
|--------|------|---------|
| **Modify** | `iosApp/iosApp/components/ParallelPipelineView.swift` | Enhance lane layout: add status badge, issue info, dependency legend, dynamic lane height tracking for arrow positioning |
| **Modify** | `iosApp/iosAppTests/components/ParallelPipelineViewTests.swift` | Add tests for new helpers: `statusBadgeColor`, `statusBadgeLabel`, legend visibility logic |
| **No change** | `iosApp/iosApp/IOSPipelineMonitorViewModel.swift` | Already bridges all parallel state (`parallelPipelines`, `dependencies`, `isParallelView`) |
| **No change** | `iosApp/iosApp/PipelineMonitorView.swift` | Already conditionally renders `ParallelPipelineView` when `isParallelView == true` |

### 2. TDD Test Plan (Write FIRST)

All tests go in `iosApp/iosAppTests/components/ParallelPipelineViewTests.swift`.

**Group A — Lane Status Badge (static helpers)**

```
testStatusBadgeColor_running_isBlue
testStatusBadgeColor_passed_isGreen
testStatusBadgeColor_failed_isRed
testStatusBadgeColor_cancelle

_(truncated)_

## Design Suggestions (non-blocking)
The design is sound and directly addresses the requirements of the issue. It uses standard, appropriate SwiftUI patterns (`PreferenceKey`, `GeometryReader`, `Canvas`) to achieve the dynamic layout and rendering goals. The test plan is thorough and covers the new logic. The plan for enhancing the UI and handling edge cases is well-considered.
**Suggestions:**

## Changed Files (2)
- `iosApp/iosApp/components/ParallelPipelineView.swift`
- `iosApp/iosAppTests/components/ParallelPipelineViewTests.swift`

## Review
Here are the findings from the review:

### Finding 1
- **File and line reference:** `iosApp/iosApp/components/ParallelPipelineView.swift`, Line 11
- **What is wrong:** The line `@orchestrator/state_sync.py private var laneHeights: [CGFloat] = []` uses a file path as a comment where a property wrapper is expected. This is syntactically incorrect for a property wrapper, confusing, and appears to be a copy-paste error from another context. The `laneHeights` property needs a state management wrapper to be updated correctly within a SwiftUI view.
- **How to fix it:** Replace the invalid comment with the `@State` property wrapper to properly declare `laneHeights` as a piece of mutable view state.
  ```swift
  // Before
  @orchestrator/state_sync.py private var laneHeights: [CGFloat] = []

  // 

_(truncated)_

## AI Audit: PASS
[AUDIT: PASS]

### Acceptance Criteria Evaluation:

1. **Lane Rendering**:  
   [PASS] - Each `MonitoredPipeline` is rendered as a lane with the correct accessibility identifier.

2. **Lane Header Content**:  
   [PASS] - Header displays pipeline ID, issue details (if present), and status badge.

3. **Status Badge Colors**:  
   [PASS] - All 5 statuses mapped to correct colors.

4. **Status Badge Labels**:  
   [PASS] - Correct labels verified by tests.

5. **Status Badge Tests**:  
   [PASS] - Both color and label tests are present.

6. **Dependency Arrows**:  
   [PASS] - Rendered as cubic Bézier curves in a 44pt gutter.

7. **Arrow Colors**:  
   [PASS] - Correct colors for both dependency types.

8. **Dependency Legend Visibility**:  
   [PASS] - Shown/hid based on dependencies existence.

9. **calcLaneCenterY Tests**:  
   [PASS] - Five tests covering various scenarios.

10. **Dynamic Lane Heights**:  
    [PASS] - Uses measured heights via GeometryReader.

11. **PipelineMonitorVi

_(truncated)_