### PR TITLE
feat: Command Center — Init/Plan/Discuss/Design/Shell

### DIFF
--- a/androidApp/src/main/kotlin/com/orchestradashboard/android/App.kt
+++ b/androidApp/src/main/kotlin/com/orchestradashboard/android/App.kt
@@ -39,6 +39,9 @@ class MainActivity : ComponentActivity() {
                     pipelineMonitorViewModelFactory = { pipelineId ->
                         AppContainer.createPipelineMonitorViewModel(pipelineId)
                     },
+                    commandCenterViewModelFactory = {
+                        AppContainer.createCommandCenterViewModel()
+                    },
                 )
             }
         }

--- a/androidApp/src/main/kotlin/com/orchestradashboard/android/di/AppContainer.kt
+++ b/androidApp/src/main/kotlin/com/orchestradashboard/android/di/AppContainer.kt
@@ -6,6 +6,7 @@ import com.orchestradashboard.shared.data.mapper.ActivePipelineMapper
 import com.orchestradashboard.shared.data.mapper.AgentEventMapper
 import com.orchestradashboard.shared.data.mapper.AgentMapper
 import com.orchestradashboard.shared.data.mapper.CheckpointMapper
+import com.orchestradashboard.shared.data.mapper.CommandMapper
 import com.orchestradashboard.shared.data.mapper.IssueMapper
 import com.orchestradashboard.shared.data.mapper.MonitoredPipelineMapper
 import com.orchestradashboard.shared.data.mapper.PipelineHistoryMapper
@@ -16,6 +17,7 @@ import com.orchestradashboard.shared.data.network.DashboardApiClient
 import com.orchestradashboard.shared.data.repository.AgentRepositoryImpl
 import com.orchestradashboard.shared.data.repository.AndroidTokenRepository
 import com.orchestradashboard.shared.data.repository.CheckpointRepositoryImpl
+import com.orchestradashboard.shared.data.repository.CommandRepositoryImpl
 import com.orchestradashboard.shared.data.repository.EventRepositoryImpl
 import com.orchestradashboard.shared.data.repository.MetricRepositoryImpl
 import com.orchestradashboard.shared.data.repository.PipelineMonitorRepositoryImpl
@@ -26,6 +28,7 @@ import com.orchestradashboard.shared.data.repository.TokenRefreshHandler
 import com.orchestradashboard.shared.domain.model.DashboardViewModel
 import com.orchestradashboard.shared.domain.repository.AgentRepository
 import com.orchestradashboard.shared.domain.repository.CheckpointRepository
+import com.orchestradashboard.shared.domain.repository.CommandRepository
 import com.orchestradashboard.shared.domain.repository.EventRepository
 import com.orchestradashboard.shared.domain.repository.MetricRepository
 import com.orchestradashboard.shared.domain.repository.PipelineMonitorRepository
@@ -33,6 +36,9 @@ import com.orchestradashboard.shared.domain.repository.PipelineRepository
 import com.orchestradashboard.shared.domain.repository.ProjectRepository
 import com.orchestradashboard.shared.domain.repository.SystemRepository
 import com.orchestradashboard.shared.domain.repository.TokenRepository
+import com.orchestradashboard.shared.domain.usecase.DesignUseCase
+import com.orchestradashboard.shared.domain.usecase.DiscussUseCase
+import com.orchestradashboard.shared.domain.usecase.ExecuteShellUseCase
 import com.orchestradashboard.shared.domain.usecase.GetActivePipelinesUseCase
 import com.orchestradashboard.shared.domain.usecase.GetAgentUseCase
 import com.orchestradashboard.shared.domain.usecase.GetAggregatedMetricsUseCase
@@ -41,12 +47,15 @@ import com.orchestradashboard.shared.domain.usecase.GetPipelineHistoryUseCase
 import com.orchestradashboard.shared.domain.usecase.GetProjectIssuesUseCase
 import com.orchestradashboard.shared.domain.usecase.GetProjectsUseCase
 import com.orchestradashboard.shared.domain.usecase.GetSystemStatusUseCase
+import com.orchestradashboard.shared.domain.usecase.InitProjectUseCase
 import com.orchestradashboard.shared.domain.usecase.ObserveAgentsUseCase
 import com.orchestradashboard.shared.domain.usecase.ObserveEventsUseCase
 import com.orchestradashboard.shared.domain.usecase.ObservePipelineRunsUseCase
 import com.orchestradashboard.shared.domain.usecase.ObserveSystemEventsUseCase
+import com.orchestradashboard.shared.domain.usecase.PlanIssuesUseCase
 import com.orchestradashboard.shared.domain.usecase.RetryCheckpointUseCase
 import com.orchestradashboard.shared.ui.agentdetail.AgentDetailViewModel
+import com.orchestradashboard.shared.ui.commandcenter.CommandCenterViewModel
 import com.orchestradashboard.shared.ui.dashboardhome.DashboardHomeViewModel
 import com.orchestradashboard.shared.ui.pipelinemonitor.PipelineMonitorViewModel
 import com.orchestradashboard.shared.ui.projectexplorer.ProjectExplorerViewModel
@@ -130,6 +139,7 @@ object AppContainer {
     private val activePipelineMapper: ActivePipelineMapper by lazy { ActivePipelineMapper() }
     private val pipelineHistoryMapper: PipelineHistoryMapper by lazy { PipelineHistoryMapper() }
     private val monitoredPipelineMapper: MonitoredPipelineMapper by lazy { MonitoredPipelineMapper() }
+    private val commandMapper: CommandMapper by lazy { CommandMapper() }
 
     // ─── Repositories ───────────────────────────────────────────
 
@@ -168,6 +178,10 @@ object AppContainer {
             activePipelineMapper,
             pipelineHistoryMapper,
         )
+    }
+
+    private val commandRepository: CommandRepository by lazy {
+        CommandRepositoryImpl(orchestratorApiClient, commandMapper)
     }
 
     // ─── UseCases ───────────────────────────────────────────────
@@ -224,6 +238,12 @@ object AppContainer {
         ObserveSystemEventsUseCase(systemRepository)
     }
 
+    private val initProjectUseCase: InitProjectUseCase by lazy { InitProjectUseCase(commandRepository) }
+    private val planIssuesUseCase: PlanIssuesUseCase by lazy { PlanIssuesUseCase(commandRepository) }
+    private val discussUseCase: DiscussUseCase by lazy { DiscussUseCase(commandRepository) }
+    private val designUseCase: DesignUseCase by lazy { DesignUseCase(commandRepository) }
+    private val executeShellUseCase: ExecuteShellUseCase by lazy { ExecuteShellUseCase(commandRepository) }
+
     // ─── ViewModels (new instance per screen lifecycle) ─────────
 
     fun createDashboardViewModel(): DashboardViewModel =
@@ -244,5 +264,15 @@ object AppContainer {
             getActivePipelinesUseCase,
             getPipelineHistoryUseCase,
             observeSystemEventsUseCase,
+        )
+
+    fun createCommandCenterViewModel(): CommandCenterViewModel =
+        CommandCenterViewModel(
+            initProjectUseCase = initProjectUseCase,
+            planIssuesUseCase = planIssuesUseCase,
+            discussUseCase = discussUseCase,
+            designUseCase = designUseCase,
+            executeShellUseCase = executeShellUseCase,
+            getProjectsUseCase = getProjectsUseCase,
         )
 }

--- a/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/Main.kt
@@ -35,6 +35,9 @@ fun main() =
                     pipelineMonitorViewModelFactory = { pipelineId ->
                         AppContainer.createPipelineMonitorViewModel(pipelineId)
                     },
+                    commandCenterViewModelFactory = {
+                        AppContainer.createCommandCenterViewModel()
+                    },
                 )
             }
         }

--- a/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/di/AppContainer.kt
+++ b/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/di/AppContainer.kt
@@ -5,6 +5,7 @@ import com.orchestradashboard.shared.data.mapper.ActivePipelineMapper
 import com.orchestradashboard.shared.data.mapper.AgentEventMapper
 import com.orchestradashboard.shared.data.mapper.AgentMapper
 import com.orchestradashboard.shared.data.mapper.CheckpointMapper
+import com.orchestradashboard.shared.data.mapper.CommandMapper
 import com.orchestradashboard.shared.data.mapper.IssueMapper
 import com.orchestradashboard.shared.data.mapper.MonitoredPipelineMapper
 import com.orchestradashboard.shared.data.mapper.PipelineHistoryMapper
@@ -14,6 +15,7 @@ import com.orchestradashboard.shared.data.mapper.SystemStatusMapper
 import com.orchestradashboard.shared.data.network.DashboardApiClient
 import com.orchestradashboard.shared.data.repository.AgentRepositoryImpl
 import com.orchestradashboard.shared.data.repository.CheckpointRepositoryImpl
+import com.orchestradashboard.shared.data.repository.CommandRepositoryImpl
 import com.orchestradashboard.shared.data.repository.DesktopTokenRepository
 import com.orchestradashboard.shared.data.repository.EventRepositoryImpl
 import com.orchestradashboard.shared.data.repository.MetricRepositoryImpl
@@ -25,6 +27,7 @@ import com.orchestradashboard.shared.data.repository.TokenRefreshHandler
 import com.orchestradashboard.shared.domain.model.DashboardViewModel
 import com.orchestradashboard.shared.domain.repository.AgentRepository
 import com.orchestradashboard.shared.domain.repository.CheckpointRepository
+import com.orchestradashboard.shared.domain.repository.CommandRepository
 import com.orchestradashboard.shared.domain.repository.EventRepository
 import com.orchestradashboard.shared.domain.repository.MetricRepository
 import com.orchestradashboard.shared.domain.repository.PipelineMonitorRepository
@@ -32,6 +35,9 @@ import com.orchestradashboard.shared.domain.repository.PipelineRepository
 import com.orchestradashboard.shared.domain.repository.ProjectRepository
 import com.orchestradashboard.shared.domain.repository.SystemRepository
 import com.orchestradashboard.shared.domain.repository.TokenRepository
+import com.orchestradashboard.shared.domain.usecase.DesignUseCase
+import com.orchestradashboard.shared.domain.usecase.DiscussUseCase
+import com.orchestradashboard.shared.domain.usecase.ExecuteShellUseCase
 import com.orchestradashboard.shared.domain.usecase.GetActivePipelinesUseCase
 import com.orchestradashboard.shared.domain.usecase.GetAgentUseCase
 import com.orchestradashboard.shared.domain.usecase.GetAggregatedMetricsUseCase
@@ -40,12 +46,15 @@ import com.orchestradashboard.shared.domain.usecase.GetPipelineHistoryUseCase
 import com.orchestradashboard.shared.domain.usecase.GetProjectIssuesUseCase
 import com.orchestradashboard.shared.domain.usecase.GetProjectsUseCase
 import com.orchestradashboard.shared.domain.usecase.GetSystemStatusUseCase
+import com.orchestradashboard.shared.domain.usecase.InitProjectUseCase
 import com.orchestradashboard.shared.domain.usecase.ObserveAgentsUseCase
 import com.orchestradashboard.shared.domain.usecase.ObserveEventsUseCase
 import com.orchestradashboard.shared.domain.usecase.ObservePipelineRunsUseCase
 import com.orchestradashboard.shared.domain.usecase.ObserveSystemEventsUseCase
+import com.orchestradashboard.shared.domain.usecase.PlanIssuesUseCase
 import com.orchestradashboard.shared.domain.usecase.RetryCheckpointUseCase
 import com.orchestradashboard.shared.ui.agentdetail.AgentDetailViewModel
+import com.orchestradashboard.shared.ui.commandcenter.CommandCenterViewModel
 import com.orchestradashboard.shared.ui.dashboardhome.DashboardHomeViewModel
 import com.orchestradashboard.shared.ui.pipelinemonitor.PipelineMonitorViewModel
 import com.orchestradashboard.shared.ui.projectexplorer.ProjectExplorerViewModel
@@ -145,6 +154,7 @@ object AppContainer {
     private val activePipelineMapper: ActivePipelineMapper by lazy { ActivePipelineMapper() }
     private val pipelineHistoryMapper: PipelineHistoryMapper by lazy { PipelineHistoryMapper() }
     private val monitoredPipelineMapper: MonitoredPipelineMapper by lazy { MonitoredPipelineMapper() }
+    private val commandMapper: CommandMapper by lazy { CommandMapper() }
 
     // ─── Repositories ───────────────────────────────────────────
 
@@ -183,6 +193,10 @@ object AppContainer {
             activePipelineMapper,
             pipelineHistoryMapper,
         )
+    }
+
+    private val commandRepository: CommandRepository by lazy {
+        CommandRepositoryImpl(orchestratorApiClient, commandMapper)
     }
 
     // ─── UseCases ───────────────────────────────────────────────
@@ -239,6 +253,12 @@ object AppContainer {
         ObserveSystemEventsUseCase(systemRepository)
     }
 
+    private val initProjectUseCase: InitProjectUseCase by lazy { InitProjectUseCase(commandRepository) }
+    private val planIssuesUseCase: PlanIssuesUseCase by lazy { PlanIssuesUseCase(commandRepository) }
+    private val discussUseCase: DiscussUseCase by lazy { DiscussUseCase(commandRepository) }
+    private val designUseCase: DesignUseCase by lazy { DesignUseCase(commandRepository) }
+    private val executeShellUseCase: ExecuteShellUseCase by lazy { ExecuteShellUseCase(commandRepository) }
+
     // ─── ViewModels (new instance per screen lifecycle) ─────────
 
     fun createDashboardViewModel(): DashboardViewModel =
@@ -259,5 +279,15 @@ object AppContainer {
             getActivePipelinesUseCase,
             getPipelineHistoryUseCase,
             observeSystemEventsUseCase,
+        )
+
+    fun createCommandCenterViewModel(): CommandCenterViewModel =
+        CommandCenterViewModel(
+            initProjectUseCase = initProjectUseCase,
+            planIssuesUseCase = planIssuesUseCase,
+            discussUseCase = discussUseCase,
+            designUseCase = designUseCase,
+            executeShellUseCase = executeShellUseCase,
+            getProjectsUseCase = getProjectsUseCase,
         )
 }

--- a/iosApp/iosApp/CommandCenterView.swift
+++ b/iosApp/iosApp/CommandCenterView.swift
@@ -1,0 +1,373 @@
+import SwiftUI
+import Shared
+
+/// SwiftUI view for the Command Center screen.
+/// Provides tabbed access to Init, Plan, Discuss, Design, and Shell commands.
+struct CommandCenterView: View {
+    @StateObject private var viewModel = IOSCommandCenterViewModel()
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                if let error = viewModel.error {
+                    HStack {
+                        Text(error)
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                        Spacer()
+                        Button("Dismiss") { viewModel.clearError() }
+                            .font(.footnote)
+                    }
+                    .padding(.horizontal)
+                    .padding(.vertical, 8)
+                    .background(Color.red.opacity(0.1))
+                }
+
+                Picker("Tab", selection: Binding(
+                    get: { viewModel.activeTab },
+                    set: { viewModel.selectTab($0) }
+                )) {
+                    Text("Init").tag(CommandTab.iNIT)
+                    Text("Plan").tag(CommandTab.pLAN)
+                    Text("Discuss").tag(CommandTab.dISCUSS)
+                    Text("Design").tag(CommandTab.dESIGN)
+                    Text("Shell").tag(CommandTab.sHELL)
+                }
+                .pickerStyle(.segmented)
+                .padding()
+
+                ScrollView {
+                    switch viewModel.activeTab {
+                    case .iNIT:
+                        InitTabView(viewModel: viewModel)
+                    case .pLAN:
+                        PlanTabView(viewModel: viewModel)
+                    case .dISCUSS:
+                        DiscussTabView(viewModel: viewModel)
+                    case .dESIGN:
+                        DesignTabView(viewModel: viewModel)
+                    case .sHELL:
+                        ShellTabView(viewModel: viewModel)
+                    default:
+                        EmptyView()
+                    }
+                }
+            }
+            .navigationTitle("Command Center")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Back") { dismiss() }
+                }
+            }
+        }
+        .onDisappear { viewModel.onCleared() }
+        .alert("Dangerous Command", isPresented: $viewModel.showDangerDialog) {
+            Button("Cancel", role: .cancel) { viewModel.cancelDangerousCommand() }
+            Button("Execute", role: .destructive) { viewModel.confirmDangerousCommand() }
+        } message: {
+            Text("This command may be destructive: \(viewModel.pendingDangerousCommand ?? "")")
+        }
+    }
+}
+
+// MARK: - Init Tab
+
+private struct InitTabView: View {
+    @ObservedObject var viewModel: IOSCommandCenterViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            TextField("Project name", text: Binding(
+                get: { viewModel.initName },
+                set: { viewModel.updateInitName($0) }
+            ))
+            .textFieldStyle(.roundedBorder)
+
+            TextField("Description", text: Binding(
+                get: { viewModel.initDescription },
+                set: { viewModel.updateInitDescription($0) }
+            ))
+            .textFieldStyle(.roundedBorder)
+
+            Picker("Visibility", selection: Binding(
+                get: { viewModel.initVisibility },
+                set: { viewModel.updateInitVisibility($0) }
+            )) {
+                Text("Public").tag(ProjectVisibility.pUBLIC)
+                Text("Private").tag(ProjectVisibility.pRIVATE)
+            }
+            .pickerStyle(.segmented)
+
+            Button(action: { viewModel.executeInit() }) {
+                if viewModel.isInitLoading {
+                    ProgressView()
+                        .frame(maxWidth: .infinity)
+                } else {
+                    Text("Initialize Project")
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(viewModel.initName.isEmpty || viewModel.isInitLoading)
+
+            if let result = viewModel.initResult {
+                VStack(alignment: .leading, spacing: 4) {
+                    Label(result.success ? "Success" : "Failed", systemImage: result.success ? "checkmark.circle" : "xmark.circle")
+                        .foregroundStyle(result.success ? .green : .red)
+                    Text(result.message)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .padding()
+                .background(Color.secondary.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+        }
+        .padding()
+    }
+}
+
+// MARK: - Plan Tab
+
+private struct PlanTabView: View {
+    @ObservedObject var viewModel: IOSCommandCenterViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ProjectPicker(
+                projects: viewModel.projects,
+                selected: viewModel.planSelectedProject,
+                onSelect: { viewModel.selectPlanProject($0) }
+            )
+
+            Button(action: { viewModel.executePlan() }) {
+                if viewModel.isPlanLoading {
+                    ProgressView().frame(maxWidth: .infinity)
+                } else {
+                    Text("Generate Plan").frame(maxWidth: .infinity)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(viewModel.planSelectedProject == nil || viewModel.isPlanLoading)
+
+            if let result = viewModel.planResult {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Planned Issues")
+                        .font(.headline)
+                    ForEach(result.issues, id: \.title) { issue in
+                        PlannedIssueRow(issue: issue)
+                    }
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+// MARK: - Discuss Tab
+
+private struct DiscussTabView: View {
+    @ObservedObject var viewModel: IOSCommandCenterViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ProjectPicker(
+                projects: viewModel.projects,
+                selected: viewModel.discussSelectedProject,
+                onSelect: { viewModel.selectDiscussProject($0) }
+            )
+
+            TextField("What should I implement first?", text: Binding(
+                get: { viewModel.discussQuestion },
+                set: { viewModel.updateDiscussQuestion($0) }
+            ), axis: .vertical)
+            .textFieldStyle(.roundedBorder)
+            .lineLimit(3...)
+
+            Button(action: { viewModel.executeDiscuss() }) {
+                if viewModel.isDiscussLoading {
+                    ProgressView().frame(maxWidth: .infinity)
+                } else {
+                    Text("Ask").frame(maxWidth: .infinity)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(viewModel.discussSelectedProject == nil || viewModel.discussQuestion.isEmpty || viewModel.isDiscussLoading)
+
+            if let result = viewModel.discussResult {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Answer")
+                        .font(.caption)
+                        .foregroundStyle(.blue)
+                    Text(result.answer)
+                        .font(.subheadline)
+
+                    if !(result.suggestedIssues.isEmpty) {
+                        Text("Suggested Issues")
+                            .font(.caption)
+                            .foregroundStyle(.blue)
+                            .padding(.top, 4)
+                        ForEach(result.suggestedIssues, id: \.title) { issue in
+                            SuggestedIssueRow(issue: issue) {
+                                viewModel.convertSuggestedIssue(issue)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+// MARK: - Design Tab
+
+private struct DesignTabView: View {
+    @ObservedObject var viewModel: IOSCommandCenterViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ProjectPicker(
+                projects: viewModel.projects,
+                selected: viewModel.designSelectedProject,
+                onSelect: { viewModel.selectDesignProject($0) }
+            )
+
+            TextField("Figma URL", text: Binding(
+                get: { viewModel.designFigmaUrl },
+                set: { viewModel.updateDesignFigmaUrl($0) }
+            ))
+            .textFieldStyle(.roundedBorder)
+            .keyboardType(.URL)
+            .autocorrectionDisabled()
+
+            Button(action: { viewModel.executeDesign() }) {
+                if viewModel.isDesignLoading {
+                    ProgressView().frame(maxWidth: .infinity)
+                } else {
+                    Text("Generate Spec").frame(maxWidth: .infinity)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(viewModel.designSelectedProject == nil || viewModel.designFigmaUrl.isEmpty || viewModel.isDesignLoading)
+
+            if let result = viewModel.designResult {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Specification")
+                        .font(.caption)
+                        .foregroundStyle(.blue)
+                    Text(result.spec)
+                        .font(.subheadline)
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+// MARK: - Shell Tab
+
+private struct ShellTabView: View {
+    @ObservedObject var viewModel: IOSCommandCenterViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            TextField("Enter shell command", text: Binding(
+                get: { viewModel.shellCommand },
+                set: { viewModel.updateShellCommand($0) }
+            ))
+            .textFieldStyle(.roundedBorder)
+            .autocorrectionDisabled()
+            .autocapitalization(.none)
+
+            Button(action: { viewModel.executeShell() }) {
+                if viewModel.isShellLoading {
+                    ProgressView().frame(maxWidth: .infinity)
+                } else {
+                    Text("Execute").frame(maxWidth: .infinity)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(viewModel.shellCommand.isEmpty || viewModel.isShellLoading)
+
+            if let result = viewModel.shellResult {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Exit code: \(result.exitCode)")
+                        .font(.caption)
+                        .foregroundStyle(result.exitCode == 0 ? .green : .red)
+                    Text(result.output)
+                        .font(.system(.footnote, design: .monospaced))
+                }
+                .padding()
+                .background(Color.black.opacity(0.05))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+        }
+        .padding()
+    }
+}
+
+// MARK: - Shared subviews
+
+private struct ProjectPicker: View {
+    let projects: [Project]
+    let selected: Project?
+    let onSelect: (Project) -> Void
+
+    var body: some View {
+        Menu {
+            ForEach(projects, id: \.name) { project in
+                Button(project.name) { onSelect(project) }
+            }
+        } label: {
+            HStack {
+                Text(selected?.name ?? "Select project")
+                    .foregroundStyle(selected == nil ? .secondary : .primary)
+                Spacer()
+                Image(systemName: "chevron.up.chevron.down")
+                    .foregroundStyle(.secondary)
+            }
+            .padding(8)
+            .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.secondary.opacity(0.4)))
+        }
+    }
+}
+
+private struct PlannedIssueRow: View {
+    let issue: PlannedIssue
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(issue.title)
+                .font(.subheadline)
+            Text(issue.body)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct SuggestedIssueRow: View {
+    let issue: PlannedIssue
+    let onConvertToIssue: () -> Void
+
+    var body: some View {
+        HStack {
+            Text(issue.title)
+                .font(.subheadline)
+            Spacer()
+            Button("Convert to Issue", action: onConvertToIssue)
+                .font(.caption)
+                .buttonStyle(.bordered)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+#Preview {
+    CommandCenterView()
+}

--- a/iosApp/iosApp/DashboardHomeView.swift
+++ b/iosApp/iosApp/DashboardHomeView.swift
@@ -5,6 +5,7 @@ import Shared
 /// Displays system health, active pipelines, recent results, and quick actions.
 struct DashboardHomeView: View {
     @StateObject private var viewModel = IOSDashboardHomeViewModel()
+    @State private var showCommandCenter = false
 
     var body: some View {
         NavigationView {
@@ -20,7 +21,8 @@ struct DashboardHomeView: View {
 
                             QuickActionsBarView(
                                 onNewSolve: { /* navigate */ },
-                                onViewProjects: { /* navigate */ }
+                                onViewProjects: { /* navigate */ },
+                                onCommandCenter: { showCommandCenter = true }
                             )
 
                             if !viewModel.activePipelines.isEmpty {
@@ -54,6 +56,9 @@ struct DashboardHomeView: View {
                     }
                 }
             }
+        }
+        .sheet(isPresented: $showCommandCenter) {
+            CommandCenterView()
         }
         .onAppear {
             viewModel.loadInitialData()

--- a/iosApp/iosApp/IOSAppContainer.swift
+++ b/iosApp/iosApp/IOSAppContainer.swift
@@ -23,4 +23,8 @@ final class IOSAppContainer {
     func createPipelineMonitorViewModel(pipelineId: String) -> PipelineMonitorViewModel {
         fatalError("KMP framework must be linked via Gradle :shared:iosArm64Binaries")
     }
+
+    func createCommandCenterViewModel() -> CommandCenterViewModel {
+        fatalError("KMP framework must be linked via Gradle :shared:iosArm64Binaries")
+    }
 }

--- a/iosApp/iosApp/IOSCommandCenterViewModel.swift
+++ b/iosApp/iosApp/IOSCommandCenterViewModel.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Shared
+
+/// iOS-specific wrapper around the KMP CommandCenterViewModel.
+/// Bridges Kotlin coroutine StateFlow to Swift's ObservableObject/Combine.
+@MainActor
+final class IOSCommandCenterViewModel: ObservableObject {
+    @Published var activeTab: CommandTab = .iNIT
+    @Published var projects: [Project] = []
+    @Published var isLoadingProjects: Bool = false
+
+    // Init Project
+    @Published var initName: String = ""
+    @Published var initDescription: String = ""
+    @Published var initVisibility: ProjectVisibility = .pUBLIC
+    @Published var isInitLoading: Bool = false
+    @Published var initResult: CommandResult? = nil
+
+    // Plan Issues
+    @Published var planSelectedProject: Project? = nil
+    @Published var isPlanLoading: Bool = false
+    @Published var planResult: PlanIssuesResult? = nil
+
+    // Discuss
+    @Published var discussSelectedProject: Project? = nil
+    @Published var discussQuestion: String = ""
+    @Published var isDiscussLoading: Bool = false
+    @Published var discussResult: DiscussResult? = nil
+
+    // Design
+    @Published var designSelectedProject: Project? = nil
+    @Published var designFigmaUrl: String = ""
+    @Published var isDesignLoading: Bool = false
+    @Published var designResult: DesignResult? = nil
+
+    // Shell
+    @Published var shellCommand: String = ""
+    @Published var isShellLoading: Bool = false
+    @Published var shellResult: ShellResult? = nil
+    @Published var showDangerDialog: Bool = false
+    @Published var pendingDangerousCommand: String? = nil
+
+    // Common
+    @Published var error: String? = nil
+
+    private let viewModel: CommandCenterViewModel
+    private var collectTask: Task<Void, Never>?
+
+    init() {
+        let container = IOSAppContainer.shared
+        self.viewModel = container.createCommandCenterViewModel()
+        startCollecting()
+    }
+
+    private func startCollecting() {
+        collectTask?.cancel()
+        collectTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let collector = CommandCenterUiStateCollector { [weak self] state in
+                self?.updateFromState(state)
+            }
+            try? await self.viewModel.uiState.collect(collector: collector)
+        }
+    }
+
+    private func updateFromState(_ state: CommandCenterUiState) {
+        self.activeTab = state.activeTab
+        self.projects = state.projects as? [Project] ?? []
+        self.isLoadingProjects = state.isLoadingProjects
+        self.initName = state.initName
+        self.initDescription = state.initDescription
+        self.initVisibility = state.initVisibility
+        self.isInitLoading = state.isInitLoading
+        self.initResult = state.initResult
+        self.planSelectedProject = state.planSelectedProject
+        self.isPlanLoading = state.isPlanLoading
+        self.planResult = state.planResult
+        self.discussSelectedProject = state.discussSelectedProject
+        self.discussQuestion = state.discussQuestion
+        self.isDiscussLoading = state.isDiscussLoading
+        self.discussResult = state.discussResult
+        self.designSelectedProject = state.designSelectedProject
+        self.designFigmaUrl = state.designFigmaUrl
+        self.isDesignLoading = state.isDesignLoading
+        self.designResult = state.designResult
+        self.shellCommand = state.shellCommand
+        self.isShellLoading = state.isShellLoading
+        self.shellResult = state.shellResult
+        self.showDangerDialog = state.showDangerDialog
+        self.pendingDangerousCommand = state.pendingDangerousCommand
+        self.error = state.error
+    }
+
+    func selectTab(_ tab: CommandTab) { viewModel.selectTab(tab: tab) }
+
+    func updateInitName(_ name: String) { viewModel.updateInitName(name: name) }
+    func updateInitDescription(_ desc: String) { viewModel.updateInitDescription(desc: desc) }
+    func updateInitVisibility(_ vis: ProjectVisibility) { viewModel.updateInitVisibility(vis: vis) }
+    func executeInit() { viewModel.executeInit() }
+
+    func selectPlanProject(_ project: Project) { viewModel.selectPlanProject(project: project) }
+    func executePlan() { viewModel.executePlan() }
+
+    func selectDiscussProject(_ project: Project) { viewModel.selectDiscussProject(project: project) }
+    func updateDiscussQuestion(_ q: String) { viewModel.updateDiscussQuestion(q: q) }
+    func executeDiscuss() { viewModel.executeDiscuss() }
+    func convertSuggestedIssue(_ issue: PlannedIssue) { viewModel.convertSuggestedIssue(issue: issue) }
+
+    func selectDesignProject(_ project: Project) { viewModel.selectDesignProject(project: project) }
+    func updateDesignFigmaUrl(_ url: String) { viewModel.updateDesignFigmaUrl(url: url) }
+    func executeDesign() { viewModel.executeDesign() }
+
+    func updateShellCommand(_ cmd: String) { viewModel.updateShellCommand(cmd: cmd) }
+    func executeShell() { viewModel.executeShell() }
+    func confirmDangerousCommand() { viewModel.confirmDangerousCommand() }
+    func cancelDangerousCommand() { viewModel.cancelDangerousCommand() }
+
+    func clearError() { viewModel.clearError() }
+
+    func onCleared() {
+        collectTask?.cancel()
+        viewModel.onCleared()
+    }
+}
+
+private final class CommandCenterUiStateCollector: Kotlinx_coroutines_coreFlowCollector {
+    let onValue: (CommandCenterUiState) -> Void
+
+    init(onValue: @escaping (CommandCenterUiState) -> Void) {
+        self.onValue = onValue
+    }
+
+    func emit(value: Any?, completionHandler: @escaping (Error?) -> Void) {
+        if let state = value as? CommandCenterUiState {
+            onValue(state)
+        }
+        completionHandler(nil)
+    }
+}

--- a/iosApp/iosApp/components/QuickActionsBarView.swift
+++ b/iosApp/iosApp/components/QuickActionsBarView.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 
-/// Quick action buttons for "New Solve" and "View Projects".
+/// Quick action buttons for "New Solve", "View Projects", and "Command Center".
 struct QuickActionsBarView: View {
     let onNewSolve: () -> Void
     let onViewProjects: () -> Void
+    let onCommandCenter: () -> Void
 
     var body: some View {
         HStack(spacing: 12) {
@@ -15,6 +16,12 @@ struct QuickActionsBarView: View {
 
             Button(action: onViewProjects) {
                 Label("View Projects", systemImage: "folder")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+
+            Button(action: onCommandCenter) {
+                Label("Command Center", systemImage: "terminal")
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.bordered)

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/api/OrchestratorApi.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/api/OrchestratorApi.kt
@@ -1,13 +1,22 @@
 package com.orchestradashboard.shared.data.api
 
 import com.orchestradashboard.shared.data.dto.orchestrator.CheckpointDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DesignRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DesignResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DiscussRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DiscussResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.InitProjectRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.InitProjectResponseDto
 import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorIssueDto
 import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorPipelineDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ParallelPipelineGroupDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineHistoryDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PlanIssuesResponseDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ProjectDetailDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ProjectDto
+import com.orchestradashboard.shared.data.dto.orchestrator.ShellRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.ShellResponseDto
 import com.orchestradashboard.shared.data.dto.orchestrator.SystemStatusDto
 import kotlinx.coroutines.flow.Flow
 
@@ -39,4 +48,14 @@ interface OrchestratorApi {
     fun connectEvents(): Flow<PipelineEventDto>
 
     fun connectEvents(pipelineId: String): Flow<PipelineEventDto>
+
+    suspend fun postInitProject(request: InitProjectRequestDto): InitProjectResponseDto
+
+    suspend fun postPlanIssues(projectName: String): PlanIssuesResponseDto
+
+    suspend fun postDiscuss(request: DiscussRequestDto): DiscussResponseDto
+
+    suspend fun postDesign(request: DesignRequestDto): DesignResponseDto
+
+    suspend fun postShell(request: ShellRequestDto): ShellResponseDto
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/api/OrchestratorApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/api/OrchestratorApiClient.kt
@@ -1,20 +1,34 @@
 package com.orchestradashboard.shared.data.api
 
 import com.orchestradashboard.shared.data.dto.orchestrator.CheckpointDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DesignRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DesignResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DiscussRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DiscussResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.InitProjectRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.InitProjectResponseDto
 import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorIssueDto
 import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorPipelineDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ParallelPipelineGroupDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineHistoryDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PlanIssuesRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PlanIssuesResponseDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ProjectDetailDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ProjectDto
+import com.orchestradashboard.shared.data.dto.orchestrator.ShellRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.ShellResponseDto
 import com.orchestradashboard.shared.data.dto.orchestrator.SystemStatusDto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.websocket.webSocket
 import io.ktor.client.request.get
 import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.client.request.url
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
 import io.ktor.websocket.Frame
 import io.ktor.websocket.readText
 import kotlinx.coroutines.flow.Flow
@@ -89,6 +103,42 @@ class OrchestratorApiClient(
                 }
             }
         }
+
+    override suspend fun postInitProject(request: InitProjectRequestDto): InitProjectResponseDto =
+        postRequest("/api/commands/init", request)
+
+    override suspend fun postPlanIssues(projectName: String): PlanIssuesResponseDto =
+        postRequest("/api/commands/plan", PlanIssuesRequestDto(project = projectName))
+
+    override suspend fun postDiscuss(request: DiscussRequestDto): DiscussResponseDto =
+        postRequest("/api/commands/discuss", request)
+
+    override suspend fun postDesign(request: DesignRequestDto): DesignResponseDto =
+        postRequest("/api/commands/design", request)
+
+    override suspend fun postShell(request: ShellRequestDto): ShellResponseDto =
+        postRequest("/api/commands/shell", request)
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend inline fun <reified T, reified B> postRequest(path: String, body: B): T {
+        try {
+            val response =
+                httpClient.post("$baseUrl$path") {
+                    header("X-API-Key", apiKey)
+                    contentType(ContentType.Application.Json)
+                    setBody(body)
+                }
+            when (response.status.value) {
+                401 -> throw OrchestratorUnauthorizedException()
+                404 -> throw OrchestratorNotFoundException("$path not found")
+            }
+            return response.body()
+        } catch (e: OrchestratorApiException) {
+            throw e
+        } catch (e: Exception) {
+            throw OrchestratorNetworkException("Network error: ${e.message}", e)
+        }
+    }
 
     @Suppress("TooGenericExceptionCaught")
     private suspend inline fun <reified T> request(path: String): T {

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/orchestrator/CommandDto.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/orchestrator/CommandDto.kt
@@ -1,0 +1,70 @@
+package com.orchestradashboard.shared.data.dto.orchestrator
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class InitProjectRequestDto(
+    val name: String,
+    val description: String,
+    val visibility: String,
+)
+
+@Serializable
+data class InitProjectResponseDto(
+    val success: Boolean,
+    val message: String,
+    @SerialName("pipeline_id") val pipelineId: String? = null,
+)
+
+@Serializable
+data class PlanIssuesRequestDto(
+    val project: String,
+)
+
+@Serializable
+data class PlannedIssueDto(
+    val title: String,
+    val body: String,
+    val labels: List<String>,
+)
+
+@Serializable
+data class PlanIssuesResponseDto(
+    val issues: List<PlannedIssueDto>,
+)
+
+@Serializable
+data class DiscussRequestDto(
+    val project: String,
+    val question: String,
+)
+
+@Serializable
+data class DiscussResponseDto(
+    val answer: String,
+    @SerialName("suggested_issues") val suggestedIssues: List<PlannedIssueDto> = emptyList(),
+)
+
+@Serializable
+data class DesignRequestDto(
+    val project: String,
+    @SerialName("figma_url") val figmaUrl: String,
+)
+
+@Serializable
+data class DesignResponseDto(
+    val spec: String,
+    @SerialName("suggested_issues") val suggestedIssues: List<PlannedIssueDto> = emptyList(),
+)
+
+@Serializable
+data class ShellRequestDto(
+    val command: String,
+)
+
+@Serializable
+data class ShellResponseDto(
+    val output: String,
+    @SerialName("exit_code") val exitCode: Int,
+)

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/mapper/CommandMapper.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/mapper/CommandMapper.kt
@@ -8,8 +8,8 @@ import com.orchestradashboard.shared.data.dto.orchestrator.ShellResponseDto
 import com.orchestradashboard.shared.domain.model.CommandResult
 import com.orchestradashboard.shared.domain.model.DesignResult
 import com.orchestradashboard.shared.domain.model.DiscussResult
-import com.orchestradashboard.shared.domain.model.PlannedIssue
 import com.orchestradashboard.shared.domain.model.PlanIssuesResult
+import com.orchestradashboard.shared.domain.model.PlannedIssue
 import com.orchestradashboard.shared.domain.model.ShellResult
 
 class CommandMapper {

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/mapper/CommandMapper.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/mapper/CommandMapper.kt
@@ -1,0 +1,45 @@
+package com.orchestradashboard.shared.data.mapper
+
+import com.orchestradashboard.shared.data.dto.orchestrator.DesignResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DiscussResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.InitProjectResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PlanIssuesResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.ShellResponseDto
+import com.orchestradashboard.shared.domain.model.CommandResult
+import com.orchestradashboard.shared.domain.model.DesignResult
+import com.orchestradashboard.shared.domain.model.DiscussResult
+import com.orchestradashboard.shared.domain.model.PlannedIssue
+import com.orchestradashboard.shared.domain.model.PlanIssuesResult
+import com.orchestradashboard.shared.domain.model.ShellResult
+
+class CommandMapper {
+    fun mapInitResponse(dto: InitProjectResponseDto): CommandResult =
+        CommandResult(
+            success = dto.success,
+            message = dto.message,
+            pipelineId = dto.pipelineId,
+        )
+
+    fun mapPlanResponse(dto: PlanIssuesResponseDto): PlanIssuesResult =
+        PlanIssuesResult(
+            issues = dto.issues.map { PlannedIssue(it.title, it.body, it.labels) },
+        )
+
+    fun mapDiscussResponse(dto: DiscussResponseDto): DiscussResult =
+        DiscussResult(
+            answer = dto.answer,
+            suggestedIssues = dto.suggestedIssues.map { PlannedIssue(it.title, it.body, it.labels) },
+        )
+
+    fun mapDesignResponse(dto: DesignResponseDto): DesignResult =
+        DesignResult(
+            spec = dto.spec,
+            suggestedIssues = dto.suggestedIssues.map { PlannedIssue(it.title, it.body, it.labels) },
+        )
+
+    fun mapShellResponse(dto: ShellResponseDto): ShellResult =
+        ShellResult(
+            output = dto.output,
+            exitCode = dto.exitCode,
+        )
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/CommandRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/CommandRepositoryImpl.kt
@@ -1,0 +1,46 @@
+package com.orchestradashboard.shared.data.repository
+
+import com.orchestradashboard.shared.data.api.OrchestratorApi
+import com.orchestradashboard.shared.data.dto.orchestrator.DesignRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DiscussRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.InitProjectRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.ShellRequestDto
+import com.orchestradashboard.shared.data.mapper.CommandMapper
+import com.orchestradashboard.shared.domain.model.CommandResult
+import com.orchestradashboard.shared.domain.model.DesignResult
+import com.orchestradashboard.shared.domain.model.DiscussResult
+import com.orchestradashboard.shared.domain.model.InitProjectRequest
+import com.orchestradashboard.shared.domain.model.PlanIssuesResult
+import com.orchestradashboard.shared.domain.model.ShellResult
+import com.orchestradashboard.shared.domain.repository.CommandRepository
+
+class CommandRepositoryImpl(
+    private val api: OrchestratorApi,
+    private val mapper: CommandMapper,
+) : CommandRepository {
+
+    override suspend fun initProject(request: InitProjectRequest): Result<CommandResult> = runCatching {
+        val dto = InitProjectRequestDto(
+            name = request.name,
+            description = request.description,
+            visibility = request.visibility.name,
+        )
+        mapper.mapInitResponse(api.postInitProject(dto))
+    }
+
+    override suspend fun planIssues(projectName: String): Result<PlanIssuesResult> = runCatching {
+        mapper.mapPlanResponse(api.postPlanIssues(projectName))
+    }
+
+    override suspend fun discuss(projectName: String, question: String): Result<DiscussResult> = runCatching {
+        mapper.mapDiscussResponse(api.postDiscuss(DiscussRequestDto(project = projectName, question = question)))
+    }
+
+    override suspend fun design(projectName: String, figmaUrl: String): Result<DesignResult> = runCatching {
+        mapper.mapDesignResponse(api.postDesign(DesignRequestDto(project = projectName, figmaUrl = figmaUrl)))
+    }
+
+    override suspend fun executeShell(command: String): Result<ShellResult> = runCatching {
+        mapper.mapShellResponse(api.postShell(ShellRequestDto(command = command)))
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/CommandRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/CommandRepositoryImpl.kt
@@ -18,29 +18,40 @@ class CommandRepositoryImpl(
     private val api: OrchestratorApi,
     private val mapper: CommandMapper,
 ) : CommandRepository {
+    override suspend fun initProject(request: InitProjectRequest): Result<CommandResult> =
+        runCatching {
+            val dto =
+                InitProjectRequestDto(
+                    name = request.name,
+                    description = request.description,
+                    visibility = request.visibility.name,
+                )
+            mapper.mapInitResponse(api.postInitProject(dto))
+        }
 
-    override suspend fun initProject(request: InitProjectRequest): Result<CommandResult> = runCatching {
-        val dto = InitProjectRequestDto(
-            name = request.name,
-            description = request.description,
-            visibility = request.visibility.name,
-        )
-        mapper.mapInitResponse(api.postInitProject(dto))
-    }
+    override suspend fun planIssues(projectName: String): Result<PlanIssuesResult> =
+        runCatching {
+            mapper.mapPlanResponse(api.postPlanIssues(projectName))
+        }
 
-    override suspend fun planIssues(projectName: String): Result<PlanIssuesResult> = runCatching {
-        mapper.mapPlanResponse(api.postPlanIssues(projectName))
-    }
+    override suspend fun discuss(
+        projectName: String,
+        question: String,
+    ): Result<DiscussResult> =
+        runCatching {
+            mapper.mapDiscussResponse(api.postDiscuss(DiscussRequestDto(project = projectName, question = question)))
+        }
 
-    override suspend fun discuss(projectName: String, question: String): Result<DiscussResult> = runCatching {
-        mapper.mapDiscussResponse(api.postDiscuss(DiscussRequestDto(project = projectName, question = question)))
-    }
+    override suspend fun design(
+        projectName: String,
+        figmaUrl: String,
+    ): Result<DesignResult> =
+        runCatching {
+            mapper.mapDesignResponse(api.postDesign(DesignRequestDto(project = projectName, figmaUrl = figmaUrl)))
+        }
 
-    override suspend fun design(projectName: String, figmaUrl: String): Result<DesignResult> = runCatching {
-        mapper.mapDesignResponse(api.postDesign(DesignRequestDto(project = projectName, figmaUrl = figmaUrl)))
-    }
-
-    override suspend fun executeShell(command: String): Result<ShellResult> = runCatching {
-        mapper.mapShellResponse(api.postShell(ShellRequestDto(command = command)))
-    }
+    override suspend fun executeShell(command: String): Result<ShellResult> =
+        runCatching {
+            mapper.mapShellResponse(api.postShell(ShellRequestDto(command = command)))
+        }
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/CommandResult.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/CommandResult.kt
@@ -1,0 +1,42 @@
+package com.orchestradashboard.shared.domain.model
+
+enum class OrchestratorCommandType { INIT, PLAN, DISCUSS, DESIGN, SHELL }
+
+enum class ProjectVisibility { PUBLIC, PRIVATE }
+
+data class InitProjectRequest(
+    val name: String,
+    val description: String,
+    val visibility: ProjectVisibility,
+)
+
+data class CommandResult(
+    val success: Boolean,
+    val message: String,
+    val pipelineId: String? = null,
+)
+
+data class PlannedIssue(
+    val title: String,
+    val body: String,
+    val labels: List<String>,
+)
+
+data class PlanIssuesResult(
+    val issues: List<PlannedIssue>,
+)
+
+data class DiscussResult(
+    val answer: String,
+    val suggestedIssues: List<PlannedIssue> = emptyList(),
+)
+
+data class DesignResult(
+    val spec: String,
+    val suggestedIssues: List<PlannedIssue> = emptyList(),
+)
+
+data class ShellResult(
+    val output: String,
+    val exitCode: Int,
+)

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/CommandRepository.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/CommandRepository.kt
@@ -9,8 +9,18 @@ import com.orchestradashboard.shared.domain.model.ShellResult
 
 interface CommandRepository {
     suspend fun initProject(request: InitProjectRequest): Result<CommandResult>
+
     suspend fun planIssues(projectName: String): Result<PlanIssuesResult>
-    suspend fun discuss(projectName: String, question: String): Result<DiscussResult>
-    suspend fun design(projectName: String, figmaUrl: String): Result<DesignResult>
+
+    suspend fun discuss(
+        projectName: String,
+        question: String,
+    ): Result<DiscussResult>
+
+    suspend fun design(
+        projectName: String,
+        figmaUrl: String,
+    ): Result<DesignResult>
+
     suspend fun executeShell(command: String): Result<ShellResult>
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/CommandRepository.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/CommandRepository.kt
@@ -1,0 +1,16 @@
+package com.orchestradashboard.shared.domain.repository
+
+import com.orchestradashboard.shared.domain.model.CommandResult
+import com.orchestradashboard.shared.domain.model.DesignResult
+import com.orchestradashboard.shared.domain.model.DiscussResult
+import com.orchestradashboard.shared.domain.model.InitProjectRequest
+import com.orchestradashboard.shared.domain.model.PlanIssuesResult
+import com.orchestradashboard.shared.domain.model.ShellResult
+
+interface CommandRepository {
+    suspend fun initProject(request: InitProjectRequest): Result<CommandResult>
+    suspend fun planIssues(projectName: String): Result<PlanIssuesResult>
+    suspend fun discuss(projectName: String, question: String): Result<DiscussResult>
+    suspend fun design(projectName: String, figmaUrl: String): Result<DesignResult>
+    suspend fun executeShell(command: String): Result<ShellResult>
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/DesignUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/DesignUseCase.kt
@@ -4,6 +4,8 @@ import com.orchestradashboard.shared.domain.model.DesignResult
 import com.orchestradashboard.shared.domain.repository.CommandRepository
 
 class DesignUseCase(private val repository: CommandRepository) {
-    suspend operator fun invoke(projectName: String, figmaUrl: String): Result<DesignResult> =
-        repository.design(projectName, figmaUrl)
+    suspend operator fun invoke(
+        projectName: String,
+        figmaUrl: String,
+    ): Result<DesignResult> = repository.design(projectName, figmaUrl)
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/DesignUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/DesignUseCase.kt
@@ -1,0 +1,9 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.DesignResult
+import com.orchestradashboard.shared.domain.repository.CommandRepository
+
+class DesignUseCase(private val repository: CommandRepository) {
+    suspend operator fun invoke(projectName: String, figmaUrl: String): Result<DesignResult> =
+        repository.design(projectName, figmaUrl)
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/DiscussUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/DiscussUseCase.kt
@@ -4,6 +4,8 @@ import com.orchestradashboard.shared.domain.model.DiscussResult
 import com.orchestradashboard.shared.domain.repository.CommandRepository
 
 class DiscussUseCase(private val repository: CommandRepository) {
-    suspend operator fun invoke(projectName: String, question: String): Result<DiscussResult> =
-        repository.discuss(projectName, question)
+    suspend operator fun invoke(
+        projectName: String,
+        question: String,
+    ): Result<DiscussResult> = repository.discuss(projectName, question)
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/DiscussUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/DiscussUseCase.kt
@@ -1,0 +1,9 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.DiscussResult
+import com.orchestradashboard.shared.domain.repository.CommandRepository
+
+class DiscussUseCase(private val repository: CommandRepository) {
+    suspend operator fun invoke(projectName: String, question: String): Result<DiscussResult> =
+        repository.discuss(projectName, question)
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ExecuteShellUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ExecuteShellUseCase.kt
@@ -4,6 +4,5 @@ import com.orchestradashboard.shared.domain.model.ShellResult
 import com.orchestradashboard.shared.domain.repository.CommandRepository
 
 class ExecuteShellUseCase(private val repository: CommandRepository) {
-    suspend operator fun invoke(command: String): Result<ShellResult> =
-        repository.executeShell(command)
+    suspend operator fun invoke(command: String): Result<ShellResult> = repository.executeShell(command)
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ExecuteShellUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ExecuteShellUseCase.kt
@@ -1,0 +1,9 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.ShellResult
+import com.orchestradashboard.shared.domain.repository.CommandRepository
+
+class ExecuteShellUseCase(private val repository: CommandRepository) {
+    suspend operator fun invoke(command: String): Result<ShellResult> =
+        repository.executeShell(command)
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/InitProjectUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/InitProjectUseCase.kt
@@ -5,6 +5,5 @@ import com.orchestradashboard.shared.domain.model.InitProjectRequest
 import com.orchestradashboard.shared.domain.repository.CommandRepository
 
 class InitProjectUseCase(private val repository: CommandRepository) {
-    suspend operator fun invoke(request: InitProjectRequest): Result<CommandResult> =
-        repository.initProject(request)
+    suspend operator fun invoke(request: InitProjectRequest): Result<CommandResult> = repository.initProject(request)
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/InitProjectUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/InitProjectUseCase.kt
@@ -1,0 +1,10 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.CommandResult
+import com.orchestradashboard.shared.domain.model.InitProjectRequest
+import com.orchestradashboard.shared.domain.repository.CommandRepository
+
+class InitProjectUseCase(private val repository: CommandRepository) {
+    suspend operator fun invoke(request: InitProjectRequest): Result<CommandResult> =
+        repository.initProject(request)
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/PlanIssuesUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/PlanIssuesUseCase.kt
@@ -1,0 +1,9 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.PlanIssuesResult
+import com.orchestradashboard.shared.domain.repository.CommandRepository
+
+class PlanIssuesUseCase(private val repository: CommandRepository) {
+    suspend operator fun invoke(projectName: String): Result<PlanIssuesResult> =
+        repository.planIssues(projectName)
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/PlanIssuesUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/PlanIssuesUseCase.kt
@@ -4,6 +4,5 @@ import com.orchestradashboard.shared.domain.model.PlanIssuesResult
 import com.orchestradashboard.shared.domain.repository.CommandRepository
 
 class PlanIssuesUseCase(private val repository: CommandRepository) {
-    suspend operator fun invoke(projectName: String): Result<PlanIssuesResult> =
-        repository.planIssues(projectName)
+    suspend operator fun invoke(projectName: String): Result<PlanIssuesResult> = repository.planIssues(projectName)
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/commandcenter/CommandCenterUiState.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/commandcenter/CommandCenterUiState.kt
@@ -1,0 +1,53 @@
+package com.orchestradashboard.shared.ui.commandcenter
+
+import com.orchestradashboard.shared.domain.model.CommandResult
+import com.orchestradashboard.shared.domain.model.DesignResult
+import com.orchestradashboard.shared.domain.model.DiscussResult
+import com.orchestradashboard.shared.domain.model.PlannedIssue
+import com.orchestradashboard.shared.domain.model.PlanIssuesResult
+import com.orchestradashboard.shared.domain.model.Project
+import com.orchestradashboard.shared.domain.model.ProjectVisibility
+import com.orchestradashboard.shared.domain.model.ShellResult
+
+enum class CommandTab { INIT, PLAN, DISCUSS, DESIGN, SHELL }
+
+data class CommandCenterUiState(
+    val activeTab: CommandTab = CommandTab.INIT,
+    val projects: List<Project> = emptyList(),
+    val isLoadingProjects: Boolean = false,
+
+    // Init Project
+    val initName: String = "",
+    val initDescription: String = "",
+    val initVisibility: ProjectVisibility = ProjectVisibility.PUBLIC,
+    val isInitLoading: Boolean = false,
+    val initResult: CommandResult? = null,
+
+    // Plan Issues
+    val planSelectedProject: Project? = null,
+    val isPlanLoading: Boolean = false,
+    val planResult: PlanIssuesResult? = null,
+
+    // Discuss
+    val discussSelectedProject: Project? = null,
+    val discussQuestion: String = "",
+    val isDiscussLoading: Boolean = false,
+    val discussResult: DiscussResult? = null,
+
+    // Design
+    val designSelectedProject: Project? = null,
+    val designFigmaUrl: String = "",
+    val isDesignLoading: Boolean = false,
+    val designResult: DesignResult? = null,
+
+    // Shell
+    val shellCommand: String = "",
+    val isShellLoading: Boolean = false,
+    val shellResult: ShellResult? = null,
+    val showDangerDialog: Boolean = false,
+    val pendingDangerousCommand: String? = null,
+
+    // Common
+    val error: String? = null,
+    val pendingIssueConversion: PlannedIssue? = null,
+)

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/commandcenter/CommandCenterUiState.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/commandcenter/CommandCenterUiState.kt
@@ -3,8 +3,8 @@ package com.orchestradashboard.shared.ui.commandcenter
 import com.orchestradashboard.shared.domain.model.CommandResult
 import com.orchestradashboard.shared.domain.model.DesignResult
 import com.orchestradashboard.shared.domain.model.DiscussResult
-import com.orchestradashboard.shared.domain.model.PlannedIssue
 import com.orchestradashboard.shared.domain.model.PlanIssuesResult
+import com.orchestradashboard.shared.domain.model.PlannedIssue
 import com.orchestradashboard.shared.domain.model.Project
 import com.orchestradashboard.shared.domain.model.ProjectVisibility
 import com.orchestradashboard.shared.domain.model.ShellResult
@@ -15,38 +15,32 @@ data class CommandCenterUiState(
     val activeTab: CommandTab = CommandTab.INIT,
     val projects: List<Project> = emptyList(),
     val isLoadingProjects: Boolean = false,
-
     // Init Project
     val initName: String = "",
     val initDescription: String = "",
     val initVisibility: ProjectVisibility = ProjectVisibility.PUBLIC,
     val isInitLoading: Boolean = false,
     val initResult: CommandResult? = null,
-
     // Plan Issues
     val planSelectedProject: Project? = null,
     val isPlanLoading: Boolean = false,
     val planResult: PlanIssuesResult? = null,
-
     // Discuss
     val discussSelectedProject: Project? = null,
     val discussQuestion: String = "",
     val isDiscussLoading: Boolean = false,
     val discussResult: DiscussResult? = null,
-
     // Design
     val designSelectedProject: Project? = null,
     val designFigmaUrl: String = "",
     val isDesignLoading: Boolean = false,
     val designResult: DesignResult? = null,
-
     // Shell
     val shellCommand: String = "",
     val isShellLoading: Boolean = false,
     val shellResult: ShellResult? = null,
     val showDangerDialog: Boolean = false,
     val pendingDangerousCommand: String? = null,
-
     // Common
     val error: String? = null,
     val pendingIssueConversion: PlannedIssue? = null,

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/commandcenter/CommandCenterViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/commandcenter/CommandCenterViewModel.kt
@@ -106,11 +106,12 @@ class CommandCenterViewModel(
 
         viewModelScope.launch {
             _uiState.update { it.copy(isInitLoading = true, error = null) }
-            val request = InitProjectRequest(
-                name = state.initName,
-                description = state.initDescription,
-                visibility = state.initVisibility,
-            )
+            val request =
+                InitProjectRequest(
+                    name = state.initName,
+                    description = state.initDescription,
+                    visibility = state.initVisibility,
+                )
             initProjectUseCase(request).fold(
                 onSuccess = { result ->
                     _uiState.update { it.copy(isInitLoading = false, initResult = result) }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/commandcenter/CommandCenterViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/commandcenter/CommandCenterViewModel.kt
@@ -1,0 +1,230 @@
+package com.orchestradashboard.shared.ui.commandcenter
+
+import com.orchestradashboard.shared.domain.model.InitProjectRequest
+import com.orchestradashboard.shared.domain.model.PlannedIssue
+import com.orchestradashboard.shared.domain.model.Project
+import com.orchestradashboard.shared.domain.model.ProjectVisibility
+import com.orchestradashboard.shared.domain.usecase.DesignUseCase
+import com.orchestradashboard.shared.domain.usecase.DiscussUseCase
+import com.orchestradashboard.shared.domain.usecase.ExecuteShellUseCase
+import com.orchestradashboard.shared.domain.usecase.GetProjectsUseCase
+import com.orchestradashboard.shared.domain.usecase.InitProjectUseCase
+import com.orchestradashboard.shared.domain.usecase.PlanIssuesUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class CommandCenterViewModel(
+    private val initProjectUseCase: InitProjectUseCase,
+    private val planIssuesUseCase: PlanIssuesUseCase,
+    private val discussUseCase: DiscussUseCase,
+    private val designUseCase: DesignUseCase,
+    private val executeShellUseCase: ExecuteShellUseCase,
+    private val getProjectsUseCase: GetProjectsUseCase,
+) {
+    private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val _uiState = MutableStateFlow(CommandCenterUiState())
+    val uiState: StateFlow<CommandCenterUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoadingProjects = true) }
+            getProjectsUseCase().fold(
+                onSuccess = { projects ->
+                    _uiState.update { it.copy(isLoadingProjects = false, projects = projects) }
+                },
+                onFailure = { e ->
+                    _uiState.update { it.copy(isLoadingProjects = false, error = e.message) }
+                },
+            )
+        }
+    }
+
+    // ─── Tab ────────────────────────────────────────────────────
+
+    fun selectTab(tab: CommandTab) {
+        _uiState.update { it.copy(activeTab = tab) }
+    }
+
+    // ─── Init Project inputs ─────────────────────────────────────
+
+    fun updateInitName(name: String) {
+        _uiState.update { it.copy(initName = name) }
+    }
+
+    fun updateInitDescription(desc: String) {
+        _uiState.update { it.copy(initDescription = desc) }
+    }
+
+    fun updateInitVisibility(vis: ProjectVisibility) {
+        _uiState.update { it.copy(initVisibility = vis) }
+    }
+
+    // ─── Plan inputs ─────────────────────────────────────────────
+
+    fun selectPlanProject(project: Project) {
+        _uiState.update { it.copy(planSelectedProject = project) }
+    }
+
+    // ─── Discuss inputs ──────────────────────────────────────────
+
+    fun selectDiscussProject(project: Project) {
+        _uiState.update { it.copy(discussSelectedProject = project) }
+    }
+
+    fun updateDiscussQuestion(q: String) {
+        _uiState.update { it.copy(discussQuestion = q) }
+    }
+
+    // ─── Design inputs ───────────────────────────────────────────
+
+    fun selectDesignProject(project: Project) {
+        _uiState.update { it.copy(designSelectedProject = project) }
+    }
+
+    fun updateDesignFigmaUrl(url: String) {
+        _uiState.update { it.copy(designFigmaUrl = url) }
+    }
+
+    // ─── Shell inputs ────────────────────────────────────────────
+
+    fun updateShellCommand(cmd: String) {
+        _uiState.update { it.copy(shellCommand = cmd) }
+    }
+
+    // ─── Actions ─────────────────────────────────────────────────
+
+    fun executeInit() {
+        val state = _uiState.value
+        if (state.initName.isBlank()) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isInitLoading = true, error = null) }
+            val request = InitProjectRequest(
+                name = state.initName,
+                description = state.initDescription,
+                visibility = state.initVisibility,
+            )
+            initProjectUseCase(request).fold(
+                onSuccess = { result ->
+                    _uiState.update { it.copy(isInitLoading = false, initResult = result) }
+                },
+                onFailure = { e ->
+                    _uiState.update { it.copy(isInitLoading = false, error = e.message) }
+                },
+            )
+        }
+    }
+
+    fun executePlan() {
+        val project = _uiState.value.planSelectedProject ?: return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isPlanLoading = true, error = null) }
+            planIssuesUseCase(project.name).fold(
+                onSuccess = { result ->
+                    _uiState.update { it.copy(isPlanLoading = false, planResult = result) }
+                },
+                onFailure = { e ->
+                    _uiState.update { it.copy(isPlanLoading = false, error = e.message) }
+                },
+            )
+        }
+    }
+
+    fun executeDiscuss() {
+        val state = _uiState.value
+        val project = state.discussSelectedProject ?: return
+        if (state.discussQuestion.isBlank()) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isDiscussLoading = true, error = null) }
+            discussUseCase(project.name, state.discussQuestion).fold(
+                onSuccess = { result ->
+                    _uiState.update { it.copy(isDiscussLoading = false, discussResult = result) }
+                },
+                onFailure = { e ->
+                    _uiState.update { it.copy(isDiscussLoading = false, error = e.message) }
+                },
+            )
+        }
+    }
+
+    fun executeDesign() {
+        val state = _uiState.value
+        val project = state.designSelectedProject ?: return
+        if (state.designFigmaUrl.isBlank()) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isDesignLoading = true, error = null) }
+            designUseCase(project.name, state.designFigmaUrl).fold(
+                onSuccess = { result ->
+                    _uiState.update { it.copy(isDesignLoading = false, designResult = result) }
+                },
+                onFailure = { e ->
+                    _uiState.update { it.copy(isDesignLoading = false, error = e.message) }
+                },
+            )
+        }
+    }
+
+    fun executeShell() {
+        val command = _uiState.value.shellCommand
+        if (command.isBlank()) return
+
+        if (ShellCommandConstants.dangerousPatterns.any { command.contains(it, ignoreCase = true) }) {
+            _uiState.update { it.copy(showDangerDialog = true, pendingDangerousCommand = command) }
+            return
+        }
+
+        runShellCommand(command)
+    }
+
+    fun confirmDangerousCommand() {
+        val command = _uiState.value.pendingDangerousCommand ?: return
+        _uiState.update { it.copy(showDangerDialog = false, pendingDangerousCommand = null) }
+        runShellCommand(command)
+    }
+
+    fun cancelDangerousCommand() {
+        _uiState.update { it.copy(showDangerDialog = false, pendingDangerousCommand = null) }
+    }
+
+    private fun runShellCommand(command: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isShellLoading = true, error = null) }
+            executeShellUseCase(command).fold(
+                onSuccess = { result ->
+                    _uiState.update { it.copy(isShellLoading = false, shellResult = result) }
+                },
+                onFailure = { e ->
+                    _uiState.update { it.copy(isShellLoading = false, error = e.message) }
+                },
+            )
+        }
+    }
+
+    fun convertSuggestedIssue(issue: PlannedIssue) {
+        _uiState.update { it.copy(pendingIssueConversion = issue) }
+    }
+
+    fun clearPendingIssueConversion() {
+        _uiState.update { it.copy(pendingIssueConversion = null) }
+    }
+
+    // ─── Common ──────────────────────────────────────────────────
+
+    fun clearError() {
+        _uiState.update { it.copy(error = null) }
+    }
+
+    fun onCleared() {
+        viewModelScope.cancel()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/commandcenter/ShellCommandConstants.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/commandcenter/ShellCommandConstants.kt
@@ -1,0 +1,5 @@
+package com.orchestradashboard.shared.ui.commandcenter
+
+object ShellCommandConstants {
+    val dangerousPatterns = listOf("rm -rf", "drop ", "shutdown", "reboot", "mkfs", "dd if=")
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/DangerCommandDialog.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/DangerCommandDialog.kt
@@ -1,0 +1,56 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun DangerCommandDialog(
+    command: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Icon(
+                imageVector = Icons.Default.Warning,
+                contentDescription = "Warning",
+                tint = MaterialTheme.colorScheme.error,
+            )
+        },
+        title = { Text("Dangerous Command") },
+        text = {
+            Column {
+                Text("This command may cause irreversible changes:")
+                Text(
+                    text = command,
+                    fontFamily = FontFamily.Monospace,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text("Execute Anyway", color = MaterialTheme.colorScheme.error)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/DesignPanel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/DesignPanel.kt
@@ -1,0 +1,99 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.orchestradashboard.shared.domain.model.DesignResult
+import com.orchestradashboard.shared.domain.model.Project
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DesignPanel(
+    projects: List<Project>,
+    selectedProject: Project?,
+    figmaUrl: String,
+    isLoading: Boolean,
+    result: DesignResult?,
+    onProjectSelect: (Project) -> Unit,
+    onFigmaUrlChange: (String) -> Unit,
+    onExecute: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Column(modifier = modifier.padding(16.dp)) {
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = it },
+        ) {
+            OutlinedTextField(
+                value = selectedProject?.name ?: "Select project",
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Project") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                modifier = Modifier.fillMaxWidth().menuAnchor(),
+            )
+            ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+            ) {
+                projects.forEach { project ->
+                    DropdownMenuItem(
+                        text = { Text(project.name) },
+                        onClick = {
+                            onProjectSelect(project)
+                            expanded = false
+                        },
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedTextField(
+            value = figmaUrl,
+            onValueChange = onFigmaUrlChange,
+            label = { Text("Figma URL") },
+            placeholder = { Text("https://figma.com/file/...") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(
+            onClick = onExecute,
+            enabled = selectedProject != null && figmaUrl.isNotBlank() && !isLoading,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(if (isLoading) "Analyzing..." else "Analyze Design")
+        }
+        result?.let { designResult ->
+            Spacer(modifier = Modifier.height(12.dp))
+            Text("UI Spec", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(designResult.spec, style = MaterialTheme.typography.bodyMedium)
+            if (designResult.suggestedIssues.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Button(onClick = {}, modifier = Modifier.fillMaxWidth()) {
+                    Text("Create ${designResult.suggestedIssues.size} Issues")
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/DiscussPanel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/DiscussPanel.kt
@@ -1,0 +1,122 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.orchestradashboard.shared.domain.model.DiscussResult
+import com.orchestradashboard.shared.domain.model.PlannedIssue
+import com.orchestradashboard.shared.domain.model.Project
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DiscussPanel(
+    projects: List<Project>,
+    selectedProject: Project?,
+    question: String,
+    isLoading: Boolean,
+    result: DiscussResult?,
+    onProjectSelect: (Project) -> Unit,
+    onQuestionChange: (String) -> Unit,
+    onExecute: () -> Unit,
+    onConvertToIssue: (PlannedIssue) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Column(modifier = modifier.padding(16.dp)) {
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = it },
+        ) {
+            OutlinedTextField(
+                value = selectedProject?.name ?: "Select project",
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Project") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                modifier = Modifier.fillMaxWidth().menuAnchor(),
+            )
+            ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+            ) {
+                projects.forEach { project ->
+                    DropdownMenuItem(
+                        text = { Text(project.name) },
+                        onClick = {
+                            onProjectSelect(project)
+                            expanded = false
+                        },
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedTextField(
+            value = question,
+            onValueChange = onQuestionChange,
+            label = { Text("Question") },
+            placeholder = { Text("What should I implement first?") },
+            modifier = Modifier.fillMaxWidth(),
+            minLines = 2,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(
+            onClick = onExecute,
+            enabled = selectedProject != null && question.isNotBlank() && !isLoading,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(if (isLoading) "Asking..." else "Ask")
+        }
+        result?.let { discussResult ->
+            Spacer(modifier = Modifier.height(12.dp))
+            Text("Answer", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(discussResult.answer, style = MaterialTheme.typography.bodyMedium)
+            if (discussResult.suggestedIssues.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    "Suggested Issues",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                discussResult.suggestedIssues.forEach { issue ->
+                    Spacer(modifier = Modifier.height(4.dp))
+                    SuggestedIssueRow(issue, onConvertToIssue = onConvertToIssue)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SuggestedIssueRow(
+    issue: PlannedIssue,
+    onConvertToIssue: (PlannedIssue) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(issue.title, style = MaterialTheme.typography.bodyMedium)
+        OutlinedButton(onClick = { onConvertToIssue(issue) }, modifier = Modifier.height(32.dp)) {
+            Text("Convert to Issue", style = MaterialTheme.typography.labelSmall)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/InitProjectForm.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/InitProjectForm.kt
@@ -1,0 +1,79 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.orchestradashboard.shared.domain.model.CommandResult
+import com.orchestradashboard.shared.domain.model.ProjectVisibility
+
+@Composable
+fun InitProjectForm(
+    name: String,
+    description: String,
+    visibility: ProjectVisibility,
+    isLoading: Boolean,
+    result: CommandResult?,
+    onNameChange: (String) -> Unit,
+    onDescriptionChange: (String) -> Unit,
+    onVisibilityChange: (ProjectVisibility) -> Unit,
+    onExecute: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.padding(16.dp)) {
+        OutlinedTextField(
+            value = name,
+            onValueChange = onNameChange,
+            label = { Text("Project Name") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedTextField(
+            value = description,
+            onValueChange = onDescriptionChange,
+            label = { Text("Description") },
+            modifier = Modifier.fillMaxWidth(),
+            minLines = 2,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text("Public", modifier = Modifier.weight(1f))
+            Switch(
+                checked = visibility == ProjectVisibility.PUBLIC,
+                onCheckedChange = { checked ->
+                    onVisibilityChange(if (checked) ProjectVisibility.PUBLIC else ProjectVisibility.PRIVATE)
+                },
+            )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(
+            onClick = onExecute,
+            enabled = name.isNotBlank() && !isLoading,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(if (isLoading) "Creating..." else "Create Project")
+        }
+        result?.let {
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = if (it.success) "✓ ${it.message}" else "✗ ${it.message}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (it.success) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/PlanIssuesPanel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/PlanIssuesPanel.kt
@@ -1,0 +1,132 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.orchestradashboard.shared.domain.model.PlannedIssue
+import com.orchestradashboard.shared.domain.model.PlanIssuesResult
+import com.orchestradashboard.shared.domain.model.Project
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PlanIssuesPanel(
+    projects: List<Project>,
+    selectedProject: Project?,
+    isLoading: Boolean,
+    result: PlanIssuesResult?,
+    onProjectSelect: (Project) -> Unit,
+    onExecute: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Column(modifier = modifier.padding(16.dp)) {
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = it },
+        ) {
+            OutlinedTextField(
+                value = selectedProject?.name ?: "Select project",
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Project") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                modifier = Modifier.fillMaxWidth().menuAnchor(),
+            )
+            ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+            ) {
+                projects.forEach { project ->
+                    DropdownMenuItem(
+                        text = { Text(project.name) },
+                        onClick = {
+                            onProjectSelect(project)
+                            expanded = false
+                        },
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(
+            onClick = onExecute,
+            enabled = selectedProject != null && !isLoading,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(if (isLoading) "Planning..." else "Plan Issues")
+        }
+        result?.let { planResult ->
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = "${planResult.issues.size} issues planned",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                items(planResult.issues) { issue ->
+                    PlannedIssueCard(issue)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlannedIssueCard(
+    issue: PlannedIssue,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(issue.title, style = MaterialTheme.typography.titleSmall)
+            if (issue.body.isNotBlank()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    issue.body,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (issue.labels.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    issue.labels.forEach { label ->
+                        Text(
+                            text = label,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/PlanIssuesPanel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/PlanIssuesPanel.kt
@@ -26,8 +26,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.orchestradashboard.shared.domain.model.PlannedIssue
 import com.orchestradashboard.shared.domain.model.PlanIssuesResult
+import com.orchestradashboard.shared.domain.model.PlannedIssue
 import com.orchestradashboard.shared.domain.model.Project
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/QuickActionsBar.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/QuickActionsBar.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 fun QuickActionsBar(
     onNewSolveClick: () -> Unit,
     onViewProjectsClick: () -> Unit,
+    onCommandCenterClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -31,6 +32,12 @@ fun QuickActionsBar(
             modifier = Modifier.weight(1f),
         ) {
             Text("View Projects")
+        }
+        FilledTonalButton(
+            onClick = onCommandCenterClick,
+            modifier = Modifier.weight(1f),
+        ) {
+            Text("Command Center")
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ShellPanel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ShellPanel.kt
@@ -64,11 +64,12 @@ fun ShellPanel(
             Text(
                 text = "Exit code: ${shellResult.exitCode}",
                 style = MaterialTheme.typography.labelSmall,
-                color = if (shellResult.exitCode == 0) {
-                    MaterialTheme.colorScheme.primary
-                } else {
-                    MaterialTheme.colorScheme.error
-                },
+                color =
+                    if (shellResult.exitCode == 0) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.error
+                    },
             )
             Spacer(modifier = Modifier.height(4.dp))
             SelectionContainer {
@@ -76,11 +77,12 @@ fun ShellPanel(
                     text = shellResult.output,
                     fontFamily = FontFamily.Monospace,
                     style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = 300.dp)
-                        .verticalScroll(rememberScrollState())
-                        .horizontalScroll(rememberScrollState()),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 300.dp)
+                            .verticalScroll(rememberScrollState())
+                            .horizontalScroll(rememberScrollState()),
                 )
             }
         }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ShellPanel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ShellPanel.kt
@@ -1,0 +1,96 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.orchestradashboard.shared.domain.model.ShellResult
+
+@Composable
+fun ShellPanel(
+    command: String,
+    isLoading: Boolean,
+    result: ShellResult?,
+    showDangerDialog: Boolean,
+    pendingDangerousCommand: String?,
+    onCommandChange: (String) -> Unit,
+    onExecute: () -> Unit,
+    onConfirmDanger: () -> Unit,
+    onCancelDanger: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.padding(16.dp)) {
+        Text(
+            text = "Warning: Shell commands execute directly on the orchestrator host.",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.error,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedTextField(
+            value = command,
+            onValueChange = onCommandChange,
+            label = { Text("Command") },
+            placeholder = { Text("ls -la") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Button(
+            onClick = onExecute,
+            enabled = command.isNotBlank() && !isLoading,
+            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(if (isLoading) "Executing..." else "Execute")
+        }
+        result?.let { shellResult ->
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = "Exit code: ${shellResult.exitCode}",
+                style = MaterialTheme.typography.labelSmall,
+                color = if (shellResult.exitCode == 0) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.error
+                },
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            SelectionContainer {
+                Text(
+                    text = shellResult.output,
+                    fontFamily = FontFamily.Monospace,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 300.dp)
+                        .verticalScroll(rememberScrollState())
+                        .horizontalScroll(rememberScrollState()),
+                )
+            }
+        }
+    }
+
+    if (showDangerDialog && pendingDangerousCommand != null) {
+        DangerCommandDialog(
+            command = pendingDangerousCommand,
+            onConfirm = onConfirmDanger,
+            onDismiss = onCancelDanger,
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/AppNavigation.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/AppNavigation.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.orchestradashboard.shared.domain.model.DashboardViewModel
 import com.orchestradashboard.shared.ui.agentdetail.AgentDetailViewModel
+import com.orchestradashboard.shared.ui.commandcenter.CommandCenterViewModel
 import com.orchestradashboard.shared.ui.dashboardhome.DashboardHomeViewModel
 import com.orchestradashboard.shared.ui.pipelinemonitor.PipelineMonitorViewModel
 import com.orchestradashboard.shared.ui.projectexplorer.ProjectExplorerViewModel
@@ -23,6 +24,8 @@ sealed class Screen {
     data object ProjectExplorer : Screen()
 
     data class PipelineMonitor(val pipelineId: String) : Screen()
+
+    data object CommandCenter : Screen()
 }
 
 @Composable
@@ -32,6 +35,7 @@ fun AppNavigation(
     agentDetailViewModelFactory: (String) -> AgentDetailViewModel,
     projectExplorerViewModelFactory: () -> ProjectExplorerViewModel,
     pipelineMonitorViewModelFactory: (String) -> PipelineMonitorViewModel,
+    commandCenterViewModelFactory: () -> CommandCenterViewModel,
     modifier: Modifier = Modifier,
 ) {
     var currentScreen: Screen by remember { mutableStateOf(Screen.DashboardHome) }
@@ -46,6 +50,7 @@ fun AppNavigation(
                 viewModel = vm,
                 onNewSolveClick = { currentScreen = Screen.ProjectExplorer },
                 onViewProjectsClick = { currentScreen = Screen.ProjectExplorer },
+                onCommandCenterClick = { currentScreen = Screen.CommandCenter },
                 onPipelineClick = { pipelineId -> currentScreen = Screen.PipelineMonitor(pipelineId) },
                 modifier = modifier,
             )
@@ -88,6 +93,17 @@ fun AppNavigation(
                 onDispose { vm.onCleared() }
             }
             PipelineMonitorScreen(
+                viewModel = vm,
+                onBackClick = { currentScreen = Screen.DashboardHome },
+                modifier = modifier,
+            )
+        }
+        is Screen.CommandCenter -> {
+            val vm = remember { commandCenterViewModelFactory() }
+            DisposableEffect(Unit) {
+                onDispose { vm.onCleared() }
+            }
+            CommandCenterScreen(
                 viewModel = vm,
                 onBackClick = { currentScreen = Screen.DashboardHome },
                 modifier = modifier,

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/CommandCenterScreen.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/CommandCenterScreen.kt
@@ -1,0 +1,133 @@
+package com.orchestradashboard.shared.ui.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import com.orchestradashboard.shared.ui.commandcenter.CommandCenterViewModel
+import com.orchestradashboard.shared.ui.commandcenter.CommandTab
+import com.orchestradashboard.shared.ui.component.DesignPanel
+import com.orchestradashboard.shared.ui.component.DiscussPanel
+import com.orchestradashboard.shared.ui.component.ErrorBanner
+import com.orchestradashboard.shared.ui.component.InitProjectForm
+import com.orchestradashboard.shared.ui.component.PlanIssuesPanel
+import com.orchestradashboard.shared.ui.component.ShellPanel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CommandCenterScreen(
+    viewModel: CommandCenterViewModel,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    val tabs = listOf("Init", "Plan", "Discuss", "Design", "Shell")
+    val tabValues = CommandTab.entries.toTypedArray()
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Command Center") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { paddingValues ->
+        Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+            state.error?.let { error ->
+                ErrorBanner(message = error, onDismiss = { viewModel.clearError() })
+            }
+
+            ScrollableTabRow(selectedTabIndex = state.activeTab.ordinal) {
+                tabs.forEachIndexed { index, title ->
+                    Tab(
+                        selected = state.activeTab.ordinal == index,
+                        onClick = { viewModel.selectTab(tabValues[index]) },
+                        text = { Text(title) },
+                    )
+                }
+            }
+
+            Column(modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+                when (state.activeTab) {
+                    CommandTab.INIT ->
+                        InitProjectForm(
+                            name = state.initName,
+                            description = state.initDescription,
+                            visibility = state.initVisibility,
+                            isLoading = state.isInitLoading,
+                            result = state.initResult,
+                            onNameChange = viewModel::updateInitName,
+                            onDescriptionChange = viewModel::updateInitDescription,
+                            onVisibilityChange = viewModel::updateInitVisibility,
+                            onExecute = viewModel::executeInit,
+                        )
+                    CommandTab.PLAN ->
+                        PlanIssuesPanel(
+                            projects = state.projects,
+                            selectedProject = state.planSelectedProject,
+                            isLoading = state.isPlanLoading,
+                            result = state.planResult,
+                            onProjectSelect = viewModel::selectPlanProject,
+                            onExecute = viewModel::executePlan,
+                        )
+                    CommandTab.DISCUSS ->
+                        DiscussPanel(
+                            projects = state.projects,
+                            selectedProject = state.discussSelectedProject,
+                            question = state.discussQuestion,
+                            isLoading = state.isDiscussLoading,
+                            result = state.discussResult,
+                            onProjectSelect = viewModel::selectDiscussProject,
+                            onQuestionChange = viewModel::updateDiscussQuestion,
+                            onExecute = viewModel::executeDiscuss,
+                            onConvertToIssue = viewModel::convertSuggestedIssue,
+                        )
+                    CommandTab.DESIGN ->
+                        DesignPanel(
+                            projects = state.projects,
+                            selectedProject = state.designSelectedProject,
+                            figmaUrl = state.designFigmaUrl,
+                            isLoading = state.isDesignLoading,
+                            result = state.designResult,
+                            onProjectSelect = viewModel::selectDesignProject,
+                            onFigmaUrlChange = viewModel::updateDesignFigmaUrl,
+                            onExecute = viewModel::executeDesign,
+                        )
+                    CommandTab.SHELL ->
+                        ShellPanel(
+                            command = state.shellCommand,
+                            isLoading = state.isShellLoading,
+                            result = state.shellResult,
+                            showDangerDialog = state.showDangerDialog,
+                            pendingDangerousCommand = state.pendingDangerousCommand,
+                            onCommandChange = viewModel::updateShellCommand,
+                            onExecute = viewModel::executeShell,
+                            onConfirmDanger = viewModel::confirmDangerousCommand,
+                            onCancelDanger = viewModel::cancelDangerousCommand,
+                        )
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/DashboardHomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/DashboardHomeScreen.kt
@@ -38,6 +38,7 @@ fun DashboardHomeScreen(
     viewModel: DashboardHomeViewModel,
     onNewSolveClick: () -> Unit,
     onViewProjectsClick: () -> Unit,
+    onCommandCenterClick: () -> Unit,
     onPipelineClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -79,6 +80,7 @@ fun DashboardHomeScreen(
                             QuickActionsBar(
                                 onNewSolveClick = onNewSolveClick,
                                 onViewProjectsClick = onViewProjectsClick,
+                                onCommandCenterClick = onCommandCenterClick,
                             )
                         }
 

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/api/FakeOrchestratorApiClient.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/api/FakeOrchestratorApiClient.kt
@@ -1,19 +1,45 @@
 package com.orchestradashboard.shared.data.api
 
 import com.orchestradashboard.shared.data.dto.orchestrator.CheckpointDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DesignRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DesignResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DiscussRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DiscussResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.InitProjectRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.InitProjectResponseDto
 import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorIssueDto
 import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorPipelineDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ParallelPipelineGroupDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineHistoryDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PlanIssuesResponseDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ProjectDetailDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ProjectDto
+import com.orchestradashboard.shared.data.dto.orchestrator.ShellRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.ShellResponseDto
 import com.orchestradashboard.shared.data.dto.orchestrator.SystemStatusDto
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 
 class FakeOrchestratorApiClient : OrchestratorApi {
     var errorToThrow: Exception? = null
+
+    var initProjectResult: InitProjectResponseDto? = null
+    var planIssuesResult: PlanIssuesResponseDto? = null
+    var discussResult: DiscussResponseDto? = null
+    var designResult: DesignResponseDto? = null
+    var shellResult: ShellResponseDto? = null
+
+    var postInitProjectCallCount = 0
+        private set
+    var postPlanIssuesCallCount = 0
+        private set
+    var postDiscussCallCount = 0
+        private set
+    var postDesignCallCount = 0
+        private set
+    var postShellCallCount = 0
+        private set
 
     var statusResult: SystemStatusDto? = null
     var projectsResult: List<ProjectDto> = emptyList()
@@ -128,5 +154,35 @@ class FakeOrchestratorApiClient : OrchestratorApi {
         connectEventsCallCount++
         maybeThrow()
         return eventsResult.filter { it.pipelineId == pipelineId }.asFlow()
+    }
+
+    override suspend fun postInitProject(request: InitProjectRequestDto): InitProjectResponseDto {
+        postInitProjectCallCount++
+        maybeThrow()
+        return initProjectResult ?: throw OrchestratorNetworkException("No initProjectResult configured")
+    }
+
+    override suspend fun postPlanIssues(projectName: String): PlanIssuesResponseDto {
+        postPlanIssuesCallCount++
+        maybeThrow()
+        return planIssuesResult ?: throw OrchestratorNetworkException("No planIssuesResult configured")
+    }
+
+    override suspend fun postDiscuss(request: DiscussRequestDto): DiscussResponseDto {
+        postDiscussCallCount++
+        maybeThrow()
+        return discussResult ?: throw OrchestratorNetworkException("No discussResult configured")
+    }
+
+    override suspend fun postDesign(request: DesignRequestDto): DesignResponseDto {
+        postDesignCallCount++
+        maybeThrow()
+        return designResult ?: throw OrchestratorNetworkException("No designResult configured")
+    }
+
+    override suspend fun postShell(request: ShellRequestDto): ShellResponseDto {
+        postShellCallCount++
+        maybeThrow()
+        return shellResult ?: throw OrchestratorNetworkException("No shellResult configured")
     }
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/mapper/CommandMapperTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/mapper/CommandMapperTest.kt
@@ -3,8 +3,8 @@ package com.orchestradashboard.shared.data.mapper
 import com.orchestradashboard.shared.data.dto.orchestrator.DesignResponseDto
 import com.orchestradashboard.shared.data.dto.orchestrator.DiscussResponseDto
 import com.orchestradashboard.shared.data.dto.orchestrator.InitProjectResponseDto
-import com.orchestradashboard.shared.data.dto.orchestrator.PlannedIssueDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PlanIssuesResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PlannedIssueDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ShellResponseDto
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -36,12 +36,14 @@ class CommandMapperTest {
 
     @Test
     fun `mapPlanResponse converts PlanIssuesResponseDto to PlanIssuesResult with issue list`() {
-        val dto = PlanIssuesResponseDto(
-            issues = listOf(
-                PlannedIssueDto(title = "Issue 1", body = "Body 1", labels = listOf("bug")),
-                PlannedIssueDto(title = "Issue 2", body = "Body 2", labels = listOf("feature")),
-            ),
-        )
+        val dto =
+            PlanIssuesResponseDto(
+                issues =
+                    listOf(
+                        PlannedIssueDto(title = "Issue 1", body = "Body 1", labels = listOf("bug")),
+                        PlannedIssueDto(title = "Issue 2", body = "Body 2", labels = listOf("feature")),
+                    ),
+            )
 
         val result = mapper.mapPlanResponse(dto)
 
@@ -53,10 +55,11 @@ class CommandMapperTest {
 
     @Test
     fun `mapDiscussResponse converts DiscussResponseDto to DiscussResult`() {
-        val dto = DiscussResponseDto(
-            answer = "Here is the answer",
-            suggestedIssues = listOf(PlannedIssueDto("suggestion", "body", emptyList())),
-        )
+        val dto =
+            DiscussResponseDto(
+                answer = "Here is the answer",
+                suggestedIssues = listOf(PlannedIssueDto("suggestion", "body", emptyList())),
+            )
 
         val result = mapper.mapDiscussResponse(dto)
 
@@ -67,10 +70,11 @@ class CommandMapperTest {
 
     @Test
     fun `mapDesignResponse converts DesignResponseDto to DesignResult`() {
-        val dto = DesignResponseDto(
-            spec = "Component layout description",
-            suggestedIssues = emptyList(),
-        )
+        val dto =
+            DesignResponseDto(
+                spec = "Component layout description",
+                suggestedIssues = emptyList(),
+            )
 
         val result = mapper.mapDesignResponse(dto)
 

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/mapper/CommandMapperTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/mapper/CommandMapperTest.kt
@@ -1,0 +1,99 @@
+package com.orchestradashboard.shared.data.mapper
+
+import com.orchestradashboard.shared.data.dto.orchestrator.DesignResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DiscussResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.InitProjectResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PlannedIssueDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PlanIssuesResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.ShellResponseDto
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CommandMapperTest {
+    private val mapper = CommandMapper()
+
+    @Test
+    fun `mapInitResponse converts InitProjectResponseDto to CommandResult`() {
+        val dto = InitProjectResponseDto(success = true, message = "Created", pipelineId = "p-42")
+
+        val result = mapper.mapInitResponse(dto)
+
+        assertTrue(result.success)
+        assertEquals("Created", result.message)
+        assertEquals("p-42", result.pipelineId)
+    }
+
+    @Test
+    fun `mapInitResponse with null pipelineId maps to null pipelineId`() {
+        val dto = InitProjectResponseDto(success = false, message = "Failed", pipelineId = null)
+
+        val result = mapper.mapInitResponse(dto)
+
+        assertNull(result.pipelineId)
+    }
+
+    @Test
+    fun `mapPlanResponse converts PlanIssuesResponseDto to PlanIssuesResult with issue list`() {
+        val dto = PlanIssuesResponseDto(
+            issues = listOf(
+                PlannedIssueDto(title = "Issue 1", body = "Body 1", labels = listOf("bug")),
+                PlannedIssueDto(title = "Issue 2", body = "Body 2", labels = listOf("feature")),
+            ),
+        )
+
+        val result = mapper.mapPlanResponse(dto)
+
+        assertEquals(2, result.issues.size)
+        assertEquals("Issue 1", result.issues[0].title)
+        assertEquals("Body 1", result.issues[0].body)
+        assertEquals(listOf("bug"), result.issues[0].labels)
+    }
+
+    @Test
+    fun `mapDiscussResponse converts DiscussResponseDto to DiscussResult`() {
+        val dto = DiscussResponseDto(
+            answer = "Here is the answer",
+            suggestedIssues = listOf(PlannedIssueDto("suggestion", "body", emptyList())),
+        )
+
+        val result = mapper.mapDiscussResponse(dto)
+
+        assertEquals("Here is the answer", result.answer)
+        assertEquals(1, result.suggestedIssues.size)
+        assertEquals("suggestion", result.suggestedIssues[0].title)
+    }
+
+    @Test
+    fun `mapDesignResponse converts DesignResponseDto to DesignResult`() {
+        val dto = DesignResponseDto(
+            spec = "Component layout description",
+            suggestedIssues = emptyList(),
+        )
+
+        val result = mapper.mapDesignResponse(dto)
+
+        assertEquals("Component layout description", result.spec)
+        assertTrue(result.suggestedIssues.isEmpty())
+    }
+
+    @Test
+    fun `mapShellResponse converts ShellResponseDto to ShellResult with exit code`() {
+        val dto = ShellResponseDto(output = "Hello World", exitCode = 0)
+
+        val result = mapper.mapShellResponse(dto)
+
+        assertEquals("Hello World", result.output)
+        assertEquals(0, result.exitCode)
+    }
+
+    @Test
+    fun `mapShellResponse maps non-zero exit code`() {
+        val dto = ShellResponseDto(output = "Error: command not found", exitCode = 127)
+
+        val result = mapper.mapShellResponse(dto)
+
+        assertEquals(127, result.exitCode)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/CommandRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/CommandRepositoryImplTest.kt
@@ -5,8 +5,8 @@ import com.orchestradashboard.shared.data.api.OrchestratorNetworkException
 import com.orchestradashboard.shared.data.dto.orchestrator.DesignResponseDto
 import com.orchestradashboard.shared.data.dto.orchestrator.DiscussResponseDto
 import com.orchestradashboard.shared.data.dto.orchestrator.InitProjectResponseDto
-import com.orchestradashboard.shared.data.dto.orchestrator.PlannedIssueDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PlanIssuesResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PlannedIssueDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ShellResponseDto
 import com.orchestradashboard.shared.data.mapper.CommandMapper
 import com.orchestradashboard.shared.domain.model.InitProjectRequest
@@ -22,85 +22,94 @@ class CommandRepositoryImplTest {
     private val mapper = CommandMapper()
     private val repository = CommandRepositoryImpl(fakeApi, mapper)
 
-    private val initRequest = InitProjectRequest(
-        name = "test-project",
-        description = "A project",
-        visibility = ProjectVisibility.PUBLIC,
-    )
-
-    @Test
-    fun `initProject calls api postInitProject and maps result`() = runTest {
-        fakeApi.initProjectResult = InitProjectResponseDto(success = true, message = "Done", pipelineId = "p-1")
-
-        val result = repository.initProject(initRequest)
-
-        assertTrue(result.isSuccess)
-        assertEquals(1, fakeApi.postInitProjectCallCount)
-        assertEquals("Done", result.getOrNull()?.message)
-    }
-
-    @Test
-    fun `initProject failure wraps exception in Result failure`() = runTest {
-        fakeApi.errorToThrow = OrchestratorNetworkException("Network error")
-
-        val result = repository.initProject(initRequest)
-
-        assertTrue(result.isFailure)
-        assertNotNull(result.exceptionOrNull())
-    }
-
-    @Test
-    fun `planIssues calls api postPlanIssues and returns mapped issue list`() = runTest {
-        fakeApi.planIssuesResult = PlanIssuesResponseDto(
-            issues = listOf(PlannedIssueDto("Issue 1", "body", listOf("bug"))),
+    private val initRequest =
+        InitProjectRequest(
+            name = "test-project",
+            description = "A project",
+            visibility = ProjectVisibility.PUBLIC,
         )
 
-        val result = repository.planIssues("test-project")
+    @Test
+    fun `initProject calls api postInitProject and maps result`() =
+        runTest {
+            fakeApi.initProjectResult = InitProjectResponseDto(success = true, message = "Done", pipelineId = "p-1")
 
-        assertTrue(result.isSuccess)
-        assertEquals(1, fakeApi.postPlanIssuesCallCount)
-        assertEquals(1, result.getOrNull()?.issues?.size)
-    }
+            val result = repository.initProject(initRequest)
+
+            assertTrue(result.isSuccess)
+            assertEquals(1, fakeApi.postInitProjectCallCount)
+            assertEquals("Done", result.getOrNull()?.message)
+        }
 
     @Test
-    fun `discuss calls api postDiscuss and returns mapped answer`() = runTest {
-        fakeApi.discussResult = DiscussResponseDto(answer = "The answer", suggestedIssues = emptyList())
+    fun `initProject failure wraps exception in Result failure`() =
+        runTest {
+            fakeApi.errorToThrow = OrchestratorNetworkException("Network error")
 
-        val result = repository.discuss("test-project", "question?")
+            val result = repository.initProject(initRequest)
 
-        assertTrue(result.isSuccess)
-        assertEquals(1, fakeApi.postDiscussCallCount)
-        assertEquals("The answer", result.getOrNull()?.answer)
-    }
-
-    @Test
-    fun `design calls api postDesign and returns mapped spec`() = runTest {
-        fakeApi.designResult = DesignResponseDto(spec = "UI layout", suggestedIssues = emptyList())
-
-        val result = repository.design("test-project", "https://figma.com/file/abc")
-
-        assertTrue(result.isSuccess)
-        assertEquals(1, fakeApi.postDesignCallCount)
-        assertEquals("UI layout", result.getOrNull()?.spec)
-    }
+            assertTrue(result.isFailure)
+            assertNotNull(result.exceptionOrNull())
+        }
 
     @Test
-    fun `executeShell calls api postShell and returns mapped output`() = runTest {
-        fakeApi.shellResult = ShellResponseDto(output = "output text", exitCode = 0)
+    fun `planIssues calls api postPlanIssues and returns mapped issue list`() =
+        runTest {
+            fakeApi.planIssuesResult =
+                PlanIssuesResponseDto(
+                    issues = listOf(PlannedIssueDto("Issue 1", "body", listOf("bug"))),
+                )
 
-        val result = repository.executeShell("ls -la")
+            val result = repository.planIssues("test-project")
 
-        assertTrue(result.isSuccess)
-        assertEquals(1, fakeApi.postShellCallCount)
-        assertEquals("output text", result.getOrNull()?.output)
-    }
+            assertTrue(result.isSuccess)
+            assertEquals(1, fakeApi.postPlanIssuesCallCount)
+            assertEquals(1, result.getOrNull()?.issues?.size)
+        }
 
     @Test
-    fun `executeShell failure returns Result failure`() = runTest {
-        fakeApi.errorToThrow = OrchestratorNetworkException("Connection refused")
+    fun `discuss calls api postDiscuss and returns mapped answer`() =
+        runTest {
+            fakeApi.discussResult = DiscussResponseDto(answer = "The answer", suggestedIssues = emptyList())
 
-        val result = repository.executeShell("ls")
+            val result = repository.discuss("test-project", "question?")
 
-        assertTrue(result.isFailure)
-    }
+            assertTrue(result.isSuccess)
+            assertEquals(1, fakeApi.postDiscussCallCount)
+            assertEquals("The answer", result.getOrNull()?.answer)
+        }
+
+    @Test
+    fun `design calls api postDesign and returns mapped spec`() =
+        runTest {
+            fakeApi.designResult = DesignResponseDto(spec = "UI layout", suggestedIssues = emptyList())
+
+            val result = repository.design("test-project", "https://figma.com/file/abc")
+
+            assertTrue(result.isSuccess)
+            assertEquals(1, fakeApi.postDesignCallCount)
+            assertEquals("UI layout", result.getOrNull()?.spec)
+        }
+
+    @Test
+    fun `executeShell calls api postShell and returns mapped output`() =
+        runTest {
+            fakeApi.shellResult = ShellResponseDto(output = "output text", exitCode = 0)
+
+            val result = repository.executeShell("ls -la")
+
+            assertTrue(result.isSuccess)
+            assertEquals(1, fakeApi.postShellCallCount)
+            assertEquals("output text", result.getOrNull()?.output)
+        }
+
+    @Test
+    fun `executeShell failure returns Result failure`() =
+        runTest {
+            fakeApi.errorToThrow = OrchestratorNetworkException("Connection refused")
+
+            val result = repository.executeShell("ls")
+
+            assertTrue(result.isFailure)
+        }
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/CommandRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/CommandRepositoryImplTest.kt
@@ -1,0 +1,106 @@
+package com.orchestradashboard.shared.data.repository
+
+import com.orchestradashboard.shared.data.api.FakeOrchestratorApiClient
+import com.orchestradashboard.shared.data.api.OrchestratorNetworkException
+import com.orchestradashboard.shared.data.dto.orchestrator.DesignResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DiscussResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.InitProjectResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PlannedIssueDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PlanIssuesResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.ShellResponseDto
+import com.orchestradashboard.shared.data.mapper.CommandMapper
+import com.orchestradashboard.shared.domain.model.InitProjectRequest
+import com.orchestradashboard.shared.domain.model.ProjectVisibility
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class CommandRepositoryImplTest {
+    private val fakeApi = FakeOrchestratorApiClient()
+    private val mapper = CommandMapper()
+    private val repository = CommandRepositoryImpl(fakeApi, mapper)
+
+    private val initRequest = InitProjectRequest(
+        name = "test-project",
+        description = "A project",
+        visibility = ProjectVisibility.PUBLIC,
+    )
+
+    @Test
+    fun `initProject calls api postInitProject and maps result`() = runTest {
+        fakeApi.initProjectResult = InitProjectResponseDto(success = true, message = "Done", pipelineId = "p-1")
+
+        val result = repository.initProject(initRequest)
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, fakeApi.postInitProjectCallCount)
+        assertEquals("Done", result.getOrNull()?.message)
+    }
+
+    @Test
+    fun `initProject failure wraps exception in Result failure`() = runTest {
+        fakeApi.errorToThrow = OrchestratorNetworkException("Network error")
+
+        val result = repository.initProject(initRequest)
+
+        assertTrue(result.isFailure)
+        assertNotNull(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `planIssues calls api postPlanIssues and returns mapped issue list`() = runTest {
+        fakeApi.planIssuesResult = PlanIssuesResponseDto(
+            issues = listOf(PlannedIssueDto("Issue 1", "body", listOf("bug"))),
+        )
+
+        val result = repository.planIssues("test-project")
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, fakeApi.postPlanIssuesCallCount)
+        assertEquals(1, result.getOrNull()?.issues?.size)
+    }
+
+    @Test
+    fun `discuss calls api postDiscuss and returns mapped answer`() = runTest {
+        fakeApi.discussResult = DiscussResponseDto(answer = "The answer", suggestedIssues = emptyList())
+
+        val result = repository.discuss("test-project", "question?")
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, fakeApi.postDiscussCallCount)
+        assertEquals("The answer", result.getOrNull()?.answer)
+    }
+
+    @Test
+    fun `design calls api postDesign and returns mapped spec`() = runTest {
+        fakeApi.designResult = DesignResponseDto(spec = "UI layout", suggestedIssues = emptyList())
+
+        val result = repository.design("test-project", "https://figma.com/file/abc")
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, fakeApi.postDesignCallCount)
+        assertEquals("UI layout", result.getOrNull()?.spec)
+    }
+
+    @Test
+    fun `executeShell calls api postShell and returns mapped output`() = runTest {
+        fakeApi.shellResult = ShellResponseDto(output = "output text", exitCode = 0)
+
+        val result = repository.executeShell("ls -la")
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, fakeApi.postShellCallCount)
+        assertEquals("output text", result.getOrNull()?.output)
+    }
+
+    @Test
+    fun `executeShell failure returns Result failure`() = runTest {
+        fakeApi.errorToThrow = OrchestratorNetworkException("Connection refused")
+
+        val result = repository.executeShell("ls")
+
+        assertTrue(result.isFailure)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/DesignUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/DesignUseCaseTest.kt
@@ -12,23 +12,25 @@ class DesignUseCaseTest {
     private val useCase = DesignUseCase(repository)
 
     @Test
-    fun `invoke with project and figmaUrl returns Result success with UI spec`() = runTest {
-        val expected = DesignResult(spec = "Component layout spec")
-        repository.designResult = Result.success(expected)
+    fun `invoke with project and figmaUrl returns Result success with UI spec`() =
+        runTest {
+            val expected = DesignResult(spec = "Component layout spec")
+            repository.designResult = Result.success(expected)
 
-        val result = useCase("my-project", "https://figma.com/file/abc")
+            val result = useCase("my-project", "https://figma.com/file/abc")
 
-        assertTrue(result.isSuccess)
-        assertEquals("Component layout spec", result.getOrNull()?.spec)
-    }
+            assertTrue(result.isSuccess)
+            assertEquals("Component layout spec", result.getOrNull()?.spec)
+        }
 
     @Test
-    fun `invoke when repository throws returns Result failure`() = runTest {
-        repository.designResult = Result.failure(RuntimeException("Design error"))
+    fun `invoke when repository throws returns Result failure`() =
+        runTest {
+            repository.designResult = Result.failure(RuntimeException("Design error"))
 
-        val result = useCase("my-project", "https://figma.com/file/abc")
+            val result = useCase("my-project", "https://figma.com/file/abc")
 
-        assertTrue(result.isFailure)
-        assertEquals("Design error", result.exceptionOrNull()?.message)
-    }
+            assertTrue(result.isFailure)
+            assertEquals("Design error", result.exceptionOrNull()?.message)
+        }
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/DesignUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/DesignUseCaseTest.kt
@@ -1,0 +1,34 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.DesignResult
+import com.orchestradashboard.shared.ui.commandcenter.FakeCommandRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DesignUseCaseTest {
+    private val repository = FakeCommandRepository()
+    private val useCase = DesignUseCase(repository)
+
+    @Test
+    fun `invoke with project and figmaUrl returns Result success with UI spec`() = runTest {
+        val expected = DesignResult(spec = "Component layout spec")
+        repository.designResult = Result.success(expected)
+
+        val result = useCase("my-project", "https://figma.com/file/abc")
+
+        assertTrue(result.isSuccess)
+        assertEquals("Component layout spec", result.getOrNull()?.spec)
+    }
+
+    @Test
+    fun `invoke when repository throws returns Result failure`() = runTest {
+        repository.designResult = Result.failure(RuntimeException("Design error"))
+
+        val result = useCase("my-project", "https://figma.com/file/abc")
+
+        assertTrue(result.isFailure)
+        assertEquals("Design error", result.exceptionOrNull()?.message)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/DiscussUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/DiscussUseCaseTest.kt
@@ -12,23 +12,25 @@ class DiscussUseCaseTest {
     private val useCase = DiscussUseCase(repository)
 
     @Test
-    fun `invoke with project and question returns Result success with answer text`() = runTest {
-        val expected = DiscussResult(answer = "Here is your answer", suggestedIssues = emptyList())
-        repository.discussResult = Result.success(expected)
+    fun `invoke with project and question returns Result success with answer text`() =
+        runTest {
+            val expected = DiscussResult(answer = "Here is your answer", suggestedIssues = emptyList())
+            repository.discussResult = Result.success(expected)
 
-        val result = useCase("my-project", "What should I implement first?")
+            val result = useCase("my-project", "What should I implement first?")
 
-        assertTrue(result.isSuccess)
-        assertEquals("Here is your answer", result.getOrNull()?.answer)
-    }
+            assertTrue(result.isSuccess)
+            assertEquals("Here is your answer", result.getOrNull()?.answer)
+        }
 
     @Test
-    fun `invoke when repository throws returns Result failure`() = runTest {
-        repository.discussResult = Result.failure(RuntimeException("Discuss error"))
+    fun `invoke when repository throws returns Result failure`() =
+        runTest {
+            repository.discussResult = Result.failure(RuntimeException("Discuss error"))
 
-        val result = useCase("my-project", "question")
+            val result = useCase("my-project", "question")
 
-        assertTrue(result.isFailure)
-        assertEquals("Discuss error", result.exceptionOrNull()?.message)
-    }
+            assertTrue(result.isFailure)
+            assertEquals("Discuss error", result.exceptionOrNull()?.message)
+        }
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/DiscussUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/DiscussUseCaseTest.kt
@@ -1,0 +1,34 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.DiscussResult
+import com.orchestradashboard.shared.ui.commandcenter.FakeCommandRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DiscussUseCaseTest {
+    private val repository = FakeCommandRepository()
+    private val useCase = DiscussUseCase(repository)
+
+    @Test
+    fun `invoke with project and question returns Result success with answer text`() = runTest {
+        val expected = DiscussResult(answer = "Here is your answer", suggestedIssues = emptyList())
+        repository.discussResult = Result.success(expected)
+
+        val result = useCase("my-project", "What should I implement first?")
+
+        assertTrue(result.isSuccess)
+        assertEquals("Here is your answer", result.getOrNull()?.answer)
+    }
+
+    @Test
+    fun `invoke when repository throws returns Result failure`() = runTest {
+        repository.discussResult = Result.failure(RuntimeException("Discuss error"))
+
+        val result = useCase("my-project", "question")
+
+        assertTrue(result.isFailure)
+        assertEquals("Discuss error", result.exceptionOrNull()?.message)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/ExecuteShellUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/ExecuteShellUseCaseTest.kt
@@ -1,0 +1,35 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.ShellResult
+import com.orchestradashboard.shared.ui.commandcenter.FakeCommandRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ExecuteShellUseCaseTest {
+    private val repository = FakeCommandRepository()
+    private val useCase = ExecuteShellUseCase(repository)
+
+    @Test
+    fun `invoke with safe command returns Result success with output`() = runTest {
+        val expected = ShellResult(output = "file1.txt\nfile2.txt", exitCode = 0)
+        repository.shellResult = Result.success(expected)
+
+        val result = useCase("ls -la")
+
+        assertTrue(result.isSuccess)
+        assertEquals("file1.txt\nfile2.txt", result.getOrNull()?.output)
+        assertEquals(0, result.getOrNull()?.exitCode)
+    }
+
+    @Test
+    fun `invoke when repository throws returns Result failure`() = runTest {
+        repository.shellResult = Result.failure(RuntimeException("Shell error"))
+
+        val result = useCase("ls")
+
+        assertTrue(result.isFailure)
+        assertEquals("Shell error", result.exceptionOrNull()?.message)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/ExecuteShellUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/ExecuteShellUseCaseTest.kt
@@ -12,24 +12,26 @@ class ExecuteShellUseCaseTest {
     private val useCase = ExecuteShellUseCase(repository)
 
     @Test
-    fun `invoke with safe command returns Result success with output`() = runTest {
-        val expected = ShellResult(output = "file1.txt\nfile2.txt", exitCode = 0)
-        repository.shellResult = Result.success(expected)
+    fun `invoke with safe command returns Result success with output`() =
+        runTest {
+            val expected = ShellResult(output = "file1.txt\nfile2.txt", exitCode = 0)
+            repository.shellResult = Result.success(expected)
 
-        val result = useCase("ls -la")
+            val result = useCase("ls -la")
 
-        assertTrue(result.isSuccess)
-        assertEquals("file1.txt\nfile2.txt", result.getOrNull()?.output)
-        assertEquals(0, result.getOrNull()?.exitCode)
-    }
+            assertTrue(result.isSuccess)
+            assertEquals("file1.txt\nfile2.txt", result.getOrNull()?.output)
+            assertEquals(0, result.getOrNull()?.exitCode)
+        }
 
     @Test
-    fun `invoke when repository throws returns Result failure`() = runTest {
-        repository.shellResult = Result.failure(RuntimeException("Shell error"))
+    fun `invoke when repository throws returns Result failure`() =
+        runTest {
+            repository.shellResult = Result.failure(RuntimeException("Shell error"))
 
-        val result = useCase("ls")
+            val result = useCase("ls")
 
-        assertTrue(result.isFailure)
-        assertEquals("Shell error", result.exceptionOrNull()?.message)
-    }
+            assertTrue(result.isFailure)
+            assertEquals("Shell error", result.exceptionOrNull()?.message)
+        }
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/InitProjectUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/InitProjectUseCaseTest.kt
@@ -13,58 +13,65 @@ class InitProjectUseCaseTest {
     private val repository = FakeCommandRepository()
     private val useCase = InitProjectUseCase(repository)
 
-    private val request = InitProjectRequest(
-        name = "my-project",
-        description = "A test project",
-        visibility = ProjectVisibility.PUBLIC,
-    )
-
-    @Test
-    fun `invoke with valid params returns Result success with command result`() = runTest {
-        val expected = CommandResult(success = true, message = "Project created")
-        repository.initProjectResult = Result.success(expected)
-
-        val result = useCase(request)
-
-        assertTrue(result.isSuccess)
-        assertEquals(expected, result.getOrNull())
-    }
-
-    @Test
-    fun `invoke when repository throws returns Result failure`() = runTest {
-        repository.initProjectResult = Result.failure(RuntimeException("Network error"))
-
-        val result = useCase(request)
-
-        assertTrue(result.isFailure)
-        assertEquals("Network error", result.exceptionOrNull()?.message)
-    }
-
-    @Test
-    fun `invoke passes PUBLIC visibility to repository`() = runTest {
-        val publicRequest = InitProjectRequest(
-            name = "public-project",
-            description = "A public project",
+    private val request =
+        InitProjectRequest(
+            name = "my-project",
+            description = "A test project",
             visibility = ProjectVisibility.PUBLIC,
         )
-        repository.initProjectResult = Result.success(CommandResult(success = true, message = "Created"))
-
-        useCase(publicRequest)
-
-        assertEquals(ProjectVisibility.PUBLIC, repository.lastInitRequest?.visibility)
-    }
 
     @Test
-    fun `invoke passes PRIVATE visibility to repository`() = runTest {
-        val privateRequest = InitProjectRequest(
-            name = "private-project",
-            description = "A private project",
-            visibility = ProjectVisibility.PRIVATE,
-        )
-        repository.initProjectResult = Result.success(CommandResult(success = true, message = "Created"))
+    fun `invoke with valid params returns Result success with command result`() =
+        runTest {
+            val expected = CommandResult(success = true, message = "Project created")
+            repository.initProjectResult = Result.success(expected)
 
-        useCase(privateRequest)
+            val result = useCase(request)
 
-        assertEquals(ProjectVisibility.PRIVATE, repository.lastInitRequest?.visibility)
-    }
+            assertTrue(result.isSuccess)
+            assertEquals(expected, result.getOrNull())
+        }
+
+    @Test
+    fun `invoke when repository throws returns Result failure`() =
+        runTest {
+            repository.initProjectResult = Result.failure(RuntimeException("Network error"))
+
+            val result = useCase(request)
+
+            assertTrue(result.isFailure)
+            assertEquals("Network error", result.exceptionOrNull()?.message)
+        }
+
+    @Test
+    fun `invoke passes PUBLIC visibility to repository`() =
+        runTest {
+            val publicRequest =
+                InitProjectRequest(
+                    name = "public-project",
+                    description = "A public project",
+                    visibility = ProjectVisibility.PUBLIC,
+                )
+            repository.initProjectResult = Result.success(CommandResult(success = true, message = "Created"))
+
+            useCase(publicRequest)
+
+            assertEquals(ProjectVisibility.PUBLIC, repository.lastInitRequest?.visibility)
+        }
+
+    @Test
+    fun `invoke passes PRIVATE visibility to repository`() =
+        runTest {
+            val privateRequest =
+                InitProjectRequest(
+                    name = "private-project",
+                    description = "A private project",
+                    visibility = ProjectVisibility.PRIVATE,
+                )
+            repository.initProjectResult = Result.success(CommandResult(success = true, message = "Created"))
+
+            useCase(privateRequest)
+
+            assertEquals(ProjectVisibility.PRIVATE, repository.lastInitRequest?.visibility)
+        }
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/InitProjectUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/InitProjectUseCaseTest.kt
@@ -1,0 +1,70 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.CommandResult
+import com.orchestradashboard.shared.domain.model.InitProjectRequest
+import com.orchestradashboard.shared.domain.model.ProjectVisibility
+import com.orchestradashboard.shared.ui.commandcenter.FakeCommandRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class InitProjectUseCaseTest {
+    private val repository = FakeCommandRepository()
+    private val useCase = InitProjectUseCase(repository)
+
+    private val request = InitProjectRequest(
+        name = "my-project",
+        description = "A test project",
+        visibility = ProjectVisibility.PUBLIC,
+    )
+
+    @Test
+    fun `invoke with valid params returns Result success with command result`() = runTest {
+        val expected = CommandResult(success = true, message = "Project created")
+        repository.initProjectResult = Result.success(expected)
+
+        val result = useCase(request)
+
+        assertTrue(result.isSuccess)
+        assertEquals(expected, result.getOrNull())
+    }
+
+    @Test
+    fun `invoke when repository throws returns Result failure`() = runTest {
+        repository.initProjectResult = Result.failure(RuntimeException("Network error"))
+
+        val result = useCase(request)
+
+        assertTrue(result.isFailure)
+        assertEquals("Network error", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun `invoke passes PUBLIC visibility to repository`() = runTest {
+        val publicRequest = InitProjectRequest(
+            name = "public-project",
+            description = "A public project",
+            visibility = ProjectVisibility.PUBLIC,
+        )
+        repository.initProjectResult = Result.success(CommandResult(success = true, message = "Created"))
+
+        useCase(publicRequest)
+
+        assertEquals(ProjectVisibility.PUBLIC, repository.lastInitRequest?.visibility)
+    }
+
+    @Test
+    fun `invoke passes PRIVATE visibility to repository`() = runTest {
+        val privateRequest = InitProjectRequest(
+            name = "private-project",
+            description = "A private project",
+            visibility = ProjectVisibility.PRIVATE,
+        )
+        repository.initProjectResult = Result.success(CommandResult(success = true, message = "Created"))
+
+        useCase(privateRequest)
+
+        assertEquals(ProjectVisibility.PRIVATE, repository.lastInitRequest?.visibility)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/PlanIssuesUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/PlanIssuesUseCaseTest.kt
@@ -1,0 +1,38 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.PlannedIssue
+import com.orchestradashboard.shared.domain.model.PlanIssuesResult
+import com.orchestradashboard.shared.ui.commandcenter.FakeCommandRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PlanIssuesUseCaseTest {
+    private val repository = FakeCommandRepository()
+    private val useCase = PlanIssuesUseCase(repository)
+
+    @Test
+    fun `invoke with project name returns Result success with list of planned issues`() = runTest {
+        val issues = listOf(
+            PlannedIssue(title = "Add auth", body = "Implement JWT", labels = listOf("feature")),
+        )
+        repository.planIssuesResult = Result.success(PlanIssuesResult(issues))
+
+        val result = useCase("my-project")
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, result.getOrNull()?.issues?.size)
+        assertEquals("Add auth", result.getOrNull()?.issues?.first()?.title)
+    }
+
+    @Test
+    fun `invoke when repository throws returns Result failure`() = runTest {
+        repository.planIssuesResult = Result.failure(RuntimeException("Plan error"))
+
+        val result = useCase("my-project")
+
+        assertTrue(result.isFailure)
+        assertEquals("Plan error", result.exceptionOrNull()?.message)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/PlanIssuesUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/domain/usecase/PlanIssuesUseCaseTest.kt
@@ -1,7 +1,7 @@
 package com.orchestradashboard.shared.domain.usecase
 
-import com.orchestradashboard.shared.domain.model.PlannedIssue
 import com.orchestradashboard.shared.domain.model.PlanIssuesResult
+import com.orchestradashboard.shared.domain.model.PlannedIssue
 import com.orchestradashboard.shared.ui.commandcenter.FakeCommandRepository
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -13,26 +13,29 @@ class PlanIssuesUseCaseTest {
     private val useCase = PlanIssuesUseCase(repository)
 
     @Test
-    fun `invoke with project name returns Result success with list of planned issues`() = runTest {
-        val issues = listOf(
-            PlannedIssue(title = "Add auth", body = "Implement JWT", labels = listOf("feature")),
-        )
-        repository.planIssuesResult = Result.success(PlanIssuesResult(issues))
+    fun `invoke with project name returns Result success with list of planned issues`() =
+        runTest {
+            val issues =
+                listOf(
+                    PlannedIssue(title = "Add auth", body = "Implement JWT", labels = listOf("feature")),
+                )
+            repository.planIssuesResult = Result.success(PlanIssuesResult(issues))
 
-        val result = useCase("my-project")
+            val result = useCase("my-project")
 
-        assertTrue(result.isSuccess)
-        assertEquals(1, result.getOrNull()?.issues?.size)
-        assertEquals("Add auth", result.getOrNull()?.issues?.first()?.title)
-    }
+            assertTrue(result.isSuccess)
+            assertEquals(1, result.getOrNull()?.issues?.size)
+            assertEquals("Add auth", result.getOrNull()?.issues?.first()?.title)
+        }
 
     @Test
-    fun `invoke when repository throws returns Result failure`() = runTest {
-        repository.planIssuesResult = Result.failure(RuntimeException("Plan error"))
+    fun `invoke when repository throws returns Result failure`() =
+        runTest {
+            repository.planIssuesResult = Result.failure(RuntimeException("Plan error"))
 
-        val result = useCase("my-project")
+            val result = useCase("my-project")
 
-        assertTrue(result.isFailure)
-        assertEquals("Plan error", result.exceptionOrNull()?.message)
-    }
+            assertTrue(result.isFailure)
+            assertEquals("Plan error", result.exceptionOrNull()?.message)
+        }
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/commandcenter/CommandCenterViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/commandcenter/CommandCenterViewModelTest.kt
@@ -1,0 +1,372 @@
+package com.orchestradashboard.shared.ui.commandcenter
+
+import com.orchestradashboard.shared.domain.model.CommandResult
+import com.orchestradashboard.shared.domain.model.DesignResult
+import com.orchestradashboard.shared.domain.model.DiscussResult
+import com.orchestradashboard.shared.domain.model.InitProjectRequest
+import com.orchestradashboard.shared.domain.model.PlannedIssue
+import com.orchestradashboard.shared.domain.model.PlanIssuesResult
+import com.orchestradashboard.shared.domain.model.Project
+import com.orchestradashboard.shared.domain.model.ProjectVisibility
+import com.orchestradashboard.shared.domain.model.ShellResult
+import com.orchestradashboard.shared.domain.usecase.DesignUseCase
+import com.orchestradashboard.shared.domain.usecase.DiscussUseCase
+import com.orchestradashboard.shared.domain.usecase.ExecuteShellUseCase
+import com.orchestradashboard.shared.domain.usecase.GetProjectsUseCase
+import com.orchestradashboard.shared.domain.usecase.InitProjectUseCase
+import com.orchestradashboard.shared.domain.usecase.PlanIssuesUseCase
+import com.orchestradashboard.shared.ui.projectexplorer.FakeProjectRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CommandCenterViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var fakeRepository: FakeCommandRepository
+    private lateinit var fakeProjectRepository: FakeProjectRepository
+    private lateinit var viewModel: CommandCenterViewModel
+
+    private val testProject = Project(
+        name = "test-project",
+        path = "/path/to/project",
+        ciCommands = emptyList(),
+        openIssuesCount = 0,
+        recentSolves = 0,
+    )
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        fakeRepository = FakeCommandRepository()
+        fakeProjectRepository = FakeProjectRepository()
+        viewModel = CommandCenterViewModel(
+            initProjectUseCase = InitProjectUseCase(fakeRepository),
+            planIssuesUseCase = PlanIssuesUseCase(fakeRepository),
+            discussUseCase = DiscussUseCase(fakeRepository),
+            designUseCase = DesignUseCase(fakeRepository),
+            executeShellUseCase = ExecuteShellUseCase(fakeRepository),
+            getProjectsUseCase = GetProjectsUseCase(fakeProjectRepository),
+        )
+    }
+
+    @AfterTest
+    fun teardown() {
+        viewModel.onCleared()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state has default tab and no results and not loading`() {
+        val state = viewModel.uiState.value
+        assertEquals(CommandTab.INIT, state.activeTab)
+        assertNull(state.initResult)
+        assertNull(state.planResult)
+        assertNull(state.discussResult)
+        assertNull(state.designResult)
+        assertNull(state.shellResult)
+        assertFalse(state.isInitLoading)
+        assertFalse(state.isPlanLoading)
+        assertFalse(state.isDiscussLoading)
+        assertFalse(state.isDesignLoading)
+        assertFalse(state.isShellLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `selectTab updates activeTab`() {
+        viewModel.selectTab(CommandTab.SHELL)
+        assertEquals(CommandTab.SHELL, viewModel.uiState.value.activeTab)
+    }
+
+    @Test
+    fun `updateInitName updates initName`() {
+        viewModel.updateInitName("my-project")
+        assertEquals("my-project", viewModel.uiState.value.initName)
+    }
+
+    @Test
+    fun `updateInitDescription updates initDescription`() {
+        viewModel.updateInitDescription("A description")
+        assertEquals("A description", viewModel.uiState.value.initDescription)
+    }
+
+    @Test
+    fun `updateInitVisibility updates initVisibility`() {
+        viewModel.updateInitVisibility(ProjectVisibility.PRIVATE)
+        assertEquals(ProjectVisibility.PRIVATE, viewModel.uiState.value.initVisibility)
+    }
+
+    @Test
+    fun `executeInit sets isInitLoading then populates initResult on success`() = runTest {
+        val expectedResult = CommandResult(success = true, message = "Created!", pipelineId = "p-1")
+        fakeRepository.initProjectResult = Result.success(expectedResult)
+
+        viewModel.updateInitName("test-project")
+        viewModel.executeInit()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isInitLoading)
+        assertNotNull(state.initResult)
+        assertEquals("Created!", state.initResult!!.message)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `executeInit failure sets error message`() = runTest {
+        fakeRepository.initProjectResult = Result.failure(RuntimeException("Init failed"))
+
+        viewModel.updateInitName("test-project")
+        viewModel.executeInit()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isInitLoading)
+        assertNull(state.initResult)
+        assertEquals("Init failed", state.error)
+    }
+
+    @Test
+    fun `executeInit does nothing when initName is blank`() = runTest {
+        viewModel.updateInitName("")
+        viewModel.executeInit()
+        advanceUntilIdle()
+
+        assertEquals(0, fakeRepository.initProjectCallCount)
+        assertNull(viewModel.uiState.value.initResult)
+    }
+
+    @Test
+    fun `executePlan sets isLoading then populates planResult on success`() = runTest {
+        val issues = listOf(PlannedIssue("Fix bug", "body", listOf("bug")))
+        fakeRepository.planIssuesResult = Result.success(PlanIssuesResult(issues))
+
+        viewModel.selectPlanProject(testProject)
+        viewModel.executePlan()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isPlanLoading)
+        assertNotNull(state.planResult)
+        assertEquals(1, state.planResult!!.issues.size)
+        assertEquals("Fix bug", state.planResult!!.issues[0].title)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `executePlan failure sets error message`() = runTest {
+        fakeRepository.planIssuesResult = Result.failure(RuntimeException("Plan failed"))
+
+        viewModel.selectPlanProject(testProject)
+        viewModel.executePlan()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isPlanLoading)
+        assertNull(state.planResult)
+        assertEquals("Plan failed", state.error)
+    }
+
+    @Test
+    fun `executePlan does nothing when no project selected`() = runTest {
+        viewModel.executePlan()
+        advanceUntilIdle()
+
+        assertEquals(0, fakeRepository.planIssuesCallCount)
+    }
+
+    @Test
+    fun `executeDiscuss sets isLoading then populates discussResult on success`() = runTest {
+        val answer = DiscussResult(answer = "Great question!", suggestedIssues = emptyList())
+        fakeRepository.discussResult = Result.success(answer)
+
+        viewModel.selectDiscussProject(testProject)
+        viewModel.updateDiscussQuestion("How does it work?")
+        viewModel.executeDiscuss()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isDiscussLoading)
+        assertNotNull(state.discussResult)
+        assertEquals("Great question!", state.discussResult!!.answer)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `executeDiscuss failure sets error message`() = runTest {
+        fakeRepository.discussResult = Result.failure(RuntimeException("Discuss failed"))
+
+        viewModel.selectDiscussProject(testProject)
+        viewModel.updateDiscussQuestion("question")
+        viewModel.executeDiscuss()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isDiscussLoading)
+        assertNull(state.discussResult)
+        assertEquals("Discuss failed", state.error)
+    }
+
+    @Test
+    fun `executeDiscuss does nothing when project or question is missing`() = runTest {
+        viewModel.executeDiscuss()
+        advanceUntilIdle()
+
+        assertEquals(0, fakeRepository.discussCallCount)
+    }
+
+    @Test
+    fun `executeDesign sets isLoading then populates designResult on success`() = runTest {
+        val spec = DesignResult(spec = "UI spec here")
+        fakeRepository.designResult = Result.success(spec)
+
+        viewModel.selectDesignProject(testProject)
+        viewModel.updateDesignFigmaUrl("https://figma.com/file/abc")
+        viewModel.executeDesign()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isDesignLoading)
+        assertNotNull(state.designResult)
+        assertEquals("UI spec here", state.designResult!!.spec)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `executeDesign failure sets error message`() = runTest {
+        fakeRepository.designResult = Result.failure(RuntimeException("Design failed"))
+
+        viewModel.selectDesignProject(testProject)
+        viewModel.updateDesignFigmaUrl("https://figma.com/file/abc")
+        viewModel.executeDesign()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isDesignLoading)
+        assertNull(state.designResult)
+        assertEquals("Design failed", state.error)
+    }
+
+    @Test
+    fun `executeDesign does nothing when project or figmaUrl is missing`() = runTest {
+        viewModel.executeDesign()
+        advanceUntilIdle()
+
+        assertEquals(0, fakeRepository.designCallCount)
+    }
+
+    @Test
+    fun `executeShell with safe command sets isLoading then populates shellResult on success`() = runTest {
+        fakeRepository.shellResult = Result.success(ShellResult(output = "hello world", exitCode = 0))
+
+        viewModel.updateShellCommand("echo hello world")
+        viewModel.executeShell()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isShellLoading)
+        assertNotNull(state.shellResult)
+        assertEquals("hello world", state.shellResult!!.output)
+        assertEquals(0, state.shellResult!!.exitCode)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `executeShell with dangerous command sets showDangerDialog true and does NOT execute`() = runTest {
+        viewModel.updateShellCommand("rm -rf /tmp/test")
+        viewModel.executeShell()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.showDangerDialog)
+        assertEquals("rm -rf /tmp/test", state.pendingDangerousCommand)
+        assertEquals(0, fakeRepository.executeShellCallCount)
+    }
+
+    @Test
+    fun `confirmDangerousCommand executes the pending command`() = runTest {
+        fakeRepository.shellResult = Result.success(ShellResult(output = "done", exitCode = 0))
+
+        viewModel.updateShellCommand("rm -rf /tmp/test")
+        viewModel.executeShell()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.showDangerDialog)
+
+        viewModel.confirmDangerousCommand()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.showDangerDialog)
+        assertNull(state.pendingDangerousCommand)
+        assertNotNull(state.shellResult)
+        assertEquals(1, fakeRepository.executeShellCallCount)
+        assertEquals("rm -rf /tmp/test", fakeRepository.lastShellCommand)
+    }
+
+    @Test
+    fun `cancelDangerousCommand clears dialog without executing`() = runTest {
+        viewModel.updateShellCommand("rm -rf /tmp/test")
+        viewModel.executeShell()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.showDangerDialog)
+
+        viewModel.cancelDangerousCommand()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.showDangerDialog)
+        assertNull(state.pendingDangerousCommand)
+        assertEquals(0, fakeRepository.executeShellCallCount)
+    }
+
+    @Test
+    fun `executeShell failure sets error message`() = runTest {
+        fakeRepository.shellResult = Result.failure(RuntimeException("Shell failed"))
+
+        viewModel.updateShellCommand("ls -la")
+        viewModel.executeShell()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isShellLoading)
+        assertNull(state.shellResult)
+        assertEquals("Shell failed", state.error)
+    }
+
+    @Test
+    fun `executeShell does nothing when command is blank`() = runTest {
+        viewModel.updateShellCommand("")
+        viewModel.executeShell()
+        advanceUntilIdle()
+
+        assertEquals(0, fakeRepository.executeShellCallCount)
+    }
+
+    @Test
+    fun `clearError resets error to null`() = runTest {
+        fakeRepository.initProjectResult = Result.failure(RuntimeException("error"))
+        viewModel.updateInitName("test")
+        viewModel.executeInit()
+        advanceUntilIdle()
+
+        assertNotNull(viewModel.uiState.value.error)
+
+        viewModel.clearError()
+
+        assertNull(viewModel.uiState.value.error)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/commandcenter/CommandCenterViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/commandcenter/CommandCenterViewModelTest.kt
@@ -3,9 +3,8 @@ package com.orchestradashboard.shared.ui.commandcenter
 import com.orchestradashboard.shared.domain.model.CommandResult
 import com.orchestradashboard.shared.domain.model.DesignResult
 import com.orchestradashboard.shared.domain.model.DiscussResult
-import com.orchestradashboard.shared.domain.model.InitProjectRequest
-import com.orchestradashboard.shared.domain.model.PlannedIssue
 import com.orchestradashboard.shared.domain.model.PlanIssuesResult
+import com.orchestradashboard.shared.domain.model.PlannedIssue
 import com.orchestradashboard.shared.domain.model.Project
 import com.orchestradashboard.shared.domain.model.ProjectVisibility
 import com.orchestradashboard.shared.domain.model.ShellResult
@@ -39,27 +38,29 @@ class CommandCenterViewModelTest {
     private lateinit var fakeProjectRepository: FakeProjectRepository
     private lateinit var viewModel: CommandCenterViewModel
 
-    private val testProject = Project(
-        name = "test-project",
-        path = "/path/to/project",
-        ciCommands = emptyList(),
-        openIssuesCount = 0,
-        recentSolves = 0,
-    )
+    private val testProject =
+        Project(
+            name = "test-project",
+            path = "/path/to/project",
+            ciCommands = emptyList(),
+            openIssuesCount = 0,
+            recentSolves = 0,
+        )
 
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         fakeRepository = FakeCommandRepository()
         fakeProjectRepository = FakeProjectRepository()
-        viewModel = CommandCenterViewModel(
-            initProjectUseCase = InitProjectUseCase(fakeRepository),
-            planIssuesUseCase = PlanIssuesUseCase(fakeRepository),
-            discussUseCase = DiscussUseCase(fakeRepository),
-            designUseCase = DesignUseCase(fakeRepository),
-            executeShellUseCase = ExecuteShellUseCase(fakeRepository),
-            getProjectsUseCase = GetProjectsUseCase(fakeProjectRepository),
-        )
+        viewModel =
+            CommandCenterViewModel(
+                initProjectUseCase = InitProjectUseCase(fakeRepository),
+                planIssuesUseCase = PlanIssuesUseCase(fakeRepository),
+                discussUseCase = DiscussUseCase(fakeRepository),
+                designUseCase = DesignUseCase(fakeRepository),
+                executeShellUseCase = ExecuteShellUseCase(fakeRepository),
+                getProjectsUseCase = GetProjectsUseCase(fakeProjectRepository),
+            )
     }
 
     @AfterTest
@@ -110,263 +111,282 @@ class CommandCenterViewModelTest {
     }
 
     @Test
-    fun `executeInit sets isInitLoading then populates initResult on success`() = runTest {
-        val expectedResult = CommandResult(success = true, message = "Created!", pipelineId = "p-1")
-        fakeRepository.initProjectResult = Result.success(expectedResult)
+    fun `executeInit sets isInitLoading then populates initResult on success`() =
+        runTest {
+            val expectedResult = CommandResult(success = true, message = "Created!", pipelineId = "p-1")
+            fakeRepository.initProjectResult = Result.success(expectedResult)
 
-        viewModel.updateInitName("test-project")
-        viewModel.executeInit()
-        advanceUntilIdle()
+            viewModel.updateInitName("test-project")
+            viewModel.executeInit()
+            advanceUntilIdle()
 
-        val state = viewModel.uiState.value
-        assertFalse(state.isInitLoading)
-        assertNotNull(state.initResult)
-        assertEquals("Created!", state.initResult!!.message)
-        assertNull(state.error)
-    }
-
-    @Test
-    fun `executeInit failure sets error message`() = runTest {
-        fakeRepository.initProjectResult = Result.failure(RuntimeException("Init failed"))
-
-        viewModel.updateInitName("test-project")
-        viewModel.executeInit()
-        advanceUntilIdle()
-
-        val state = viewModel.uiState.value
-        assertFalse(state.isInitLoading)
-        assertNull(state.initResult)
-        assertEquals("Init failed", state.error)
-    }
+            val state = viewModel.uiState.value
+            assertFalse(state.isInitLoading)
+            assertNotNull(state.initResult)
+            assertEquals("Created!", state.initResult!!.message)
+            assertNull(state.error)
+        }
 
     @Test
-    fun `executeInit does nothing when initName is blank`() = runTest {
-        viewModel.updateInitName("")
-        viewModel.executeInit()
-        advanceUntilIdle()
+    fun `executeInit failure sets error message`() =
+        runTest {
+            fakeRepository.initProjectResult = Result.failure(RuntimeException("Init failed"))
 
-        assertEquals(0, fakeRepository.initProjectCallCount)
-        assertNull(viewModel.uiState.value.initResult)
-    }
+            viewModel.updateInitName("test-project")
+            viewModel.executeInit()
+            advanceUntilIdle()
 
-    @Test
-    fun `executePlan sets isLoading then populates planResult on success`() = runTest {
-        val issues = listOf(PlannedIssue("Fix bug", "body", listOf("bug")))
-        fakeRepository.planIssuesResult = Result.success(PlanIssuesResult(issues))
-
-        viewModel.selectPlanProject(testProject)
-        viewModel.executePlan()
-        advanceUntilIdle()
-
-        val state = viewModel.uiState.value
-        assertFalse(state.isPlanLoading)
-        assertNotNull(state.planResult)
-        assertEquals(1, state.planResult!!.issues.size)
-        assertEquals("Fix bug", state.planResult!!.issues[0].title)
-        assertNull(state.error)
-    }
+            val state = viewModel.uiState.value
+            assertFalse(state.isInitLoading)
+            assertNull(state.initResult)
+            assertEquals("Init failed", state.error)
+        }
 
     @Test
-    fun `executePlan failure sets error message`() = runTest {
-        fakeRepository.planIssuesResult = Result.failure(RuntimeException("Plan failed"))
+    fun `executeInit does nothing when initName is blank`() =
+        runTest {
+            viewModel.updateInitName("")
+            viewModel.executeInit()
+            advanceUntilIdle()
 
-        viewModel.selectPlanProject(testProject)
-        viewModel.executePlan()
-        advanceUntilIdle()
-
-        val state = viewModel.uiState.value
-        assertFalse(state.isPlanLoading)
-        assertNull(state.planResult)
-        assertEquals("Plan failed", state.error)
-    }
+            assertEquals(0, fakeRepository.initProjectCallCount)
+            assertNull(viewModel.uiState.value.initResult)
+        }
 
     @Test
-    fun `executePlan does nothing when no project selected`() = runTest {
-        viewModel.executePlan()
-        advanceUntilIdle()
+    fun `executePlan sets isLoading then populates planResult on success`() =
+        runTest {
+            val issues = listOf(PlannedIssue("Fix bug", "body", listOf("bug")))
+            fakeRepository.planIssuesResult = Result.success(PlanIssuesResult(issues))
 
-        assertEquals(0, fakeRepository.planIssuesCallCount)
-    }
+            viewModel.selectPlanProject(testProject)
+            viewModel.executePlan()
+            advanceUntilIdle()
 
-    @Test
-    fun `executeDiscuss sets isLoading then populates discussResult on success`() = runTest {
-        val answer = DiscussResult(answer = "Great question!", suggestedIssues = emptyList())
-        fakeRepository.discussResult = Result.success(answer)
-
-        viewModel.selectDiscussProject(testProject)
-        viewModel.updateDiscussQuestion("How does it work?")
-        viewModel.executeDiscuss()
-        advanceUntilIdle()
-
-        val state = viewModel.uiState.value
-        assertFalse(state.isDiscussLoading)
-        assertNotNull(state.discussResult)
-        assertEquals("Great question!", state.discussResult!!.answer)
-        assertNull(state.error)
-    }
+            val state = viewModel.uiState.value
+            assertFalse(state.isPlanLoading)
+            assertNotNull(state.planResult)
+            assertEquals(1, state.planResult!!.issues.size)
+            assertEquals("Fix bug", state.planResult!!.issues[0].title)
+            assertNull(state.error)
+        }
 
     @Test
-    fun `executeDiscuss failure sets error message`() = runTest {
-        fakeRepository.discussResult = Result.failure(RuntimeException("Discuss failed"))
+    fun `executePlan failure sets error message`() =
+        runTest {
+            fakeRepository.planIssuesResult = Result.failure(RuntimeException("Plan failed"))
 
-        viewModel.selectDiscussProject(testProject)
-        viewModel.updateDiscussQuestion("question")
-        viewModel.executeDiscuss()
-        advanceUntilIdle()
+            viewModel.selectPlanProject(testProject)
+            viewModel.executePlan()
+            advanceUntilIdle()
 
-        val state = viewModel.uiState.value
-        assertFalse(state.isDiscussLoading)
-        assertNull(state.discussResult)
-        assertEquals("Discuss failed", state.error)
-    }
-
-    @Test
-    fun `executeDiscuss does nothing when project or question is missing`() = runTest {
-        viewModel.executeDiscuss()
-        advanceUntilIdle()
-
-        assertEquals(0, fakeRepository.discussCallCount)
-    }
+            val state = viewModel.uiState.value
+            assertFalse(state.isPlanLoading)
+            assertNull(state.planResult)
+            assertEquals("Plan failed", state.error)
+        }
 
     @Test
-    fun `executeDesign sets isLoading then populates designResult on success`() = runTest {
-        val spec = DesignResult(spec = "UI spec here")
-        fakeRepository.designResult = Result.success(spec)
+    fun `executePlan does nothing when no project selected`() =
+        runTest {
+            viewModel.executePlan()
+            advanceUntilIdle()
 
-        viewModel.selectDesignProject(testProject)
-        viewModel.updateDesignFigmaUrl("https://figma.com/file/abc")
-        viewModel.executeDesign()
-        advanceUntilIdle()
-
-        val state = viewModel.uiState.value
-        assertFalse(state.isDesignLoading)
-        assertNotNull(state.designResult)
-        assertEquals("UI spec here", state.designResult!!.spec)
-        assertNull(state.error)
-    }
+            assertEquals(0, fakeRepository.planIssuesCallCount)
+        }
 
     @Test
-    fun `executeDesign failure sets error message`() = runTest {
-        fakeRepository.designResult = Result.failure(RuntimeException("Design failed"))
+    fun `executeDiscuss sets isLoading then populates discussResult on success`() =
+        runTest {
+            val answer = DiscussResult(answer = "Great question!", suggestedIssues = emptyList())
+            fakeRepository.discussResult = Result.success(answer)
 
-        viewModel.selectDesignProject(testProject)
-        viewModel.updateDesignFigmaUrl("https://figma.com/file/abc")
-        viewModel.executeDesign()
-        advanceUntilIdle()
+            viewModel.selectDiscussProject(testProject)
+            viewModel.updateDiscussQuestion("How does it work?")
+            viewModel.executeDiscuss()
+            advanceUntilIdle()
 
-        val state = viewModel.uiState.value
-        assertFalse(state.isDesignLoading)
-        assertNull(state.designResult)
-        assertEquals("Design failed", state.error)
-    }
-
-    @Test
-    fun `executeDesign does nothing when project or figmaUrl is missing`() = runTest {
-        viewModel.executeDesign()
-        advanceUntilIdle()
-
-        assertEquals(0, fakeRepository.designCallCount)
-    }
+            val state = viewModel.uiState.value
+            assertFalse(state.isDiscussLoading)
+            assertNotNull(state.discussResult)
+            assertEquals("Great question!", state.discussResult!!.answer)
+            assertNull(state.error)
+        }
 
     @Test
-    fun `executeShell with safe command sets isLoading then populates shellResult on success`() = runTest {
-        fakeRepository.shellResult = Result.success(ShellResult(output = "hello world", exitCode = 0))
+    fun `executeDiscuss failure sets error message`() =
+        runTest {
+            fakeRepository.discussResult = Result.failure(RuntimeException("Discuss failed"))
 
-        viewModel.updateShellCommand("echo hello world")
-        viewModel.executeShell()
-        advanceUntilIdle()
+            viewModel.selectDiscussProject(testProject)
+            viewModel.updateDiscussQuestion("question")
+            viewModel.executeDiscuss()
+            advanceUntilIdle()
 
-        val state = viewModel.uiState.value
-        assertFalse(state.isShellLoading)
-        assertNotNull(state.shellResult)
-        assertEquals("hello world", state.shellResult!!.output)
-        assertEquals(0, state.shellResult!!.exitCode)
-        assertNull(state.error)
-    }
-
-    @Test
-    fun `executeShell with dangerous command sets showDangerDialog true and does NOT execute`() = runTest {
-        viewModel.updateShellCommand("rm -rf /tmp/test")
-        viewModel.executeShell()
-        advanceUntilIdle()
-
-        val state = viewModel.uiState.value
-        assertTrue(state.showDangerDialog)
-        assertEquals("rm -rf /tmp/test", state.pendingDangerousCommand)
-        assertEquals(0, fakeRepository.executeShellCallCount)
-    }
+            val state = viewModel.uiState.value
+            assertFalse(state.isDiscussLoading)
+            assertNull(state.discussResult)
+            assertEquals("Discuss failed", state.error)
+        }
 
     @Test
-    fun `confirmDangerousCommand executes the pending command`() = runTest {
-        fakeRepository.shellResult = Result.success(ShellResult(output = "done", exitCode = 0))
+    fun `executeDiscuss does nothing when project or question is missing`() =
+        runTest {
+            viewModel.executeDiscuss()
+            advanceUntilIdle()
 
-        viewModel.updateShellCommand("rm -rf /tmp/test")
-        viewModel.executeShell()
-        advanceUntilIdle()
-
-        assertTrue(viewModel.uiState.value.showDangerDialog)
-
-        viewModel.confirmDangerousCommand()
-        advanceUntilIdle()
-
-        val state = viewModel.uiState.value
-        assertFalse(state.showDangerDialog)
-        assertNull(state.pendingDangerousCommand)
-        assertNotNull(state.shellResult)
-        assertEquals(1, fakeRepository.executeShellCallCount)
-        assertEquals("rm -rf /tmp/test", fakeRepository.lastShellCommand)
-    }
+            assertEquals(0, fakeRepository.discussCallCount)
+        }
 
     @Test
-    fun `cancelDangerousCommand clears dialog without executing`() = runTest {
-        viewModel.updateShellCommand("rm -rf /tmp/test")
-        viewModel.executeShell()
-        advanceUntilIdle()
+    fun `executeDesign sets isLoading then populates designResult on success`() =
+        runTest {
+            val spec = DesignResult(spec = "UI spec here")
+            fakeRepository.designResult = Result.success(spec)
 
-        assertTrue(viewModel.uiState.value.showDangerDialog)
+            viewModel.selectDesignProject(testProject)
+            viewModel.updateDesignFigmaUrl("https://figma.com/file/abc")
+            viewModel.executeDesign()
+            advanceUntilIdle()
 
-        viewModel.cancelDangerousCommand()
-
-        val state = viewModel.uiState.value
-        assertFalse(state.showDangerDialog)
-        assertNull(state.pendingDangerousCommand)
-        assertEquals(0, fakeRepository.executeShellCallCount)
-    }
-
-    @Test
-    fun `executeShell failure sets error message`() = runTest {
-        fakeRepository.shellResult = Result.failure(RuntimeException("Shell failed"))
-
-        viewModel.updateShellCommand("ls -la")
-        viewModel.executeShell()
-        advanceUntilIdle()
-
-        val state = viewModel.uiState.value
-        assertFalse(state.isShellLoading)
-        assertNull(state.shellResult)
-        assertEquals("Shell failed", state.error)
-    }
+            val state = viewModel.uiState.value
+            assertFalse(state.isDesignLoading)
+            assertNotNull(state.designResult)
+            assertEquals("UI spec here", state.designResult!!.spec)
+            assertNull(state.error)
+        }
 
     @Test
-    fun `executeShell does nothing when command is blank`() = runTest {
-        viewModel.updateShellCommand("")
-        viewModel.executeShell()
-        advanceUntilIdle()
+    fun `executeDesign failure sets error message`() =
+        runTest {
+            fakeRepository.designResult = Result.failure(RuntimeException("Design failed"))
 
-        assertEquals(0, fakeRepository.executeShellCallCount)
-    }
+            viewModel.selectDesignProject(testProject)
+            viewModel.updateDesignFigmaUrl("https://figma.com/file/abc")
+            viewModel.executeDesign()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertFalse(state.isDesignLoading)
+            assertNull(state.designResult)
+            assertEquals("Design failed", state.error)
+        }
 
     @Test
-    fun `clearError resets error to null`() = runTest {
-        fakeRepository.initProjectResult = Result.failure(RuntimeException("error"))
-        viewModel.updateInitName("test")
-        viewModel.executeInit()
-        advanceUntilIdle()
+    fun `executeDesign does nothing when project or figmaUrl is missing`() =
+        runTest {
+            viewModel.executeDesign()
+            advanceUntilIdle()
 
-        assertNotNull(viewModel.uiState.value.error)
+            assertEquals(0, fakeRepository.designCallCount)
+        }
 
-        viewModel.clearError()
+    @Test
+    fun `executeShell with safe command sets isLoading then populates shellResult on success`() =
+        runTest {
+            fakeRepository.shellResult = Result.success(ShellResult(output = "hello world", exitCode = 0))
 
-        assertNull(viewModel.uiState.value.error)
-    }
+            viewModel.updateShellCommand("echo hello world")
+            viewModel.executeShell()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertFalse(state.isShellLoading)
+            assertNotNull(state.shellResult)
+            assertEquals("hello world", state.shellResult!!.output)
+            assertEquals(0, state.shellResult!!.exitCode)
+            assertNull(state.error)
+        }
+
+    @Test
+    fun `executeShell with dangerous command sets showDangerDialog true and does NOT execute`() =
+        runTest {
+            viewModel.updateShellCommand("rm -rf /tmp/test")
+            viewModel.executeShell()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertTrue(state.showDangerDialog)
+            assertEquals("rm -rf /tmp/test", state.pendingDangerousCommand)
+            assertEquals(0, fakeRepository.executeShellCallCount)
+        }
+
+    @Test
+    fun `confirmDangerousCommand executes the pending command`() =
+        runTest {
+            fakeRepository.shellResult = Result.success(ShellResult(output = "done", exitCode = 0))
+
+            viewModel.updateShellCommand("rm -rf /tmp/test")
+            viewModel.executeShell()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.showDangerDialog)
+
+            viewModel.confirmDangerousCommand()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertFalse(state.showDangerDialog)
+            assertNull(state.pendingDangerousCommand)
+            assertNotNull(state.shellResult)
+            assertEquals(1, fakeRepository.executeShellCallCount)
+            assertEquals("rm -rf /tmp/test", fakeRepository.lastShellCommand)
+        }
+
+    @Test
+    fun `cancelDangerousCommand clears dialog without executing`() =
+        runTest {
+            viewModel.updateShellCommand("rm -rf /tmp/test")
+            viewModel.executeShell()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.showDangerDialog)
+
+            viewModel.cancelDangerousCommand()
+
+            val state = viewModel.uiState.value
+            assertFalse(state.showDangerDialog)
+            assertNull(state.pendingDangerousCommand)
+            assertEquals(0, fakeRepository.executeShellCallCount)
+        }
+
+    @Test
+    fun `executeShell failure sets error message`() =
+        runTest {
+            fakeRepository.shellResult = Result.failure(RuntimeException("Shell failed"))
+
+            viewModel.updateShellCommand("ls -la")
+            viewModel.executeShell()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertFalse(state.isShellLoading)
+            assertNull(state.shellResult)
+            assertEquals("Shell failed", state.error)
+        }
+
+    @Test
+    fun `executeShell does nothing when command is blank`() =
+        runTest {
+            viewModel.updateShellCommand("")
+            viewModel.executeShell()
+            advanceUntilIdle()
+
+            assertEquals(0, fakeRepository.executeShellCallCount)
+        }
+
+    @Test
+    fun `clearError resets error to null`() =
+        runTest {
+            fakeRepository.initProjectResult = Result.failure(RuntimeException("error"))
+            viewModel.updateInitName("test")
+            viewModel.executeInit()
+            advanceUntilIdle()
+
+            assertNotNull(viewModel.uiState.value.error)
+
+            viewModel.clearError()
+
+            assertNull(viewModel.uiState.value.error)
+        }
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/commandcenter/FakeCommandRepository.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/commandcenter/FakeCommandRepository.kt
@@ -1,0 +1,77 @@
+package com.orchestradashboard.shared.ui.commandcenter
+
+import com.orchestradashboard.shared.domain.model.CommandResult
+import com.orchestradashboard.shared.domain.model.DesignResult
+import com.orchestradashboard.shared.domain.model.DiscussResult
+import com.orchestradashboard.shared.domain.model.InitProjectRequest
+import com.orchestradashboard.shared.domain.model.PlanIssuesResult
+import com.orchestradashboard.shared.domain.model.ShellResult
+import com.orchestradashboard.shared.domain.repository.CommandRepository
+
+class FakeCommandRepository : CommandRepository {
+    var initProjectResult: Result<CommandResult> = Result.success(
+        CommandResult(success = true, message = "Project initialized"),
+    )
+    var planIssuesResult: Result<PlanIssuesResult> = Result.success(PlanIssuesResult(emptyList()))
+    var discussResult: Result<DiscussResult> = Result.success(DiscussResult(answer = "Answer"))
+    var designResult: Result<DesignResult> = Result.success(DesignResult(spec = "Spec"))
+    var shellResult: Result<ShellResult> = Result.success(ShellResult(output = "output", exitCode = 0))
+
+    var initProjectCallCount = 0
+        private set
+    var planIssuesCallCount = 0
+        private set
+    var discussCallCount = 0
+        private set
+    var designCallCount = 0
+        private set
+    var executeShellCallCount = 0
+        private set
+
+    var lastInitRequest: InitProjectRequest? = null
+        private set
+    var lastPlanProject: String? = null
+        private set
+    var lastDiscussProject: String? = null
+        private set
+    var lastDiscussQuestion: String? = null
+        private set
+    var lastDesignProject: String? = null
+        private set
+    var lastDesignFigmaUrl: String? = null
+        private set
+    var lastShellCommand: String? = null
+        private set
+
+    override suspend fun initProject(request: InitProjectRequest): Result<CommandResult> {
+        initProjectCallCount++
+        lastInitRequest = request
+        return initProjectResult
+    }
+
+    override suspend fun planIssues(projectName: String): Result<PlanIssuesResult> {
+        planIssuesCallCount++
+        lastPlanProject = projectName
+        return planIssuesResult
+    }
+
+    override suspend fun discuss(projectName: String, question: String): Result<DiscussResult> {
+        discussCallCount++
+        lastDiscussProject = projectName
+        lastDiscussQuestion = question
+        return discussResult
+    }
+
+    override suspend fun design(projectName: String, figmaUrl: String): Result<DesignResult> {
+        designCallCount++
+        lastDesignProject = projectName
+        lastDesignFigmaUrl = figmaUrl
+        return designResult
+    }
+
+    override suspend fun executeShell(command: String): Result<ShellResult> {
+        executeShellCallCount++
+        lastShellCommand = command
+        return shellResult
+    }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/commandcenter/FakeCommandRepository.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/commandcenter/FakeCommandRepository.kt
@@ -9,9 +9,10 @@ import com.orchestradashboard.shared.domain.model.ShellResult
 import com.orchestradashboard.shared.domain.repository.CommandRepository
 
 class FakeCommandRepository : CommandRepository {
-    var initProjectResult: Result<CommandResult> = Result.success(
-        CommandResult(success = true, message = "Project initialized"),
-    )
+    var initProjectResult: Result<CommandResult> =
+        Result.success(
+            CommandResult(success = true, message = "Project initialized"),
+        )
     var planIssuesResult: Result<PlanIssuesResult> = Result.success(PlanIssuesResult(emptyList()))
     var discussResult: Result<DiscussResult> = Result.success(DiscussResult(answer = "Answer"))
     var designResult: Result<DesignResult> = Result.success(DesignResult(spec = "Spec"))
@@ -55,14 +56,20 @@ class FakeCommandRepository : CommandRepository {
         return planIssuesResult
     }
 
-    override suspend fun discuss(projectName: String, question: String): Result<DiscussResult> {
+    override suspend fun discuss(
+        projectName: String,
+        question: String,
+    ): Result<DiscussResult> {
         discussCallCount++
         lastDiscussProject = projectName
         lastDiscussQuestion = question
         return discussResult
     }
 
-    override suspend fun design(projectName: String, figmaUrl: String): Result<DesignResult> {
+    override suspend fun design(
+        projectName: String,
+        figmaUrl: String,
+    ): Result<DesignResult> {
         designCallCount++
         lastDesignProject = projectName
         lastDesignFigmaUrl = figmaUrl

--- a/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/data/repository/ProjectRepositoryImplTest.kt
+++ b/shared/src/desktopTest/kotlin/com/orchestradashboard/shared/data/repository/ProjectRepositoryImplTest.kt
@@ -4,13 +4,22 @@ import com.orchestradashboard.shared.data.api.OrchestratorApi
 import com.orchestradashboard.shared.data.api.OrchestratorNetworkException
 import com.orchestradashboard.shared.data.api.OrchestratorNotFoundException
 import com.orchestradashboard.shared.data.dto.orchestrator.CheckpointDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DesignRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DesignResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DiscussRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.DiscussResponseDto
+import com.orchestradashboard.shared.data.dto.orchestrator.InitProjectRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.InitProjectResponseDto
 import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorIssueDto
 import com.orchestradashboard.shared.data.dto.orchestrator.OrchestratorPipelineDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ParallelPipelineGroupDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineHistoryDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PlanIssuesResponseDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ProjectDetailDto
 import com.orchestradashboard.shared.data.dto.orchestrator.ProjectDto
+import com.orchestradashboard.shared.data.dto.orchestrator.ShellRequestDto
+import com.orchestradashboard.shared.data.dto.orchestrator.ShellResponseDto
 import com.orchestradashboard.shared.data.dto.orchestrator.SystemStatusDto
 import com.orchestradashboard.shared.data.mapper.CheckpointMapper
 import com.orchestradashboard.shared.data.mapper.IssueMapper
@@ -70,6 +79,16 @@ class FakeOrchestratorApi(
     override fun connectEvents(): Flow<PipelineEventDto> = emptyFlow()
 
     override fun connectEvents(pipelineId: String): Flow<PipelineEventDto> = emptyFlow()
+
+    override suspend fun postInitProject(request: InitProjectRequestDto): InitProjectResponseDto = throw NotImplementedError()
+
+    override suspend fun postPlanIssues(projectName: String): PlanIssuesResponseDto = throw NotImplementedError()
+
+    override suspend fun postDiscuss(request: DiscussRequestDto): DiscussResponseDto = throw NotImplementedError()
+
+    override suspend fun postDesign(request: DesignRequestDto): DesignResponseDto = throw NotImplementedError()
+
+    override suspend fun postShell(request: ShellRequestDto): ShellResponseDto = throw NotImplementedError()
 }
 
 class ProjectRepositoryImplTest {


### PR DESCRIPTION
Closes #65

## Design
I now have a complete picture of the codebase. Here is the design document:

---

# Command Center — Design Document (Issue #65)

## SECTION A: Design Document

### 1. Files to Create / Modify

**New Files (shared module — `shared/src/commonMain/kotlin/com/orchestradashboard/shared/`)**

| # | Path | Purpose |
|---|------|---------|
| 1 | `domain/model/CommandResult.kt` | Domain models: `CommandResult`, `CommandType`, `InitProjectRequest`, `PlanIssuesResult`, `DiscussResult`, `DesignResult`, `ShellResult` |
| 2 | `domain/repository/CommandRepository.kt` | Interface: `initProject()`, `planIssues()`, `discuss()`, `design()`, `executeShell()` |
| 3 | `domain/usecase/InitProjectUseCase.kt` | Wraps `commandRepository.initProject()` |
| 4 | `domain/usecase/PlanIssuesUseCase.kt` | Wraps `commandRepository.planIssues()` |
| 5 | `domain/usecase/DiscussUseCase.kt` | Wraps `commandRepository.discuss()` |
| 6 | `domain/usecase/DesignUseCase.kt` | Wraps `commandRepository.design()` |
| 7 | `domain/usecase/ExecuteShellUseCase.kt` | Wraps `commandRepository.executeShell()` |
| 8 | `data/dto/orchestrator/CommandDto.kt` | DTOs: `InitProjectRequestDto`, `InitProjectResponseDto`, `PlanIssuesResponseDto`, `DiscussRequestDto`, `DiscussResponseDto`, `DesignRequestDto`, `DesignResponseDto`, `ShellRequestDto`, `ShellResponseDto` |
| 9 | `data/mapper/CommandMapper.kt` | Maps DTOs ↔ domain models |
| 10 | `data/repository/CommandRepositoryImpl.kt` | Implements `CommandRepository` using `OrchestratorAp

_(truncated)_

## Changed Files (20)
- `androidApp/src/main/kotlin/com/orchestradashboard/android/App.kt`
- `androidApp/src/main/kotlin/com/orchestradashboard/android/di/AppContainer.kt`
- `desktopApp/src/main/kotlin/com/orchestradashboard/desktop/Main.kt`
- `desktopApp/src/main/kotlin/com/orchestradashboard/desktop/di/AppContainer.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/api/OrchestratorApi.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/api/OrchestratorApiClient.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/orchestrator/CommandDto.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/mapper/CommandMapper.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/CommandRepositoryImpl.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/CommandResult.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/CommandRepository.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/DesignUseCase.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/DiscussUseCase.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ExecuteShellUseCase.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/InitProjectUseCase.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/PlanIssuesUseCase.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/commandcenter/CommandCenterUiState.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/commandcenter/CommandCenterViewModel.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/DangerCommandDialog.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/DesignPanel.kt`

## Review
Here are the findings from the review:

### 1. Missing Functionality: iOS Implementation
- **File & Line:** N/A (files are missing)
- **What is wrong:** The acceptance criteria explicitly require a native iOS implementation with `CommandCenterView.swift` (using SwiftUI) and a corresponding `IOSCommandCenterViewModel.swift` wrapper. These files, and the entire iOS feature implementation, are absent from the provided changes.
- **How to fix it:** Create the necessary Swift files and implement the Command Center feature for the iOS target. This includes building the tabbed UI in SwiftUI for the five commands (Init, Plan, Discuss, Design, Shell) and connecting it to the shared `CommandCenterViewModel` via a platform-specific wrapper, ensuring full feature parity with the Desktop and Android ap

_(truncated)_

## AI Audit: PASS
### Audit Verdict

#### Acceptance Criteria Evaluation:

1. **OrchestratorApi interface has 5 new methods**:  
   [PASS] - Methods `postInitProject`, `postPlanIssues`, `postDiscuss`, `postDesign`, `postShell` are added.

2. **OrchestratorApiClient implements all 5 POST methods**:  
   [PASS] - All 5 methods are implemented and hit the correct endpoints.

3. **CommandRepository interface exists with required methods**:  
   [PASS] - Interface includes `initProject()`, `planIssues()`, `discuss()`, `design()`, `executeShell()`.

4. **CommandRepositoryImpl maps DTOs to domain models**:  
   [PASS] - Uses `CommandMapper` and wraps exceptions in `Result`.

5. **CommandCenterViewModel exposes StateFlow**:  
   [PASS] - Exposes `StateFlow<CommandCenterUiState>` with loading/result/error fields.

6. **Init Project form validates project name**:  
   [PASS] - Form checks for non-blank name.

7. **Plan Issues displays PlannedIssue items**:  
   [PASS] - `PlanIssuesPanel` shows title and labels.



_(truncated)_