### PR TITLE
feat: Android/iOS 모바일 앱 — Settings + 네트워크 상태 + TabView (#66)

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:name=".OrchestraApplication"

--- a/androidApp/src/main/kotlin/com/orchestradashboard/android/App.kt
+++ b/androidApp/src/main/kotlin/com/orchestradashboard/android/App.kt
@@ -45,6 +45,9 @@ class MainActivity : ComponentActivity() {
                     commandCenterViewModelFactory = {
                         AppContainer.createCommandCenterViewModel()
                     },
+                    settingsViewModelFactory = {
+                        AppContainer.createSettingsViewModel()
+                    },
                 )
             }
         }

--- a/androidApp/src/main/kotlin/com/orchestradashboard/android/di/AppContainer.kt
+++ b/androidApp/src/main/kotlin/com/orchestradashboard/android/di/AppContainer.kt
@@ -17,6 +17,7 @@ import com.orchestradashboard.shared.data.mapper.SolveCommandMapper
 import com.orchestradashboard.shared.data.mapper.SystemStatusMapper
 import com.orchestradashboard.shared.data.network.DashboardApiClient
 import com.orchestradashboard.shared.data.repository.AgentRepositoryImpl
+import com.orchestradashboard.shared.data.repository.AndroidSettingsRepository
 import com.orchestradashboard.shared.data.repository.AndroidTokenRepository
 import com.orchestradashboard.shared.data.repository.ApprovalRepositoryImpl
 import com.orchestradashboard.shared.data.repository.CheckpointRepositoryImpl
@@ -39,6 +40,7 @@ import com.orchestradashboard.shared.domain.repository.MetricRepository
 import com.orchestradashboard.shared.domain.repository.PipelineMonitorRepository
 import com.orchestradashboard.shared.domain.repository.PipelineRepository
 import com.orchestradashboard.shared.domain.repository.ProjectRepository
+import com.orchestradashboard.shared.domain.repository.SettingsRepository
 import com.orchestradashboard.shared.domain.repository.SolveRepository
 import com.orchestradashboard.shared.domain.repository.SystemRepository
 import com.orchestradashboard.shared.domain.repository.TokenRepository
@@ -53,6 +55,7 @@ import com.orchestradashboard.shared.domain.usecase.GetCheckpointsUseCase
 import com.orchestradashboard.shared.domain.usecase.GetPipelineHistoryUseCase
 import com.orchestradashboard.shared.domain.usecase.GetProjectIssuesUseCase
 import com.orchestradashboard.shared.domain.usecase.GetProjectsUseCase
+import com.orchestradashboard.shared.domain.usecase.GetSettingsUseCase
 import com.orchestradashboard.shared.domain.usecase.GetSystemStatusUseCase
 import com.orchestradashboard.shared.domain.usecase.InitProjectUseCase
 import com.orchestradashboard.shared.domain.usecase.ObserveAgentsUseCase
@@ -62,11 +65,13 @@ import com.orchestradashboard.shared.domain.usecase.ObserveSystemEventsUseCase
 import com.orchestradashboard.shared.domain.usecase.PlanIssuesUseCase
 import com.orchestradashboard.shared.domain.usecase.RespondToApprovalUseCase
 import com.orchestradashboard.shared.domain.usecase.RetryCheckpointUseCase
+import com.orchestradashboard.shared.domain.usecase.SaveSettingsUseCase
 import com.orchestradashboard.shared.ui.agentdetail.AgentDetailViewModel
 import com.orchestradashboard.shared.ui.commandcenter.CommandCenterViewModel
 import com.orchestradashboard.shared.ui.dashboardhome.DashboardHomeViewModel
 import com.orchestradashboard.shared.ui.pipelinemonitor.PipelineMonitorViewModel
 import com.orchestradashboard.shared.ui.projectexplorer.ProjectExplorerViewModel
+import com.orchestradashboard.shared.ui.settings.SettingsViewModel
 import com.orchestradashboard.shared.ui.solvedialog.SolveDialogViewModel
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
@@ -134,6 +139,20 @@ object AppContainer {
 
     val tokenRefreshHandler: TokenRefreshHandler by lazy {
         TokenRefreshHandler(httpClient, serverBaseUrl, tokenRepository)
+    }
+
+    // ─── Settings ──────────────────────────────────────────────────
+
+    val settingsRepository: SettingsRepository by lazy {
+        AndroidSettingsRepository(applicationContext)
+    }
+
+    private val getSettingsUseCase: GetSettingsUseCase by lazy {
+        GetSettingsUseCase(settingsRepository)
+    }
+
+    private val saveSettingsUseCase: SaveSettingsUseCase by lazy {
+        SaveSettingsUseCase(settingsRepository)
     }
 
     // ─── Mappers ────────────────────────────────────────────────
@@ -308,4 +327,6 @@ object AppContainer {
             executeShellUseCase = executeShellUseCase,
             getProjectsUseCase = getProjectsUseCase,
         )
+
+    fun createSettingsViewModel(): SettingsViewModel = SettingsViewModel(getSettingsUseCase, saveSettingsUseCase)
 }

--- a/androidApp/src/main/kotlin/com/orchestradashboard/android/network/AndroidNetworkMonitor.kt
+++ b/androidApp/src/main/kotlin/com/orchestradashboard/android/network/AndroidNetworkMonitor.kt
@@ -1,0 +1,65 @@
+package com.orchestradashboard.android.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import com.orchestradashboard.shared.domain.model.NetworkStatus
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+/**
+ * Monitors network connectivity on Android using ConnectivityManager.
+ * Emits [NetworkStatus] changes as a Flow.
+ */
+class AndroidNetworkMonitor(private val context: Context) {
+    fun observe(): Flow<NetworkStatus> =
+        callbackFlow {
+            val connectivityManager =
+                context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+            val callback =
+                object : ConnectivityManager.NetworkCallback() {
+                    override fun onAvailable(network: Network) {
+                        trySend(NetworkStatus.Available)
+                    }
+
+                    override fun onLost(network: Network) {
+                        trySend(NetworkStatus.Unavailable)
+                    }
+
+                    override fun onCapabilitiesChanged(
+                        network: Network,
+                        networkCapabilities: NetworkCapabilities,
+                    ) {
+                        val hasInternet =
+                            networkCapabilities.hasCapability(
+                                NetworkCapabilities.NET_CAPABILITY_INTERNET,
+                            )
+                        trySend(
+                            if (hasInternet) NetworkStatus.Available else NetworkStatus.Unavailable,
+                        )
+                    }
+                }
+
+            val request =
+                NetworkRequest.Builder()
+                    .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    .build()
+
+            connectivityManager.registerNetworkCallback(request, callback)
+
+            // Emit initial state
+            val activeNetwork = connectivityManager.activeNetwork
+            val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork)
+            val isConnected =
+                capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
+            trySend(if (isConnected) NetworkStatus.Available else NetworkStatus.Unavailable)
+
+            awaitClose {
+                connectivityManager.unregisterNetworkCallback(callback)
+            }
+        }
+}

--- a/androidApp/src/main/kotlin/com/orchestradashboard/android/push/PushNotificationSetup.kt
+++ b/androidApp/src/main/kotlin/com/orchestradashboard/android/push/PushNotificationSetup.kt
@@ -1,0 +1,26 @@
+package com.orchestradashboard.android.push
+
+/**
+ * Push notification setup stub.
+ *
+ * Phase 3: Replace with actual Firebase Cloud Messaging (FCM) integration.
+ * - Add `com.google.firebase:firebase-messaging` dependency
+ * - Add `google-services.json` to androidApp/
+ * - Implement FirebaseMessagingService subclass
+ * - Register device token with orchestrator server
+ */
+object PushNotificationSetup {
+    /**
+     * Initialize push notification services.
+     * Currently a no-op stub for Phase 3 implementation.
+     */
+    fun initialize() {
+        // Phase 3: Initialize Firebase Messaging
+        // FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+        //     if (task.isSuccessful) {
+        //         val token = task.result
+        //         // Send token to orchestrator server
+        //     }
+        // }
+    }
+}

--- a/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/Main.kt
@@ -41,6 +41,9 @@ fun main() =
                     commandCenterViewModelFactory = {
                         AppContainer.createCommandCenterViewModel()
                     },
+                    settingsViewModelFactory = {
+                        AppContainer.createSettingsViewModel()
+                    },
                 )
             }
         }

--- a/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/di/AppContainer.kt
+++ b/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/di/AppContainer.kt
@@ -19,6 +19,7 @@ import com.orchestradashboard.shared.data.repository.AgentRepositoryImpl
 import com.orchestradashboard.shared.data.repository.ApprovalRepositoryImpl
 import com.orchestradashboard.shared.data.repository.CheckpointRepositoryImpl
 import com.orchestradashboard.shared.data.repository.CommandRepositoryImpl
+import com.orchestradashboard.shared.data.repository.DesktopSettingsRepository
 import com.orchestradashboard.shared.data.repository.DesktopTokenRepository
 import com.orchestradashboard.shared.data.repository.EventRepositoryImpl
 import com.orchestradashboard.shared.data.repository.MetricRepositoryImpl
@@ -38,6 +39,7 @@ import com.orchestradashboard.shared.domain.repository.MetricRepository
 import com.orchestradashboard.shared.domain.repository.PipelineMonitorRepository
 import com.orchestradashboard.shared.domain.repository.PipelineRepository
 import com.orchestradashboard.shared.domain.repository.ProjectRepository
+import com.orchestradashboard.shared.domain.repository.SettingsRepository
 import com.orchestradashboard.shared.domain.repository.SolveRepository
 import com.orchestradashboard.shared.domain.repository.SystemRepository
 import com.orchestradashboard.shared.domain.repository.TokenRepository
@@ -52,6 +54,7 @@ import com.orchestradashboard.shared.domain.usecase.GetCheckpointsUseCase
 import com.orchestradashboard.shared.domain.usecase.GetPipelineHistoryUseCase
 import com.orchestradashboard.shared.domain.usecase.GetProjectIssuesUseCase
 import com.orchestradashboard.shared.domain.usecase.GetProjectsUseCase
+import com.orchestradashboard.shared.domain.usecase.GetSettingsUseCase
 import com.orchestradashboard.shared.domain.usecase.GetSystemStatusUseCase
 import com.orchestradashboard.shared.domain.usecase.InitProjectUseCase
 import com.orchestradashboard.shared.domain.usecase.ObserveAgentsUseCase
@@ -61,11 +64,13 @@ import com.orchestradashboard.shared.domain.usecase.ObserveSystemEventsUseCase
 import com.orchestradashboard.shared.domain.usecase.PlanIssuesUseCase
 import com.orchestradashboard.shared.domain.usecase.RespondToApprovalUseCase
 import com.orchestradashboard.shared.domain.usecase.RetryCheckpointUseCase
+import com.orchestradashboard.shared.domain.usecase.SaveSettingsUseCase
 import com.orchestradashboard.shared.ui.agentdetail.AgentDetailViewModel
 import com.orchestradashboard.shared.ui.commandcenter.CommandCenterViewModel
 import com.orchestradashboard.shared.ui.dashboardhome.DashboardHomeViewModel
 import com.orchestradashboard.shared.ui.pipelinemonitor.PipelineMonitorViewModel
 import com.orchestradashboard.shared.ui.projectexplorer.ProjectExplorerViewModel
+import com.orchestradashboard.shared.ui.settings.SettingsViewModel
 import com.orchestradashboard.shared.ui.solvedialog.SolveDialogViewModel
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
@@ -149,6 +154,20 @@ object AppContainer {
 
     val tokenRefreshHandler: TokenRefreshHandler by lazy {
         TokenRefreshHandler(httpClient, serverBaseUrl, tokenRepository)
+    }
+
+    // ─── Settings ──────────────────────────────────────────────────
+
+    val settingsRepository: SettingsRepository by lazy {
+        DesktopSettingsRepository()
+    }
+
+    private val getSettingsUseCase: GetSettingsUseCase by lazy {
+        GetSettingsUseCase(settingsRepository)
+    }
+
+    private val saveSettingsUseCase: SaveSettingsUseCase by lazy {
+        SaveSettingsUseCase(settingsRepository)
     }
 
     // ─── Mappers ────────────────────────────────────────────────
@@ -323,4 +342,6 @@ object AppContainer {
             executeShellUseCase = executeShellUseCase,
             getProjectsUseCase = getProjectsUseCase,
         )
+
+    fun createSettingsViewModel(): SettingsViewModel = SettingsViewModel(getSettingsUseCase, saveSettingsUseCase)
 }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -2,10 +2,36 @@ import SwiftUI
 import Shared
 
 /// Root view for the Orchestra Dashboard iOS app.
-/// Bridges the KMP Shared framework into SwiftUI.
+/// Uses TabView for main navigation across Home, Projects, Commands, and Settings.
 struct ContentView: View {
+    @StateObject private var networkMonitor = NetworkMonitor()
+
     var body: some View {
-        DashboardHomeView()
+        VStack(spacing: 0) {
+            NetworkStatusBannerView(isConnected: networkMonitor.isConnected)
+
+            TabView {
+                DashboardHomeView()
+                    .tabItem {
+                        Label("Home", systemImage: "house")
+                    }
+
+                ProjectExplorerView()
+                    .tabItem {
+                        Label("Projects", systemImage: "folder")
+                    }
+
+                CommandCenterView()
+                    .tabItem {
+                        Label("Commands", systemImage: "terminal")
+                    }
+
+                SettingsView()
+                    .tabItem {
+                        Label("Settings", systemImage: "gearshape")
+                    }
+            }
+        }
     }
 }
 

--- a/iosApp/iosApp/IOSAppContainer.swift
+++ b/iosApp/iosApp/IOSAppContainer.swift
@@ -31,6 +31,14 @@ final class IOSAppContainer {
 
     private lazy var executeSolveUseCase = ExecuteSolveUseCase(repository: solveRepository)
 
+    // MARK: - Settings
+
+    private lazy var settingsRepository: any SettingsRepository = IOSSettingsRepository()
+
+    private lazy var getSettingsUseCase = GetSettingsUseCase(repository: settingsRepository)
+
+    private lazy var saveSettingsUseCase = SaveSettingsUseCase(repository: settingsRepository)
+
     // MARK: - ViewModel Factories
 
     func createDashboardViewModel() -> DashboardViewModel {
@@ -55,5 +63,12 @@ final class IOSAppContainer {
 
     func createCommandCenterViewModel() -> CommandCenterViewModel {
         fatalError("KMP framework must be linked via Gradle :shared:iosArm64Binaries")
+    }
+
+    func createSettingsViewModel() -> SettingsViewModel {
+        return SettingsViewModel(
+            getSettingsUseCase: getSettingsUseCase,
+            saveSettingsUseCase: saveSettingsUseCase
+        )
     }
 }

--- a/iosApp/iosApp/IOSSettingsViewModel.swift
+++ b/iosApp/iosApp/IOSSettingsViewModel.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Shared
+
+/// iOS-specific wrapper around the KMP SettingsViewModel.
+/// Bridges Kotlin coroutine StateFlow to Swift's ObservableObject/Combine.
+@MainActor
+final class IOSSettingsViewModel: ObservableObject {
+    @Published var baseUrl: String = ""
+    @Published var apiKey: String = ""
+    @Published var isSaving: Bool = false
+    @Published var isLoading: Bool = false
+    @Published var saveSuccess: Bool = false
+    @Published var error: String? = nil
+
+    private let kmpViewModel: SettingsViewModel
+    private var stateCollectionTask: Task<Void, Never>?
+
+    init() {
+        let container = IOSAppContainer.shared
+        self.kmpViewModel = container.createSettingsViewModel()
+        startCollectingState()
+    }
+
+    private func startCollectingState() {
+        stateCollectionTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            for await state in kmpViewModel.uiState {
+                self.baseUrl = state.baseUrl
+                self.apiKey = state.apiKey
+                self.isSaving = state.isSaving
+                self.isLoading = state.isLoading
+                self.saveSuccess = state.saveSuccess
+                self.error = state.error
+            }
+        }
+    }
+
+    func loadSettings() {
+        kmpViewModel.loadSettings()
+    }
+
+    func updateBaseUrl(_ url: String) {
+        kmpViewModel.updateBaseUrl(url: url)
+    }
+
+    func updateApiKey(_ key: String) {
+        kmpViewModel.updateApiKey(key: key)
+    }
+
+    func saveSettings() {
+        kmpViewModel.saveSettings()
+    }
+
+    func clearError() {
+        kmpViewModel.clearError()
+    }
+
+    func onCleared() {
+        stateCollectionTask?.cancel()
+        kmpViewModel.onCleared()
+    }
+}

--- a/iosApp/iosApp/NetworkMonitor.swift
+++ b/iosApp/iosApp/NetworkMonitor.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Network
+
+/// Monitors network connectivity using NWPathMonitor.
+/// Publishes connection status changes as an ObservableObject for SwiftUI.
+@MainActor
+final class NetworkMonitor: ObservableObject {
+    @Published var isConnected: Bool = true
+
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "com.orchestradashboard.networkmonitor")
+
+    init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            Task { @MainActor in
+                self?.isConnected = path.status == .satisfied
+            }
+        }
+        monitor.start(queue: queue)
+    }
+
+    deinit {
+        monitor.cancel()
+    }
+}

--- a/iosApp/iosApp/SettingsView.swift
+++ b/iosApp/iosApp/SettingsView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+/// Settings screen for configuring Orchestrator connection.
+/// Provides Base URL and API Key input fields with save functionality.
+struct SettingsView: View {
+    @StateObject private var viewModel = IOSSettingsViewModel()
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Orchestrator Connection")) {
+                    TextField("Base URL", text: Binding(
+                        get: { viewModel.baseUrl },
+                        set: { viewModel.updateBaseUrl($0) }
+                    ))
+                    .keyboardType(.URL)
+                    .autocapitalization(.none)
+                    .disableAutocorrection(true)
+
+                    SecureField("API Key", text: Binding(
+                        get: { viewModel.apiKey },
+                        set: { viewModel.updateApiKey($0) }
+                    ))
+                }
+
+                Section {
+                    Button(action: { viewModel.saveSettings() }) {
+                        HStack {
+                            if viewModel.isSaving {
+                                ProgressView()
+                                    .progressViewStyle(CircularProgressViewStyle())
+                            }
+                            Text("Save Settings")
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                    .disabled(viewModel.isSaving || viewModel.isLoading)
+                }
+
+                if viewModel.saveSuccess {
+                    Section {
+                        HStack {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                            Text("Settings saved successfully.")
+                                .foregroundStyle(.green)
+                        }
+                    }
+                }
+
+                Section(header: Text("About")) {
+                    HStack {
+                        Text("Version")
+                        Spacer()
+                        Text("1.0.0")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                // Phase 3: Push notification settings will be added here
+            }
+            .navigationTitle("Settings")
+        }
+        .onAppear { viewModel.loadSettings() }
+        .onDisappear { viewModel.onCleared() }
+        .alert("Error", isPresented: .constant(viewModel.error != nil)) {
+            Button("OK") { viewModel.clearError() }
+        } message: {
+            Text(viewModel.error ?? "")
+        }
+    }
+}
+
+#Preview {
+    SettingsView()
+}

--- a/iosApp/iosApp/components/NetworkStatusBannerView.swift
+++ b/iosApp/iosApp/components/NetworkStatusBannerView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// Displays an offline banner when network is unavailable.
+struct NetworkStatusBannerView: View {
+    let isConnected: Bool
+
+    var body: some View {
+        if !isConnected {
+            HStack {
+                Image(systemName: "wifi.slash")
+                    .font(.footnote)
+                Text("No internet connection")
+                    .font(.footnote)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+            .padding(.horizontal, 16)
+            .background(Color.red.opacity(0.15))
+            .foregroundStyle(.red)
+        }
+    }
+}
+
+#Preview {
+    VStack {
+        NetworkStatusBannerView(isConnected: false)
+        NetworkStatusBannerView(isConnected: true)
+    }
+}

--- a/shared/src/androidMain/kotlin/com/orchestradashboard/shared/data/repository/AndroidSettingsRepository.kt
+++ b/shared/src/androidMain/kotlin/com/orchestradashboard/shared/data/repository/AndroidSettingsRepository.kt
@@ -1,0 +1,58 @@
+package com.orchestradashboard.shared.data.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import com.orchestradashboard.shared.domain.model.AppSettings
+import com.orchestradashboard.shared.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+
+class AndroidSettingsRepository(context: Context) : SettingsRepository {
+    private val prefs: SharedPreferences by lazy {
+        val masterKey =
+            MasterKey.Builder(context)
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build()
+        EncryptedSharedPreferences.create(
+            context,
+            PREFS_FILE_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+    }
+
+    private val settingsVersion = MutableStateFlow(0)
+
+    override suspend fun getBaseUrl(): String = prefs.getString(KEY_BASE_URL, null) ?: DEFAULT_BASE_URL
+
+    override suspend fun saveBaseUrl(url: String) {
+        prefs.edit().putString(KEY_BASE_URL, url).apply()
+        settingsVersion.value++
+    }
+
+    override suspend fun getApiKey(): String = prefs.getString(KEY_API_KEY, null) ?: ""
+
+    override suspend fun saveApiKey(key: String) {
+        prefs.edit().putString(KEY_API_KEY, key).apply()
+        settingsVersion.value++
+    }
+
+    override fun observeSettings(): Flow<AppSettings> =
+        settingsVersion.map {
+            AppSettings(
+                baseUrl = prefs.getString(KEY_BASE_URL, null) ?: DEFAULT_BASE_URL,
+                apiKey = prefs.getString(KEY_API_KEY, null) ?: "",
+            )
+        }
+
+    companion object {
+        private const val PREFS_FILE_NAME = "orchestra_settings_prefs"
+        private const val KEY_BASE_URL = "base_url"
+        private const val KEY_API_KEY = "api_key"
+        private const val DEFAULT_BASE_URL = "http://localhost:9000"
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/AppSettings.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/AppSettings.kt
@@ -1,0 +1,6 @@
+package com.orchestradashboard.shared.domain.model
+
+data class AppSettings(
+    val baseUrl: String,
+    val apiKey: String,
+)

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/NetworkStatus.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/NetworkStatus.kt
@@ -1,0 +1,7 @@
+package com.orchestradashboard.shared.domain.model
+
+enum class NetworkStatus {
+    Available,
+    Unavailable,
+    Unknown,
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/SettingsRepository.kt
@@ -1,0 +1,16 @@
+package com.orchestradashboard.shared.domain.repository
+
+import com.orchestradashboard.shared.domain.model.AppSettings
+import kotlinx.coroutines.flow.Flow
+
+interface SettingsRepository {
+    suspend fun getBaseUrl(): String
+
+    suspend fun saveBaseUrl(url: String)
+
+    suspend fun getApiKey(): String
+
+    suspend fun saveApiKey(key: String)
+
+    fun observeSettings(): Flow<AppSettings>
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/GetSettingsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/GetSettingsUseCase.kt
@@ -1,0 +1,14 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.model.AppSettings
+import com.orchestradashboard.shared.domain.repository.SettingsRepository
+
+class GetSettingsUseCase(
+    private val repository: SettingsRepository,
+) {
+    suspend operator fun invoke(): AppSettings =
+        AppSettings(
+            baseUrl = repository.getBaseUrl(),
+            apiKey = repository.getApiKey(),
+        )
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/SaveSettingsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/SaveSettingsUseCase.kt
@@ -1,0 +1,15 @@
+package com.orchestradashboard.shared.domain.usecase
+
+import com.orchestradashboard.shared.domain.repository.SettingsRepository
+
+class SaveSettingsUseCase(
+    private val repository: SettingsRepository,
+) {
+    suspend operator fun invoke(
+        baseUrl: String,
+        apiKey: String,
+    ) {
+        repository.saveBaseUrl(baseUrl)
+        repository.saveApiKey(apiKey)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/NetworkStatusBanner.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/NetworkStatusBanner.kt
@@ -1,0 +1,36 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.orchestradashboard.shared.domain.model.NetworkStatus
+
+@Composable
+fun NetworkStatusBanner(
+    status: NetworkStatus,
+    modifier: Modifier = Modifier,
+) {
+    if (status == NetworkStatus.Unavailable) {
+        Box(
+            modifier =
+                modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.errorContainer)
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "No internet connection",
+                color = MaterialTheme.colorScheme.onErrorContainer,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/AppNavigation.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/AppNavigation.kt
@@ -13,6 +13,7 @@ import com.orchestradashboard.shared.ui.commandcenter.CommandCenterViewModel
 import com.orchestradashboard.shared.ui.dashboardhome.DashboardHomeViewModel
 import com.orchestradashboard.shared.ui.pipelinemonitor.PipelineMonitorViewModel
 import com.orchestradashboard.shared.ui.projectexplorer.ProjectExplorerViewModel
+import com.orchestradashboard.shared.ui.settings.SettingsViewModel
 import com.orchestradashboard.shared.ui.solvedialog.SolveDialogViewModel
 
 sealed class Screen {
@@ -27,6 +28,8 @@ sealed class Screen {
     data class PipelineMonitor(val pipelineId: String) : Screen()
 
     data object CommandCenter : Screen()
+
+    data object Settings : Screen()
 }
 
 @Composable
@@ -38,6 +41,7 @@ fun AppNavigation(
     solveDialogViewModelFactory: () -> SolveDialogViewModel,
     pipelineMonitorViewModelFactory: (String) -> PipelineMonitorViewModel,
     commandCenterViewModelFactory: () -> CommandCenterViewModel,
+    settingsViewModelFactory: () -> SettingsViewModel,
     modifier: Modifier = Modifier,
 ) {
     var currentScreen: Screen by remember { mutableStateOf(Screen.DashboardHome) }
@@ -54,6 +58,7 @@ fun AppNavigation(
                 onViewProjectsClick = { currentScreen = Screen.ProjectExplorer },
                 onCommandCenterClick = { currentScreen = Screen.CommandCenter },
                 onPipelineClick = { pipelineId -> currentScreen = Screen.PipelineMonitor(pipelineId) },
+                onSettingsClick = { currentScreen = Screen.Settings },
                 modifier = modifier,
             )
         }
@@ -112,6 +117,17 @@ fun AppNavigation(
                 onDispose { vm.onCleared() }
             }
             CommandCenterScreen(
+                viewModel = vm,
+                onBackClick = { currentScreen = Screen.DashboardHome },
+                modifier = modifier,
+            )
+        }
+        is Screen.Settings -> {
+            val vm = remember { settingsViewModelFactory() }
+            DisposableEffect(Unit) {
+                onDispose { vm.onCleared() }
+            }
+            SettingsScreen(
                 viewModel = vm,
                 onBackClick = { currentScreen = Screen.DashboardHome },
                 modifier = modifier,

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/DashboardHomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/DashboardHomeScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -40,6 +41,7 @@ fun DashboardHomeScreen(
     onViewProjectsClick: () -> Unit,
     onCommandCenterClick: () -> Unit,
     onPipelineClick: (String) -> Unit,
+    onSettingsClick: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsState()
@@ -55,6 +57,9 @@ fun DashboardHomeScreen(
             TopAppBar(
                 title = { Text("Dashboard") },
                 actions = {
+                    IconButton(onClick = onSettingsClick) {
+                        Icon(Icons.Default.Settings, contentDescription = "Settings")
+                    }
                     IconButton(onClick = { viewModel.refresh() }) {
                         Icon(Icons.Default.Refresh, contentDescription = "Refresh")
                     }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/SettingsScreen.kt
@@ -1,0 +1,148 @@
+package com.orchestradashboard.shared.ui.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import com.orchestradashboard.shared.ui.component.ErrorBanner
+import com.orchestradashboard.shared.ui.settings.SettingsViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(
+    viewModel: SettingsViewModel,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadSettings()
+    }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Settings") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+        },
+    ) { paddingValues ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .verticalScroll(rememberScrollState()),
+        ) {
+            state.error?.let { error ->
+                ErrorBanner(message = error, onDismiss = { viewModel.clearError() })
+            }
+
+            if (state.saveSuccess) {
+                Text(
+                    text = "Settings saved successfully.",
+                    color = MaterialTheme.colorScheme.primary,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
+
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text(
+                    text = "Orchestrator Connection",
+                    style = MaterialTheme.typography.titleMedium,
+                )
+
+                OutlinedTextField(
+                    value = state.baseUrl,
+                    onValueChange = { viewModel.updateBaseUrl(it) },
+                    label = { Text("Base URL") },
+                    placeholder = { Text("http://localhost:9000") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                OutlinedTextField(
+                    value = state.apiKey,
+                    onValueChange = { viewModel.updateApiKey(it) },
+                    label = { Text("API Key") },
+                    placeholder = { Text("Enter your API key") },
+                    singleLine = true,
+                    visualTransformation = PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Button(
+                    onClick = { viewModel.saveSettings() },
+                    enabled = !state.isSaving && !state.isLoading,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    if (state.isSaving) {
+                        CircularProgressIndicator(
+                            color = MaterialTheme.colorScheme.onPrimary,
+                        )
+                    } else {
+                        Text("Save Settings")
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = "About",
+                    style = MaterialTheme.typography.titleMedium,
+                )
+
+                Text(
+                    text = "Orchestra Dashboard v1.0.0",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                // Phase 3: Push notification settings will be added here
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/settings/SettingsUiState.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/settings/SettingsUiState.kt
@@ -1,0 +1,10 @@
+package com.orchestradashboard.shared.ui.settings
+
+data class SettingsUiState(
+    val baseUrl: String = "",
+    val apiKey: String = "",
+    val isSaving: Boolean = false,
+    val isLoading: Boolean = false,
+    val saveSuccess: Boolean = false,
+    val error: String? = null,
+)

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/settings/SettingsViewModel.kt
@@ -1,0 +1,87 @@
+package com.orchestradashboard.shared.ui.settings
+
+import com.orchestradashboard.shared.domain.usecase.GetSettingsUseCase
+import com.orchestradashboard.shared.domain.usecase.SaveSettingsUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class SettingsViewModel(
+    private val getSettingsUseCase: GetSettingsUseCase,
+    private val saveSettingsUseCase: SaveSettingsUseCase,
+) {
+    private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val _uiState = MutableStateFlow(SettingsUiState())
+    val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
+    fun loadSettings() {
+        _uiState.update { it.copy(isLoading = true, error = null) }
+        viewModelScope.launch {
+            try {
+                val settings = getSettingsUseCase()
+                _uiState.update {
+                    it.copy(
+                        baseUrl = settings.baseUrl,
+                        apiKey = settings.apiKey,
+                        isLoading = false,
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = e.message ?: "Failed to load settings",
+                    )
+                }
+            }
+        }
+    }
+
+    fun updateBaseUrl(url: String) {
+        _uiState.update { it.copy(baseUrl = url, saveSuccess = false) }
+    }
+
+    fun updateApiKey(key: String) {
+        _uiState.update { it.copy(apiKey = key, saveSuccess = false) }
+    }
+
+    fun saveSettings() {
+        val state = _uiState.value
+        if (state.baseUrl.isBlank()) {
+            _uiState.update { it.copy(error = "Base URL cannot be empty") }
+            return
+        }
+
+        _uiState.update { it.copy(isSaving = true, error = null, saveSuccess = false) }
+        viewModelScope.launch {
+            try {
+                saveSettingsUseCase(
+                    baseUrl = state.baseUrl.trim(),
+                    apiKey = state.apiKey.trim(),
+                )
+                _uiState.update { it.copy(isSaving = false, saveSuccess = true) }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        isSaving = false,
+                        error = e.message ?: "Failed to save settings",
+                    )
+                }
+            }
+        }
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(error = null) }
+    }
+
+    fun onCleared() {
+        viewModelScope.cancel()
+    }
+}

--- a/shared/src/desktopMain/kotlin/com/orchestradashboard/shared/data/repository/DesktopSettingsRepository.kt
+++ b/shared/src/desktopMain/kotlin/com/orchestradashboard/shared/data/repository/DesktopSettingsRepository.kt
@@ -1,0 +1,45 @@
+package com.orchestradashboard.shared.data.repository
+
+import com.orchestradashboard.shared.domain.model.AppSettings
+import com.orchestradashboard.shared.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import java.util.prefs.Preferences
+
+class DesktopSettingsRepository : SettingsRepository {
+    private val prefs: Preferences =
+        Preferences.userNodeForPackage(DesktopSettingsRepository::class.java)
+
+    private val settingsVersion = MutableStateFlow(0)
+
+    override suspend fun getBaseUrl(): String = prefs.get(KEY_BASE_URL, DEFAULT_BASE_URL)
+
+    override suspend fun saveBaseUrl(url: String) {
+        prefs.put(KEY_BASE_URL, url)
+        prefs.flush()
+        settingsVersion.value++
+    }
+
+    override suspend fun getApiKey(): String = prefs.get(KEY_API_KEY, "")
+
+    override suspend fun saveApiKey(key: String) {
+        prefs.put(KEY_API_KEY, key)
+        prefs.flush()
+        settingsVersion.value++
+    }
+
+    override fun observeSettings(): Flow<AppSettings> =
+        settingsVersion.map {
+            AppSettings(
+                baseUrl = prefs.get(KEY_BASE_URL, DEFAULT_BASE_URL),
+                apiKey = prefs.get(KEY_API_KEY, ""),
+            )
+        }
+
+    companion object {
+        private const val KEY_BASE_URL = "base_url"
+        private const val KEY_API_KEY = "api_key"
+        private const val DEFAULT_BASE_URL = "http://localhost:9000"
+    }
+}

--- a/shared/src/iosMain/kotlin/com/orchestradashboard/shared/data/repository/IOSSettingsRepository.kt
+++ b/shared/src/iosMain/kotlin/com/orchestradashboard/shared/data/repository/IOSSettingsRepository.kt
@@ -1,0 +1,46 @@
+package com.orchestradashboard.shared.data.repository
+
+import com.orchestradashboard.shared.domain.model.AppSettings
+import com.orchestradashboard.shared.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import platform.Foundation.NSUserDefaults
+
+class IOSSettingsRepository : SettingsRepository {
+    private val defaults = NSUserDefaults.standardUserDefaults
+
+    private val settingsVersion = MutableStateFlow(0)
+
+    override suspend fun getBaseUrl(): String = defaults.stringForKey(KEY_BASE_URL) ?: DEFAULT_BASE_URL
+
+    override suspend fun saveBaseUrl(url: String) {
+        defaults.setObject(url, forKey = KEY_BASE_URL)
+        defaults.synchronize()
+        settingsVersion.value++
+    }
+
+    // TODO: Phase 2 — Migrate API key storage to iOS Keychain for production security.
+    //  Currently using NSUserDefaults for simplicity during initial implementation.
+    override suspend fun getApiKey(): String = defaults.stringForKey(KEY_API_KEY) ?: ""
+
+    override suspend fun saveApiKey(key: String) {
+        defaults.setObject(key, forKey = KEY_API_KEY)
+        defaults.synchronize()
+        settingsVersion.value++
+    }
+
+    override fun observeSettings(): Flow<AppSettings> =
+        settingsVersion.map {
+            AppSettings(
+                baseUrl = defaults.stringForKey(KEY_BASE_URL) ?: DEFAULT_BASE_URL,
+                apiKey = defaults.stringForKey(KEY_API_KEY) ?: "",
+            )
+        }
+
+    companion object {
+        private const val KEY_BASE_URL = "orchestra_base_url"
+        private const val KEY_API_KEY = "orchestra_api_key"
+        private const val DEFAULT_BASE_URL = "http://localhost:9000"
+    }
+}


### PR DESCRIPTION
## Summary
- Settings 화면 전체 레이어 구현 (Base URL + API Key 입력/저장) — domain, data(플랫폼별), ui
- 네트워크 상태 처리: Android ConnectivityManager / iOS NWPathMonitor + 오프라인 배너 UI
- iOS ContentView를 TabView 4탭 구조로 변경 (Home, Projects, Commands, Settings)
- Push 알림 기본 설정 스텁 (Phase 3 서버 연동 대비)
- Android/Desktop/iOS DI 컨테이너 업데이트

## Test plan
- [x] ktlintCheck 통과
- [x] detekt 통과
- [x] desktopApp:build 통과
- [x] shared:desktopTest 전체 통과

Closes #66