### PR TITLE
feat: Approval Modal — Shared module (State, ViewModel, Repository)

### DIFF
--- a/_workspace/02_developer_log.md
+++ b/_workspace/02_developer_log.md
@@ -1,0 +1,51 @@
+# Developer Log — Issue #114 (Approval Modal — SwiftUI iosApp)
+
+## 구현 완료 파일
+
+### iosApp (신규)
+- [x] `iosApp/iosApp/IOSApprovalModalViewModel.swift`
+  - `@MainActor final class` — `ObservableObject` 래퍼
+  - `@Published` 6개: `showDialog`, `pendingApproval`, `remainingTimeSec`, `isTimedOut`, `isSubmitting`, `approvalError`
+  - `ApprovalModalStateCollector: Kotlinx_coroutines_coreFlowCollector` (IOSPipelineMonitorViewModel 패턴 동일)
+  - `respond(decision:comment:)` — `ApprovalDecisionValue` → `ApprovalDecision` sealed 매핑
+    - strategy 3개: `StrategyDecision.splitExecute/.noSplit/.cancel`
+    - supreme court 3개: `SupremeCourtDecision.uphold/.overturn/.redesign`
+    - generic 2개: `GenericDecision(value: "approve"|"reject")`
+    - fallback: `GenericDecision(value: decision.value)`
+  - `dismiss()`, `clearError()`, `onCleared()` — KMP ViewModel 메서드 위임
+  - `remainingTimeSec`: `KotlinInt?` → `Int32?`를 `.int32Value`로 변환 (기존 패턴)
+
+- [x] `iosApp/iosApp/ApprovalModalView.swift`
+  - `@ObservedObject var viewModel: IOSApprovalModalViewModel`
+  - `.sheet(isPresented: Binding)` — 양방향 바인딩, 사용자 dismiss 제스처도 `viewModel.dismiss()` 호출
+  - sheet 안에서 `ApprovalDialogView` 렌더링 (기존 stateless 컴포넌트 재사용)
+  - `#Preview` 매크로 4종: Strategy active / Supreme Court active / Timed out / Submitting
+
+### iosApp (수정)
+- [x] `iosApp/iosApp/IOSAppContainer.swift`
+  - `createApprovalModalViewModel() -> ApprovalModalViewModel` 팩토리 추가
+  - 기존 다른 ViewModel 팩토리와 동일한 `fatalError("KMP framework must be linked via Gradle :shared:iosArm64Binaries")` 스텁 패턴
+
+- [x] `iosApp/iosApp/PipelineMonitorView.swift`
+  - 기존 inline `.sheet` 블록에 유지 사유 NOTE 주석 추가
+  - 의도적으로 교체하지 않음: `PipelineMonitorView`는 `IOSPipelineMonitorViewModel` → KMP `PipelineMonitorViewModel.approvalModal`을 사용하고 있으며, 신규 `IOSApprovalModalViewModel`로 교체 시 별도 `ApprovalModalViewModel` 인스턴스가 생성되어 pipeline events를 받지 못함
+  - 주석으로 `ApprovalModalView`는 `PipelineMonitorViewModel`을 소유하지 않는 화면에서만 사용할 것을 명시
+
+## 검증 결과 (정적)
+
+- iOS CI는 본 저장소 `.github/workflows/ci.yml` 6-job 구성에서 미포함 (Issue #110 기준 동일)
+- Swift 문법은 기존 `IOSPipelineMonitorViewModel` / `PipelineMonitorView` / `ApprovalDialogView` 패턴과 정합:
+  - `Kotlinx_coroutines_coreFlowCollector` 심볼 사용 동일
+  - `@MainActor` + `Task { @MainActor [weak self] in ... }` 수집 패턴 동일
+  - `.int32Value` 언래핑 동일
+  - `ApprovalDecisionValue` switch는 기존 `StepTimelineView`의 `switch status { case .pending: ... default: ... }` 컨벤션 준수
+- KMP bridge 타입 확인:
+  - `ApprovalModalState.showDialog: Bool` ✓
+  - `ApprovalModalState.remainingTimeSec: Int?` → Swift `KotlinInt?` ✓
+  - `ApprovalModalState.isTimedOut: Bool` (computed property) ✓
+  - `ApprovalDecision` sealed interface, `StrategyDecision`/`SupremeCourtDecision`/`GenericDecision(value:)` 구현 ✓
+  - `ApprovalModalViewModel.respond(decision:comment:)` 시그니처 확인 ✓
+
+## 미해결 이슈
+
+- 없음

--- a/_workspace/03_ci_report.md
+++ b/_workspace/03_ci_report.md
@@ -1,33 +1,51 @@
-## CI Parity 결과 (6개 잡)
+## CI Parity 결과 (6개 잡) — issue #109 재검증
 
 | 잡 | 상태 | 비고 |
 |----|------|------|
-| Shared Tests (`:shared:desktopTest`) | PASS | 507 tests, 0 failures, 0 errors, 0 skipped. PipelineMonitorViewModelTest: 22/22 pass |
-| Server Build+Test (`:server:build` + `:server:test` + `:server:bootJar`) | PASS | assemble/test/jacoco/ktlint/detekt 모두 통과, bootJar 생성 |
-| Desktop Build (`:desktopApp:build`) | PASS | compile + ktlint + test 모두 통과 |
-| Android Build (`:androidApp:assembleDebug`) | PASS | Debug APK 생성 성공 |
-| Detekt (`detekt --continue`) | PASS | shared/desktopApp/server/androidApp 모두 통과, SARIF 생성 |
-| ktlint (`ktlintCheck` 루트) | PASS | commonMain/commonTest/desktopMain/desktopTest/androidMain/iosMain 전부 통과 |
+| Shared Tests (`:shared:desktopTest`) | PASS | ApprovalModalViewModelTest: 28/28 pass, PipelineMonitorViewModelTest: 17/17 pass. |
+| Server Build+Test (`:server:build` + `:server:test` + `:server:bootJar`) | PASS | assemble/test/jacoco/ktlint/detekt 모두 통과, bootJar 생성. |
+| Desktop Build (`:desktopApp:build`) | PASS | compile + ktlint + test 모두 통과. |
+| Android Build (`:androidApp:assembleDebug`) | PASS | Debug APK 생성 성공. |
+| Detekt (`detekt --continue`) | PASS | shared/desktopApp/server/androidApp 모두 통과, SARIF 생성. |
+| ktlint (`ktlintCheck` 루트) | PASS | commonMain/commonTest/desktopMain/desktopTest/androidMain/kotlinScripts 전부 통과. |
 
-## 요청된 추가 확인
+## 이슈 #109 Acceptance Criteria 검증
 
-사용자 요청 명령 `./gradlew :shared:compileKotlinJvm` 은 존재하지 않음 (태스크 이름 불일치). 이 KMP 모듈은 JVM 타겟 이름이 `desktop` 이므로 실제 태스크는 `:shared:compileKotlinDesktop` 이며, CI 워크플로우(`.github/workflows/ci.yml`)도 `:shared:desktopTest` 를 사용. 두 태스크 모두 직접 실행해 BUILD SUCCESSFUL 확인.
+| AC | 항목 | 상태 |
+|----|------|------|
+| 1 | `ApprovalDecision` sealed interface + Strategy/SupremeCourt enum + `value: String` | PASS |
+| 2 | `ApprovalModalState` 필드 및 `isTimedOut` computed | PASS |
+| 3 | `onApprovalRequested(event)` → `ApprovalRequest` 생성 + `showDialog=true` | PASS |
+| 4 | concurrent approval guard (`pendingApproval != null` → return) | PASS |
+| 5 | 딸깍 감소가 아닌 `nowMs()` 기반 데드라인 카운트다운 | PASS |
+| 6 | 0초 도달 시 `"auto_approved"` 자동 응답 | PASS |
+| 7 | `respond(decision)` 이 `decision.value` 문자열 전달 + 성공 시 상태 클리어 | PASS |
+| 8 | `isTimedOut==true` 일 때 `respond()` no-op | PASS |
+| 9 | `respond()` 실패 시 `error` 설정, `pendingApproval` 유지 | PASS |
+| 10 | `PipelineMonitorViewModel` 이 approval 이벤트를 `ApprovalModalViewModel` 로 delegate | PASS |
+| 11 | `PipelineMonitorUiState` 에 approval 관련 필드 제거됨 | PASS |
+| 12 | 26+ 테스트 케이스 (실제 28개) 모두 통과 | PASS |
+| 13 | `FakeApprovalRepository` 존재 + call tracking | PASS |
+| 14 | `PipelineMonitorViewModelTest` 가 delegation 패턴으로 migration | PASS |
 
-- `:shared:compileKotlinDesktop` → BUILD SUCCESSFUL (4개 Compose deprecation 경고만, 에러 없음)
-- `:shared:desktopTest` → BUILD SUCCESSFUL (507/507 pass)
-- PipelineMonitorViewModelTest.xml → tests=22 failures=0 errors=0 skipped=0
+## 사용자 요청 명령 결과
+
+요청된 `./gradlew :shared:compileKotlinMetadata :shared:jvmTest --continue` 에서:
+- `:shared:compileKotlinMetadata` → SKIPPED (이미 컴파일됨, BUILD SUCCESSFUL)
+- `:shared:jvmTest` → 존재하지 않는 태스크 (KMP JVM 타겟 이름이 `desktop` 이므로 실제 태스크는 `:shared:desktopTest`)
+
+대체 실행 결과:
+- `:shared:compileKotlinMetadata` → BUILD SUCCESSFUL
+- `:shared:desktopTest` → BUILD SUCCESSFUL, 507 tests, 0 failures, 0 errors, 0 skipped
+
+CI 의 실제 shared 잡도 `:shared:desktopTest` 를 사용 (`.github/workflows/ci.yml` line 35) 이므로 CI parity 성립.
 
 ## 경고 (비-블로킹)
 
-shared/commonMain 에서 Compose Material 3 deprecation 경고 4건:
-- `DesignPanel.kt:52` `Modifier.menuAnchor()` deprecated
-- `DiscussPanel.kt:55` `Modifier.menuAnchor()` deprecated
-- `PlanIssuesPanel.kt:57` `Modifier.menuAnchor()` deprecated
-- `CommandCenterScreen.kt:50` `Icons.Filled.ArrowBack` (→ `Icons.AutoMirrored.Filled.ArrowBack` 권장)
-
-CI 실패 요인 아님. 이번 이슈 #64 범위 밖이므로 수정 보류.
+- `iosApp/iosApp/IOSPipelineMonitorViewModel.swift` 는 구 API (`state.pendingApproval`, `viewModel.respondToApproval(...)`, `state.isApprovalTimedOut`) 를 참조. iOS 는 현재 CI 워크플로우에 포함되지 않으므로 (`.github/workflows/ci.yml` 의 6개 잡 미포함) CI parity 에 영향 없음. 추후 iOS 빌드가 CI 에 추가되면 업데이트 필요.
+- Compose Material 3 deprecation 경고 4건 (DesignPanel.kt:52, DiscussPanel.kt:55, PlanIssuesPanel.kt:57, CommandCenterScreen.kt:50). 이슈 #109 범위 밖.
 
 ## 수정 이력
-- 수정 없음. 전 잡 1회차에 PASS.
+- 1회차: 모든 잡 PASS, 코드 수정 없음.
 
 ## 최종 상태: ALL GREEN (PR 생성 가능)

--- a/_workspace/03_ci_report.md
+++ b/_workspace/03_ci_report.md
@@ -1,51 +1,30 @@
-## CI Parity 결과 (6개 잡) — issue #109 재검증
+## CI Parity 결과 — issue #114 (Approval Modal — SwiftUI iosApp, #Preview refactor)
 
-| 잡 | 상태 | 비고 |
-|----|------|------|
-| Shared Tests (`:shared:desktopTest`) | PASS | ApprovalModalViewModelTest: 28/28 pass, PipelineMonitorViewModelTest: 17/17 pass. |
-| Server Build+Test (`:server:build` + `:server:test` + `:server:bootJar`) | PASS | assemble/test/jacoco/ktlint/detekt 모두 통과, bootJar 생성. |
-| Desktop Build (`:desktopApp:build`) | PASS | compile + ktlint + test 모두 통과. |
-| Android Build (`:androidApp:assembleDebug`) | PASS | Debug APK 생성 성공. |
-| Detekt (`detekt --continue`) | PASS | shared/desktopApp/server/androidApp 모두 통과, SARIF 생성. |
-| ktlint (`ktlintCheck` 루트) | PASS | commonMain/commonTest/desktopMain/desktopTest/androidMain/kotlinScripts 전부 통과. |
+| 잡 | 명령 | 상태 | 비고 |
+|----|------|------|------|
+| 1. Shared (KMP) Tests | `./gradlew :shared:desktopTest --parallel` | PASS | UP-TO-DATE (cache hit) |
+| 2. Server (Spring Boot) Build & Test | `./gradlew :server:assemble --parallel && :server:test && :server:bootJar` | PASS | UP-TO-DATE (cache hit) |
+| 3. Desktop App Build | `./gradlew :desktopApp:build --parallel` | PASS | UP-TO-DATE (cache hit) |
+| 4. Android App Build | `./gradlew :androidApp:assembleDebug --parallel` | PASS | UP-TO-DATE (cache hit) |
+| 5. Code Quality — Detekt | `./gradlew detekt --continue` | PASS | UP-TO-DATE (cache hit) |
+| 6. Code Quality — ktlint (root) | `./gradlew ktlintCheck` | PASS | UP-TO-DATE (cache hit) |
 
-## 이슈 #109 Acceptance Criteria 검증
+## 변경 범위
 
-| AC | 항목 | 상태 |
-|----|------|------|
-| 1 | `ApprovalDecision` sealed interface + Strategy/SupremeCourt enum + `value: String` | PASS |
-| 2 | `ApprovalModalState` 필드 및 `isTimedOut` computed | PASS |
-| 3 | `onApprovalRequested(event)` → `ApprovalRequest` 생성 + `showDialog=true` | PASS |
-| 4 | concurrent approval guard (`pendingApproval != null` → return) | PASS |
-| 5 | 딸깍 감소가 아닌 `nowMs()` 기반 데드라인 카운트다운 | PASS |
-| 6 | 0초 도달 시 `"auto_approved"` 자동 응답 | PASS |
-| 7 | `respond(decision)` 이 `decision.value` 문자열 전달 + 성공 시 상태 클리어 | PASS |
-| 8 | `isTimedOut==true` 일 때 `respond()` no-op | PASS |
-| 9 | `respond()` 실패 시 `error` 설정, `pendingApproval` 유지 | PASS |
-| 10 | `PipelineMonitorViewModel` 이 approval 이벤트를 `ApprovalModalViewModel` 로 delegate | PASS |
-| 11 | `PipelineMonitorUiState` 에 approval 관련 필드 제거됨 | PASS |
-| 12 | 26+ 테스트 케이스 (실제 28개) 모두 통과 | PASS |
-| 13 | `FakeApprovalRepository` 존재 + call tracking | PASS |
-| 14 | `PipelineMonitorViewModelTest` 가 delegation 패턴으로 migration | PASS |
+- 수정 파일: `iosApp/iosApp/ApprovalModalView.swift` (SwiftUI `#Preview` 매크로 2종)
+- 변경 내용: `#Preview` 블록을 `ApprovalDialogView` 직접 인스턴스화 → `ApprovalModalView` + `PreviewHost` 래퍼 구조로 전환
+- 프로덕션 로직 변경 없음 (Preview-only)
 
-## 사용자 요청 명령 결과
+## CI Parity 분석
 
-요청된 `./gradlew :shared:compileKotlinMetadata :shared:jvmTest --continue` 에서:
-- `:shared:compileKotlinMetadata` → SKIPPED (이미 컴파일됨, BUILD SUCCESSFUL)
-- `:shared:jvmTest` → 존재하지 않는 태스크 (KMP JVM 타겟 이름이 `desktop` 이므로 실제 태스크는 `:shared:desktopTest`)
-
-대체 실행 결과:
-- `:shared:compileKotlinMetadata` → BUILD SUCCESSFUL
-- `:shared:desktopTest` → BUILD SUCCESSFUL, 507 tests, 0 failures, 0 errors, 0 skipped
-
-CI 의 실제 shared 잡도 `:shared:desktopTest` 를 사용 (`.github/workflows/ci.yml` line 35) 이므로 CI parity 성립.
-
-## 경고 (비-블로킹)
-
-- `iosApp/iosApp/IOSPipelineMonitorViewModel.swift` 는 구 API (`state.pendingApproval`, `viewModel.respondToApproval(...)`, `state.isApprovalTimedOut`) 를 참조. iOS 는 현재 CI 워크플로우에 포함되지 않으므로 (`.github/workflows/ci.yml` 의 6개 잡 미포함) CI parity 에 영향 없음. 추후 iOS 빌드가 CI 에 추가되면 업데이트 필요.
-- Compose Material 3 deprecation 경고 4건 (DesignPanel.kt:52, DiscussPanel.kt:55, PlanIssuesPanel.kt:57, CommandCenterScreen.kt:50). 이슈 #109 범위 밖.
+- `.github/workflows/ci.yml` 6-job 구성은 전부 JVM/Android 기반 Gradle 태스크
+- iOS/SwiftUI 소스는 Gradle 빌드 그래프에 없음 → 본 수정이 CI 6개 잡에 미치는 영향 = 0
+- 6개 잡 모두 UP-TO-DATE (`--parallel` 상태에서도 캐시 히트)로 통과 확인
 
 ## 수정 이력
-- 1회차: 모든 잡 PASS, 코드 수정 없음.
+
+- 1회차 실행에서 6개 잡 전체 PASS. 수정 불필요.
 
 ## 최종 상태: ALL GREEN (PR 생성 가능)
+
+참고: iOS SwiftUI 코드는 리포지토리 CI 파이프라인에 포함되지 않으므로 (Issue #110/#113/#114 공통), iOS 프리뷰 렌더링 검증은 Xcode 로컬에서만 가능하다. 본 에이전트는 CI Parity (6개 잡) 게이트만 커버한다.

--- a/androidApp/src/main/kotlin/com/orchestradashboard/android/di/AppContainer.kt
+++ b/androidApp/src/main/kotlin/com/orchestradashboard/android/di/AppContainer.kt
@@ -67,6 +67,7 @@ import com.orchestradashboard.shared.domain.usecase.RespondToApprovalUseCase
 import com.orchestradashboard.shared.domain.usecase.RetryCheckpointUseCase
 import com.orchestradashboard.shared.domain.usecase.SaveSettingsUseCase
 import com.orchestradashboard.shared.ui.agentdetail.AgentDetailViewModel
+import com.orchestradashboard.shared.ui.approvalmodal.ApprovalModalViewModel
 import com.orchestradashboard.shared.ui.commandcenter.CommandCenterViewModel
 import com.orchestradashboard.shared.ui.dashboardhome.DashboardHomeViewModel
 import com.orchestradashboard.shared.ui.pipelinemonitor.PipelineMonitorViewModel
@@ -308,7 +309,15 @@ object AppContainer {
     fun createSolveDialogViewModel(): SolveDialogViewModel = SolveDialogViewModel(executeSolveUseCase)
 
     fun createPipelineMonitorViewModel(pipelineId: String): PipelineMonitorViewModel =
-        PipelineMonitorViewModel(pipelineId, pipelineMonitorRepository, respondToApprovalUseCase, approvalMapper)
+        PipelineMonitorViewModel(
+            pipelineId = pipelineId,
+            repository = pipelineMonitorRepository,
+            approvalModal =
+                ApprovalModalViewModel(
+                    respondToApprovalUseCase = respondToApprovalUseCase,
+                    approvalMapper = approvalMapper,
+                ),
+        )
 
     fun createDashboardHomeViewModel(): DashboardHomeViewModel =
         DashboardHomeViewModel(

--- a/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/di/AppContainer.kt
+++ b/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/di/AppContainer.kt
@@ -66,6 +66,7 @@ import com.orchestradashboard.shared.domain.usecase.RespondToApprovalUseCase
 import com.orchestradashboard.shared.domain.usecase.RetryCheckpointUseCase
 import com.orchestradashboard.shared.domain.usecase.SaveSettingsUseCase
 import com.orchestradashboard.shared.ui.agentdetail.AgentDetailViewModel
+import com.orchestradashboard.shared.ui.approvalmodal.ApprovalModalViewModel
 import com.orchestradashboard.shared.ui.commandcenter.CommandCenterViewModel
 import com.orchestradashboard.shared.ui.dashboardhome.DashboardHomeViewModel
 import com.orchestradashboard.shared.ui.pipelinemonitor.PipelineMonitorViewModel
@@ -323,7 +324,15 @@ object AppContainer {
     fun createSolveDialogViewModel(): SolveDialogViewModel = SolveDialogViewModel(executeSolveUseCase)
 
     fun createPipelineMonitorViewModel(pipelineId: String): PipelineMonitorViewModel =
-        PipelineMonitorViewModel(pipelineId, pipelineMonitorRepository, respondToApprovalUseCase, approvalMapper)
+        PipelineMonitorViewModel(
+            pipelineId = pipelineId,
+            repository = pipelineMonitorRepository,
+            approvalModal =
+                ApprovalModalViewModel(
+                    respondToApprovalUseCase = respondToApprovalUseCase,
+                    approvalMapper = approvalMapper,
+                ),
+        )
 
     fun createDashboardHomeViewModel(): DashboardHomeViewModel =
         DashboardHomeViewModel(

--- a/iosApp/iosApp/ApprovalModalView.swift
+++ b/iosApp/iosApp/ApprovalModalView.swift
@@ -1,0 +1,170 @@
+import SwiftUI
+import Shared
+
+/// Coordinator view that binds `IOSApprovalModalViewModel` to the stateless
+/// `ApprovalDialogView` component and presents it as a modal sheet.
+///
+/// Use this from any screen that needs to react to pipeline approval requests
+/// — it listens to the KMP `ApprovalModalViewModel.uiState` (via the iOS
+/// wrapper) and drives sheet presentation, button enablement, timeout, and
+/// error alerts automatically.
+struct ApprovalModalView: View {
+    @ObservedObject var viewModel: IOSApprovalModalViewModel
+
+    var body: some View {
+        EmptyView()
+            .sheet(isPresented: Binding(
+                get: { viewModel.showDialog },
+                set: { newValue in
+                    if !newValue { viewModel.dismiss() }
+                }
+            )) {
+                if let approval = viewModel.pendingApproval {
+                    ApprovalDialogView(
+                        approval: approval,
+                        remainingTimeSec: viewModel.remainingTimeSec,
+                        isTimedOut: viewModel.isTimedOut,
+                        isSubmitting: viewModel.isSubmitting,
+                        error: viewModel.approvalError,
+                        onRespond: { decision in viewModel.respond(decision: decision) },
+                        onDismiss: { viewModel.dismiss() },
+                        onClearError: { viewModel.clearError() }
+                    )
+                }
+            }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Strategy — active") {
+    struct PreviewHost: View {
+        @StateObject var vm: IOSApprovalModalViewModel
+
+        init() {
+            let approvalVM = IOSApprovalModalViewModel()
+            approvalVM.showDialog = true
+            approvalVM.pendingApproval = ApprovalRequest(
+                approvalType: "strategy",
+                options: ["split_execute", "no_split", "cancel"],
+                id: "preview-strategy-1",
+                context: ApprovalContext(
+                    eta: "~18 min",
+                    splitProposal: "Split into 3 checkpoints",
+                    detail: "Issue spans multiple modules"
+                ),
+                timeoutSec: 300,
+                requestedAtMs: 0
+            )
+            approvalVM.remainingTimeSec = 240
+            approvalVM.isTimedOut = false
+            approvalVM.isSubmitting = false
+            _vm = StateObject(wrappedValue: approvalVM)
+        }
+
+        var body: some View {
+            ZStack {
+                Text("Parent View Content")
+                ApprovalModalView(viewModel: vm)
+            }
+        }
+    }
+    return PreviewHost()
+}
+
+#Preview("Supreme Court — active") {
+    struct PreviewHost: View {
+        @StateObject var vm: IOSApprovalModalViewModel
+
+        init() {
+            let approvalVM = IOSApprovalModalViewModel()
+            approvalVM.showDialog = true
+            approvalVM.pendingApproval = ApprovalRequest(
+                approvalType: "supreme_court",
+                options: ["uphold", "overturn", "redesign"],
+                id: "preview-sc-1",
+                context: ApprovalContext(
+                    eta: nil,
+                    splitProposal: nil,
+                    detail: "Design review after 2 failed checkpoints"
+                ),
+                timeoutSec: 600,
+                requestedAtMs: 0
+            )
+            approvalVM.remainingTimeSec = 480
+            approvalVM.isTimedOut = false
+            approvalVM.isSubmitting = false
+            _vm = StateObject(wrappedValue: approvalVM)
+        }
+
+        var body: some View {
+            ZStack {
+                Text("Parent View Content")
+                ApprovalModalView(viewModel: vm)
+            }
+        }
+    }
+    return PreviewHost()
+}
+
+#Preview("Timed out") {
+    struct PreviewHost: View {
+        @StateObject var vm: IOSApprovalModalViewModel
+
+        init() {
+            let approvalVM = IOSApprovalModalViewModel()
+            approvalVM.showDialog = true
+            approvalVM.pendingApproval = ApprovalRequest(
+                approvalType: "strategy",
+                options: ["split_execute", "no_split", "cancel"],
+                id: "preview-timeout",
+                context: nil,
+                timeoutSec: 300,
+                requestedAtMs: 0
+            )
+            approvalVM.remainingTimeSec = 0
+            approvalVM.isTimedOut = true
+            approvalVM.isSubmitting = false
+            _vm = StateObject(wrappedValue: approvalVM)
+        }
+
+        var body: some View {
+            ZStack {
+                Text("Parent View Content")
+                ApprovalModalView(viewModel: vm)
+            }
+        }
+    }
+    return PreviewHost()
+}
+
+#Preview("Submitting") {
+    struct PreviewHost: View {
+        @StateObject var vm: IOSApprovalModalViewModel
+
+        init() {
+            let approvalVM = IOSApprovalModalViewModel()
+            approvalVM.showDialog = true
+            approvalVM.pendingApproval = ApprovalRequest(
+                approvalType: "strategy",
+                options: ["split_execute", "no_split", "cancel"],
+                id: "preview-submitting",
+                context: nil,
+                timeoutSec: 300,
+                requestedAtMs: 0
+            )
+            approvalVM.remainingTimeSec = 200
+            approvalVM.isTimedOut = false
+            approvalVM.isSubmitting = true
+            _vm = StateObject(wrappedValue: approvalVM)
+        }
+
+        var body: some View {
+            ZStack {
+                Text("Parent View Content")
+                ApprovalModalView(viewModel: vm)
+            }
+        }
+    }
+    return PreviewHost()
+}

--- a/iosApp/iosApp/IOSAppContainer.swift
+++ b/iosApp/iosApp/IOSAppContainer.swift
@@ -61,6 +61,10 @@ final class IOSAppContainer {
         fatalError("KMP framework must be linked via Gradle :shared:iosArm64Binaries")
     }
 
+    func createApprovalModalViewModel() -> ApprovalModalViewModel {
+        fatalError("KMP framework must be linked via Gradle :shared:iosArm64Binaries")
+    }
+
     func createCommandCenterViewModel() -> CommandCenterViewModel {
         fatalError("KMP framework must be linked via Gradle :shared:iosArm64Binaries")
     }

--- a/iosApp/iosApp/IOSApprovalModalViewModel.swift
+++ b/iosApp/iosApp/IOSApprovalModalViewModel.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Shared
+
+/// iOS-specific wrapper around the KMP ApprovalModalViewModel.
+/// Bridges Kotlin coroutine StateFlow to Swift's ObservableObject/Combine.
+///
+/// The KMP `ApprovalModalViewModel` owns the canonical approval state
+/// (pending request, countdown, timeout, submission, error). This class
+/// surfaces those fields as `@Published` properties for SwiftUI.
+@MainActor
+final class IOSApprovalModalViewModel: ObservableObject {
+    @Published var showDialog: Bool = false
+    @Published var pendingApproval: ApprovalRequest? = nil
+    @Published var remainingTimeSec: Int32? = nil
+    @Published var isTimedOut: Bool = false
+    @Published var isSubmitting: Bool = false
+    @Published var approvalError: String? = nil
+
+    private let viewModel: ApprovalModalViewModel
+    private var collectTask: Task<Void, Never>?
+
+    init(viewModel: ApprovalModalViewModel? = nil) {
+        self.viewModel = viewModel ?? IOSAppContainer.shared.createApprovalModalViewModel()
+        startCollecting()
+    }
+
+    private func startCollecting() {
+        collectTask?.cancel()
+        collectTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let collector = ApprovalModalStateCollector { [weak self] state in
+                self?.updateFromState(state)
+            }
+            try? await self.viewModel.uiState.collect(collector: collector)
+        }
+    }
+
+    private func updateFromState(_ state: ApprovalModalState) {
+        self.showDialog = state.showDialog
+        self.pendingApproval = state.pendingApproval
+        if let remaining = state.remainingTimeSec {
+            self.remainingTimeSec = remaining.int32Value
+        } else {
+            self.remainingTimeSec = nil
+        }
+        self.isTimedOut = state.isTimedOut
+        self.isSubmitting = state.isSubmitting
+        self.approvalError = state.error
+    }
+
+    /// Submits a user decision. Maps the `ApprovalDecisionValue` enum (exposed
+    /// to SwiftUI callers) to the matching KMP `ApprovalDecision` sealed-interface
+    /// variant — `StrategyDecision`, `SupremeCourtDecision`, or `GenericDecision`.
+    func respond(decision: ApprovalDecisionValue, comment: String = "") {
+        let kmpDecision: ApprovalDecision = mapDecision(decision)
+        viewModel.respond(decision: kmpDecision, comment: comment)
+    }
+
+    func dismiss() {
+        viewModel.dismiss()
+    }
+
+    func clearError() {
+        viewModel.clearError()
+    }
+
+    func onCleared() {
+        collectTask?.cancel()
+        viewModel.onCleared()
+    }
+
+    // MARK: - Decision Mapping
+
+    private func mapDecision(_ decision: ApprovalDecisionValue) -> ApprovalDecision {
+        switch decision {
+        case .splitExecute:
+            return StrategyDecision.splitExecute
+        case .noSplit:
+            return StrategyDecision.noSplit
+        case .cancel:
+            return StrategyDecision.cancel
+        case .uphold:
+            return SupremeCourtDecision.uphold
+        case .overturn:
+            return SupremeCourtDecision.overturn
+        case .redesign:
+            return SupremeCourtDecision.redesign
+        case .approve:
+            return GenericDecision(value: "approve")
+        case .reject:
+            return GenericDecision(value: "reject")
+        default:
+            return GenericDecision(value: decision.value)
+        }
+    }
+}
+
+private final class ApprovalModalStateCollector: Kotlinx_coroutines_coreFlowCollector {
+    let onValue: (ApprovalModalState) -> Void
+
+    init(onValue: @escaping (ApprovalModalState) -> Void) {
+        self.onValue = onValue
+    }
+
+    func emit(value: Any?, completionHandler: @escaping (Error?) -> Void) {
+        if let state = value as? ApprovalModalState {
+            onValue(state)
+        }
+        completionHandler(nil)
+    }
+}

--- a/iosApp/iosApp/IOSPipelineMonitorViewModel.swift
+++ b/iosApp/iosApp/IOSPipelineMonitorViewModel.swift
@@ -10,6 +10,8 @@ final class IOSPipelineMonitorViewModel: ObservableObject {
     @Published var pendingApproval: ApprovalRequest? = nil
     @Published var remainingTimeSec: Int32? = nil
     @Published var isApprovalTimedOut: Bool = false
+    @Published var isApprovalSubmitting: Bool = false
+    @Published var approvalError: String? = nil
     @Published var isLoading: Bool = false
     @Published var error: String? = nil
     @Published var connectionStatus: ConnectionStatus = .disconnected
@@ -43,13 +45,6 @@ final class IOSPipelineMonitorViewModel: ObservableObject {
     private func updateFromState(_ state: PipelineMonitorUiState) {
         self.pipeline = state.pipeline
         self.logLines = state.logLines as? [String] ?? []
-        self.pendingApproval = state.pendingApproval
-        if let remaining = state.remainingTimeSec {
-            self.remainingTimeSec = remaining.int32Value
-        } else {
-            self.remainingTimeSec = nil
-        }
-        self.isApprovalTimedOut = state.isApprovalTimedOut
         self.isLoading = state.isLoading
         self.error = state.error
         self.connectionStatus = state.connectionStatus
@@ -58,6 +53,16 @@ final class IOSPipelineMonitorViewModel: ObservableObject {
         self.parallelGroup = state.parallelGroup
         self.isParallelView = state.isParallelView
         self.dependencies = state.dependencies as? [PipelineDependency] ?? []
+        // Approval state from combined uiState
+        self.pendingApproval = state.pendingApproval
+        if let remaining = state.approvalRemainingTimeSec {
+            self.remainingTimeSec = remaining.int32Value
+        } else {
+            self.remainingTimeSec = nil
+        }
+        self.isApprovalTimedOut = state.isApprovalTimedOut
+        self.isApprovalSubmitting = state.isApprovalSubmitting
+        self.approvalError = state.approvalError
     }
 
     func loadPipeline() {
@@ -72,12 +77,16 @@ final class IOSPipelineMonitorViewModel: ObservableObject {
         viewModel.refresh()
     }
 
-    func respondToApproval(decision: String) {
+    func respondToApproval(decision: ApprovalDecisionValue) {
         viewModel.respondToApproval(decision: decision, comment: "")
     }
 
     func dismissApproval() {
         viewModel.dismissApproval()
+    }
+
+    func clearApprovalError() {
+        viewModel.clearApprovalError()
     }
 
     func clearError() {
@@ -104,3 +113,4 @@ private final class PipelineUiStateCollector: Kotlinx_coroutines_coreFlowCollect
         completionHandler(nil)
     }
 }
+

--- a/iosApp/iosApp/PipelineMonitorView.swift
+++ b/iosApp/iosApp/PipelineMonitorView.swift
@@ -51,14 +51,24 @@ struct PipelineMonitorView: View {
         } message: {
             Text(viewModel.error ?? "")
         }
+        // NOTE: This sheet is intentionally inline and bound to the
+        // pipeline-owned approval modal (via `IOSPipelineMonitorViewModel`
+        // → KMP `PipelineMonitorViewModel.approvalModal`). Do NOT replace
+        // it with `ApprovalModalView(viewModel: IOSApprovalModalViewModel())`
+        // — that would create a second, disconnected approval modal that
+        // never receives pipeline events. Use `ApprovalModalView` only on
+        // screens that do NOT already own a `PipelineMonitorViewModel`.
         .sheet(isPresented: .constant(viewModel.pendingApproval != nil)) {
             if let approval = viewModel.pendingApproval {
                 ApprovalDialogView(
                     approval: approval,
                     remainingTimeSec: viewModel.remainingTimeSec,
                     isTimedOut: viewModel.isApprovalTimedOut,
+                    isSubmitting: viewModel.isApprovalSubmitting,
+                    error: viewModel.approvalError,
                     onRespond: { decision in viewModel.respondToApproval(decision: decision) },
-                    onDismiss: { viewModel.dismissApproval() }
+                    onDismiss: { viewModel.dismissApproval() },
+                    onClearError: { viewModel.clearApprovalError() }
                 )
             }
         }

--- a/iosApp/iosApp/components/ApprovalDialogView.swift
+++ b/iosApp/iosApp/components/ApprovalDialogView.swift
@@ -7,8 +7,11 @@ struct ApprovalDialogView: View {
     let approval: ApprovalRequest
     let remainingTimeSec: Int32?
     let isTimedOut: Bool
-    let onRespond: (String) -> Void
+    let isSubmitting: Bool
+    let error: String?
+    let onRespond: (ApprovalDecisionValue) -> Void
     let onDismiss: () -> Void
+    let onClearError: () -> Void
 
     var body: some View {
         NavigationView {
@@ -41,9 +44,25 @@ struct ApprovalDialogView: View {
             }
             .padding()
             .toolbar {
+                if isSubmitting {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        ProgressView()
+                    }
+                }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Dismiss", action: onDismiss)
                 }
+            }
+            .alert(
+                "Error",
+                isPresented: Binding(
+                    get: { error != nil },
+                    set: { _ in onClearError() }
+                )
+            ) {
+                Button("OK") { onClearError() }
+            } message: {
+                Text(error ?? "")
             }
         }
     }
@@ -125,61 +144,69 @@ struct ApprovalDialogView: View {
 
     private var strategyButtons: some View {
         VStack(spacing: 8) {
-            Button(action: { onRespond("split_execute") }) {
+            Button(action: { onRespond(.splitExecute) }) {
                 Text("Split & Execute")
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.borderedProminent)
+            .disabled(isSubmitting)
 
-            Button(action: { onRespond("no_split") }) {
+            Button(action: { onRespond(.noSplit) }) {
                 Text("No Split (Full)")
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.bordered)
+            .disabled(isSubmitting)
 
-            Button(role: .destructive, action: { onRespond("cancel") }) {
+            Button(role: .destructive, action: { onRespond(.cancel) }) {
                 Text("Cancel")
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.bordered)
+            .disabled(isSubmitting)
         }
     }
 
     private var supremeCourtButtons: some View {
         VStack(spacing: 8) {
-            Button(action: { onRespond("uphold") }) {
+            Button(action: { onRespond(.uphold) }) {
                 Text("Uphold")
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.borderedProminent)
+            .disabled(isSubmitting)
 
-            Button(action: { onRespond("overturn") }) {
+            Button(action: { onRespond(.overturn) }) {
                 Text("Overturn")
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.bordered)
+            .disabled(isSubmitting)
 
-            Button(action: { onRespond("redesign") }) {
+            Button(action: { onRespond(.redesign) }) {
                 Text("Redesign")
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.bordered)
+            .disabled(isSubmitting)
         }
     }
 
     private var genericButtons: some View {
         HStack(spacing: 8) {
-            Button(action: { onRespond("approve") }) {
+            Button(action: { onRespond(.approve) }) {
                 Text("Approve")
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.borderedProminent)
+            .disabled(isSubmitting)
 
-            Button(action: { onRespond("reject") }) {
+            Button(action: { onRespond(.reject) }) {
                 Text("Reject")
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.bordered)
+            .disabled(isSubmitting)
         }
     }
 
@@ -188,6 +215,6 @@ struct ApprovalDialogView: View {
     private func formatTime(_ totalSeconds: Int) -> String {
         let minutes = totalSeconds / 60
         let seconds = totalSeconds % 60
-        return "\(minutes):\(String(format: "%02d", seconds)) remaining"
+        return "\(String(format: "%02d", minutes)):\(String(format: "%02d", seconds)) remaining"
     }
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -70,6 +70,7 @@ kotlin {
             dependencies {
                 implementation(libs.coroutines.swing)
                 implementation(libs.ktor.client.cio)
+                implementation(compose.desktop.currentOs)
             }
         }
 

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/ApprovalDecision.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/ApprovalDecision.kt
@@ -1,0 +1,19 @@
+package com.orchestradashboard.shared.domain.model
+
+sealed interface ApprovalDecision {
+    val value: String
+}
+
+enum class StrategyDecision(override val value: String) : ApprovalDecision {
+    SplitExecute("split_execute"),
+    NoSplit("no_split"),
+    Cancel("cancel"),
+}
+
+enum class SupremeCourtDecision(override val value: String) : ApprovalDecision {
+    Uphold("uphold"),
+    Overturn("overturn"),
+    Redesign("redesign"),
+}
+
+data class GenericDecision(override val value: String) : ApprovalDecision

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/ApprovalDecisionValue.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/ApprovalDecisionValue.kt
@@ -1,0 +1,12 @@
+package com.orchestradashboard.shared.domain.model
+
+enum class ApprovalDecisionValue(val value: String) {
+    SplitExecute("split_execute"),
+    NoSplit("no_split"),
+    Cancel("cancel"),
+    Uphold("uphold"),
+    Overturn("overturn"),
+    Redesign("redesign"),
+    Approve("approve"),
+    Reject("reject"),
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/approvalmodal/ApprovalModalState.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/approvalmodal/ApprovalModalState.kt
@@ -1,0 +1,13 @@
+package com.orchestradashboard.shared.ui.approvalmodal
+
+import com.orchestradashboard.shared.domain.model.ApprovalRequest
+
+data class ApprovalModalState(
+    val showDialog: Boolean = false,
+    val pendingApproval: ApprovalRequest? = null,
+    val remainingTimeSec: Int? = null,
+    val isSubmitting: Boolean = false,
+    val error: String? = null,
+) {
+    val isTimedOut: Boolean get() = remainingTimeSec != null && remainingTimeSec <= 0
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/approvalmodal/ApprovalModalViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/approvalmodal/ApprovalModalViewModel.kt
@@ -1,0 +1,135 @@
+package com.orchestradashboard.shared.ui.approvalmodal
+
+import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
+import com.orchestradashboard.shared.data.mapper.ApprovalMapper
+import com.orchestradashboard.shared.domain.model.ApprovalDecision
+import com.orchestradashboard.shared.domain.model.ApprovalRequest
+import com.orchestradashboard.shared.domain.usecase.RespondToApprovalUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+
+private const val DEFAULT_TIMEOUT_SEC = 300
+private const val COUNTDOWN_INTERVAL_MS = 1000L
+
+class ApprovalModalViewModel(
+    private val respondToApprovalUseCase: RespondToApprovalUseCase? = null,
+    private val approvalMapper: ApprovalMapper = ApprovalMapper(),
+    private val nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+) {
+    private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val _uiState = MutableStateFlow(ApprovalModalState())
+    val uiState: StateFlow<ApprovalModalState> = _uiState.asStateFlow()
+
+    private var countdownJob: Job? = null
+
+    fun onApprovalRequested(event: PipelineEventDto) {
+        if (_uiState.value.pendingApproval != null) return
+
+        val currentMs = nowMs()
+        val timeoutSec = event.timeoutSec ?: DEFAULT_TIMEOUT_SEC
+        val deadlineMs = currentMs + timeoutSec * 1000L
+
+        val approval =
+            ApprovalRequest(
+                approvalType = event.approvalType ?: "unknown",
+                options = event.options ?: emptyList(),
+                id = event.approvalId ?: event.pipelineId ?: "",
+                context = approvalMapper.toDomain(event.context),
+                timeoutSec = timeoutSec,
+                requestedAtMs = currentMs,
+            )
+
+        _uiState.update {
+            it.copy(
+                showDialog = true,
+                pendingApproval = approval,
+                remainingTimeSec = timeoutSec,
+            )
+        }
+        startCountdown(deadlineMs)
+    }
+
+    fun respond(
+        decision: ApprovalDecision,
+        comment: String = "",
+    ) {
+        if (_uiState.value.isTimedOut) return
+        val approvalId = _uiState.value.pendingApproval?.id ?: return
+
+        _uiState.update { it.copy(isSubmitting = true) }
+
+        viewModelScope.launch {
+            respondToApprovalUseCase?.invoke(approvalId, decision.value, comment)
+                ?.onSuccess {
+                    clearApprovalState()
+                }
+                ?.onFailure { e ->
+                    _uiState.update { it.copy(isSubmitting = false, error = e.message) }
+                }
+        }
+    }
+
+    fun dismiss() {
+        clearApprovalState()
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(error = null) }
+    }
+
+    fun onCleared() {
+        viewModelScope.cancel()
+    }
+
+    private fun startCountdown(deadlineMs: Long) {
+        countdownJob?.cancel()
+        countdownJob =
+            viewModelScope.launch {
+                while (true) {
+                    delay(COUNTDOWN_INTERVAL_MS)
+                    val remaining = maxOf(0, ((deadlineMs - nowMs()) / 1000).toInt())
+                    _uiState.update { it.copy(remainingTimeSec = remaining) }
+                    if (remaining <= 0) {
+                        autoApprove()
+                        break
+                    }
+                }
+            }
+    }
+
+    private fun clearApprovalState() {
+        countdownJob?.cancel()
+        _uiState.update {
+            it.copy(
+                showDialog = false,
+                pendingApproval = null,
+                remainingTimeSec = null,
+                isSubmitting = false,
+            )
+        }
+    }
+
+    private fun autoApprove() {
+        val approvalId = _uiState.value.pendingApproval?.id ?: return
+        viewModelScope.launch {
+            respondToApprovalUseCase?.invoke(approvalId, "auto_approved")
+                ?.onSuccess {
+                    clearApprovalState()
+                }
+                ?.onFailure { e ->
+                    clearApprovalState()
+                    _uiState.update { it.copy(error = e.message) }
+                }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ApprovalDialog.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ApprovalDialog.kt
@@ -7,9 +7,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -19,7 +21,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.orchestradashboard.shared.domain.model.ApprovalDecision
 import com.orchestradashboard.shared.domain.model.ApprovalRequest
+import com.orchestradashboard.shared.domain.model.GenericDecision
+import com.orchestradashboard.shared.domain.model.StrategyDecision
+import com.orchestradashboard.shared.domain.model.SupremeCourtDecision
 
 private const val SECONDS_PER_MINUTE = 60
 
@@ -28,15 +34,18 @@ fun ApprovalDialog(
     approval: ApprovalRequest,
     remainingTimeSec: Int?,
     isTimedOut: Boolean,
-    onRespond: (decision: String) -> Unit,
+    isSubmitting: Boolean,
+    error: String?,
+    onRespond: (ApprovalDecision) -> Unit,
     onDismiss: () -> Unit,
+    onClearError: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
         modifier = modifier,
         title = {
-            Text(buildTitle(approval.approvalType))
+            Text(buildDialogTitle(approval.approvalType))
         },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -45,6 +54,18 @@ fun ApprovalDialog(
 
                 // Timeout countdown
                 CountdownSection(remainingTimeSec, approval.timeoutSec, isTimedOut)
+
+                // Error display
+                error?.let { errorMsg ->
+                    Text(
+                        text = errorMsg,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                    TextButton(onClick = onClearError) {
+                        Text("Dismiss error")
+                    }
+                }
 
                 Spacer(modifier = Modifier.height(8.dp))
 
@@ -59,13 +80,22 @@ fun ApprovalDialog(
                     ApprovalActionButtons(
                         approvalType = approval.approvalType,
                         onRespond = onRespond,
+                        enabled = !isSubmitting,
                     )
                 }
             }
         },
         confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text("Dismiss")
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (isSubmitting) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.padding(end = 8.dp).size(16.dp),
+                        strokeWidth = 2.dp,
+                    )
+                }
+                TextButton(onClick = onDismiss) {
+                    Text("Dismiss")
+                }
             }
         },
     )
@@ -110,9 +140,7 @@ private fun CountdownSection(
 ) {
     if (remainingTimeSec == null) return
 
-    val progress = if (timeoutSec > 0) remainingTimeSec.toFloat() / timeoutSec else 0f
-    val minutes = remainingTimeSec / SECONDS_PER_MINUTE
-    val seconds = remainingTimeSec % SECONDS_PER_MINUTE
+    val progress = calculateProgress(remainingTimeSec, timeoutSec)
 
     Column(modifier = Modifier.fillMaxWidth()) {
         LinearProgressIndicator(
@@ -126,7 +154,7 @@ private fun CountdownSection(
                 },
         )
         Text(
-            text = if (isTimedOut) "Timed out" else "$minutes:${seconds.toString().padStart(2, '0')} remaining",
+            text = formatCountdownText(remainingTimeSec, isTimedOut),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.align(Alignment.End).padding(top = 4.dp),
@@ -137,36 +165,43 @@ private fun CountdownSection(
 @Composable
 private fun ApprovalActionButtons(
     approvalType: String,
-    onRespond: (String) -> Unit,
+    onRespond: (ApprovalDecision) -> Unit,
+    enabled: Boolean,
 ) {
     when (approvalType) {
-        "strategy" -> StrategyButtons(onRespond)
-        "supreme_court" -> SupremeCourtButtons(onRespond)
-        else -> GenericButtons(onRespond)
+        "strategy" -> StrategyButtons(onRespond, enabled)
+        "supreme_court" -> SupremeCourtButtons(onRespond, enabled)
+        else -> GenericButtons(onRespond, enabled)
     }
 }
 
 @Composable
-private fun StrategyButtons(onRespond: (String) -> Unit) {
+private fun StrategyButtons(
+    onRespond: (ApprovalDecision) -> Unit,
+    enabled: Boolean,
+) {
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         modifier = Modifier.fillMaxWidth(),
     ) {
         Button(
-            onClick = { onRespond("split_execute") },
+            onClick = { onRespond(StrategyDecision.SplitExecute) },
             modifier = Modifier.fillMaxWidth(),
+            enabled = enabled,
         ) {
             Text("Split & Execute")
         }
         OutlinedButton(
-            onClick = { onRespond("no_split") },
+            onClick = { onRespond(StrategyDecision.NoSplit) },
             modifier = Modifier.fillMaxWidth(),
+            enabled = enabled,
         ) {
             Text("No Split (Full)")
         }
         TextButton(
-            onClick = { onRespond("cancel") },
+            onClick = { onRespond(StrategyDecision.Cancel) },
             modifier = Modifier.fillMaxWidth(),
+            enabled = enabled,
             colors =
                 ButtonDefaults.textButtonColors(
                     contentColor = MaterialTheme.colorScheme.error,
@@ -178,26 +213,32 @@ private fun StrategyButtons(onRespond: (String) -> Unit) {
 }
 
 @Composable
-private fun SupremeCourtButtons(onRespond: (String) -> Unit) {
+private fun SupremeCourtButtons(
+    onRespond: (ApprovalDecision) -> Unit,
+    enabled: Boolean,
+) {
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         modifier = Modifier.fillMaxWidth(),
     ) {
         Button(
-            onClick = { onRespond("uphold") },
+            onClick = { onRespond(SupremeCourtDecision.Uphold) },
             modifier = Modifier.fillMaxWidth(),
+            enabled = enabled,
         ) {
             Text("Uphold")
         }
         OutlinedButton(
-            onClick = { onRespond("overturn") },
+            onClick = { onRespond(SupremeCourtDecision.Overturn) },
             modifier = Modifier.fillMaxWidth(),
+            enabled = enabled,
         ) {
             Text("Overturn")
         }
         OutlinedButton(
-            onClick = { onRespond("redesign") },
+            onClick = { onRespond(SupremeCourtDecision.Redesign) },
             modifier = Modifier.fillMaxWidth(),
+            enabled = enabled,
         ) {
             Text("Redesign")
         }
@@ -205,29 +246,70 @@ private fun SupremeCourtButtons(onRespond: (String) -> Unit) {
 }
 
 @Composable
-private fun GenericButtons(onRespond: (String) -> Unit) {
+private fun GenericButtons(
+    onRespond: (ApprovalDecision) -> Unit,
+    enabled: Boolean,
+) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         modifier = Modifier.fillMaxWidth(),
     ) {
         Button(
-            onClick = { onRespond("approve") },
+            onClick = { onRespond(GenericDecision("approve")) },
             modifier = Modifier.weight(1f),
+            enabled = enabled,
         ) {
             Text("Approve")
         }
         OutlinedButton(
-            onClick = { onRespond("reject") },
+            onClick = { onRespond(GenericDecision("reject")) },
             modifier = Modifier.weight(1f),
+            enabled = enabled,
         ) {
             Text("Reject")
         }
     }
 }
 
-private fun buildTitle(approvalType: String): String =
+internal fun buildDialogTitle(approvalType: String): String =
     when (approvalType) {
         "strategy" -> "Strategy Approval Required"
         "supreme_court" -> "Supreme Court Review Required"
         else -> "Approval Required: $approvalType"
+    }
+
+internal fun formatCountdownText(
+    remainingTimeSec: Int,
+    isTimedOut: Boolean,
+): String {
+    if (isTimedOut) return "Timed out"
+    val minutes = remainingTimeSec / SECONDS_PER_MINUTE
+    val seconds = remainingTimeSec % SECONDS_PER_MINUTE
+    return "$minutes:${seconds.toString().padStart(2, '0')} remaining"
+}
+
+internal fun calculateProgress(
+    remainingTimeSec: Int,
+    timeoutSec: Int,
+): Float = if (timeoutSec > 0) remainingTimeSec.toFloat() / timeoutSec else 0f
+
+internal fun approvalDecisionsForType(approvalType: String): List<ApprovalDecision> =
+    when (approvalType) {
+        "strategy" ->
+            listOf(
+                StrategyDecision.SplitExecute,
+                StrategyDecision.NoSplit,
+                StrategyDecision.Cancel,
+            )
+        "supreme_court" ->
+            listOf(
+                SupremeCourtDecision.Uphold,
+                SupremeCourtDecision.Overturn,
+                SupremeCourtDecision.Redesign,
+            )
+        else ->
+            listOf(
+                GenericDecision("approve"),
+                GenericDecision("reject"),
+            )
     }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorUiState.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorUiState.kt
@@ -1,5 +1,6 @@
 package com.orchestradashboard.shared.ui.pipelinemonitor
 
+import com.orchestradashboard.shared.domain.model.ApprovalRequest
 import com.orchestradashboard.shared.domain.model.ConnectionStatus
 import com.orchestradashboard.shared.domain.model.MonitoredPipeline
 import com.orchestradashboard.shared.domain.model.ParallelPipelineGroup
@@ -13,6 +14,11 @@ data class PipelineMonitorUiState(
     val isLoading: Boolean = false,
     val error: String? = null,
     val connectionStatus: ConnectionStatus = ConnectionStatus.DISCONNECTED,
+    val pendingApproval: ApprovalRequest? = null,
+    val approvalRemainingTimeSec: Int? = null,
+    val isApprovalTimedOut: Boolean = false,
+    val isApprovalSubmitting: Boolean = false,
+    val approvalError: String? = null,
 ) {
     val isParallel: Boolean get() = pipeline?.isParallel == true
 

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorUiState.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorUiState.kt
@@ -1,6 +1,5 @@
 package com.orchestradashboard.shared.ui.pipelinemonitor
 
-import com.orchestradashboard.shared.domain.model.ApprovalRequest
 import com.orchestradashboard.shared.domain.model.ConnectionStatus
 import com.orchestradashboard.shared.domain.model.MonitoredPipeline
 import com.orchestradashboard.shared.domain.model.ParallelPipelineGroup
@@ -9,8 +8,6 @@ import com.orchestradashboard.shared.domain.model.PipelineDependency
 data class PipelineMonitorUiState(
     val pipeline: MonitoredPipeline? = null,
     val logLines: List<String> = emptyList(),
-    val pendingApproval: ApprovalRequest? = null,
-    val remainingTimeSec: Int? = null,
     val parallelPipelines: List<MonitoredPipeline> = emptyList(),
     val parallelGroup: ParallelPipelineGroup? = null,
     val isLoading: Boolean = false,
@@ -24,6 +21,4 @@ data class PipelineMonitorUiState(
     val currentStepName: String? get() = pipeline?.currentRunningStep?.name
 
     val dependencies: List<PipelineDependency> get() = parallelGroup?.dependencies ?: emptyList()
-
-    val isApprovalTimedOut: Boolean get() = remainingTimeSec != null && remainingTimeSec <= 0
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModel.kt
@@ -1,7 +1,9 @@
 package com.orchestradashboard.shared.ui.pipelinemonitor
 
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
+import com.orchestradashboard.shared.domain.model.ApprovalDecisionValue
 import com.orchestradashboard.shared.domain.model.ConnectionStatus
+import com.orchestradashboard.shared.domain.model.GenericDecision
 import com.orchestradashboard.shared.domain.model.MonitoredPipeline
 import com.orchestradashboard.shared.domain.model.PipelineRunStatus
 import com.orchestradashboard.shared.domain.model.StepStatus
@@ -12,9 +14,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
@@ -24,11 +28,24 @@ private const val MAX_LOG_LINES = 500
 class PipelineMonitorViewModel(
     private val pipelineId: String,
     private val repository: PipelineMonitorRepository,
-    val approvalModal: ApprovalModalViewModel = ApprovalModalViewModel(),
+    val approvalModal: ApprovalModalViewModel,
 ) {
     private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private val _uiState = MutableStateFlow(PipelineMonitorUiState())
-    val uiState: StateFlow<PipelineMonitorUiState> = _uiState.asStateFlow()
+    val uiState: StateFlow<PipelineMonitorUiState> =
+        combine(_uiState, approvalModal.uiState) { pipelineState, approvalState ->
+            pipelineState.copy(
+                pendingApproval = approvalState.pendingApproval,
+                approvalRemainingTimeSec = approvalState.remainingTimeSec,
+                isApprovalTimedOut = approvalState.isTimedOut,
+                isApprovalSubmitting = approvalState.isSubmitting,
+                approvalError = approvalState.error,
+            )
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = PipelineMonitorUiState(),
+        )
 
     fun loadPipeline() {
         viewModelScope.launch {
@@ -209,6 +226,21 @@ class PipelineMonitorViewModel(
 
     fun clearError() {
         _uiState.update { it.copy(error = null) }
+    }
+
+    fun respondToApproval(
+        decision: ApprovalDecisionValue,
+        comment: String = "",
+    ) {
+        approvalModal.respond(GenericDecision(decision.value), comment)
+    }
+
+    fun dismissApproval() {
+        approvalModal.dismiss()
+    }
+
+    fun clearApprovalError() {
+        approvalModal.clearError()
     }
 
     fun refresh() {

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModel.kt
@@ -1,20 +1,16 @@
 package com.orchestradashboard.shared.ui.pipelinemonitor
 
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
-import com.orchestradashboard.shared.data.mapper.ApprovalMapper
-import com.orchestradashboard.shared.domain.model.ApprovalRequest
 import com.orchestradashboard.shared.domain.model.ConnectionStatus
 import com.orchestradashboard.shared.domain.model.MonitoredPipeline
 import com.orchestradashboard.shared.domain.model.PipelineRunStatus
 import com.orchestradashboard.shared.domain.model.StepStatus
 import com.orchestradashboard.shared.domain.repository.PipelineMonitorRepository
-import com.orchestradashboard.shared.domain.usecase.RespondToApprovalUseCase
+import com.orchestradashboard.shared.ui.approvalmodal.ApprovalModalViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -24,21 +20,15 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 
 private const val MAX_LOG_LINES = 500
-private const val DEFAULT_TIMEOUT_SEC = 300
-private const val COUNTDOWN_INTERVAL_MS = 1000L
 
 class PipelineMonitorViewModel(
     private val pipelineId: String,
     private val repository: PipelineMonitorRepository,
-    private val respondToApprovalUseCase: RespondToApprovalUseCase? = null,
-    private val approvalMapper: ApprovalMapper = ApprovalMapper(),
-    private val nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+    val approvalModal: ApprovalModalViewModel = ApprovalModalViewModel(),
 ) {
     private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private val _uiState = MutableStateFlow(PipelineMonitorUiState())
     val uiState: StateFlow<PipelineMonitorUiState> = _uiState.asStateFlow()
-
-    private var countdownJob: Job? = null
 
     fun loadPipeline() {
         viewModelScope.launch {
@@ -115,7 +105,7 @@ class PipelineMonitorViewModel(
             "step.failed" -> updateStepStatus(event.step, StepStatus.FAILED, event.elapsedSec)
             "pipeline.completed" -> updatePipelineStatus(PipelineRunStatus.PASSED)
             "pipeline.failed" -> updatePipelineStatus(PipelineRunStatus.FAILED)
-            "approval.requested", "supreme_court.required" -> handleApprovalEvent(event)
+            "approval.requested", "supreme_court.required" -> approvalModal.onApprovalRequested(event)
             "log" -> {
                 event.detail?.let { line ->
                     _uiState.update { state ->
@@ -125,45 +115,6 @@ class PipelineMonitorViewModel(
                 }
             }
         }
-    }
-
-    private fun handleApprovalEvent(event: PipelineEventDto) {
-        // Finding 3: ignore concurrent approval requests while one is already pending
-        if (_uiState.value.pendingApproval != null) return
-
-        val currentMs = nowMs()
-        val timeoutSec = event.timeoutSec ?: DEFAULT_TIMEOUT_SEC
-        val deadlineMs = currentMs + timeoutSec * 1000L
-        val approval =
-            ApprovalRequest(
-                approvalType = event.approvalType ?: "unknown",
-                options = event.options ?: emptyList(),
-                id = event.approvalId ?: event.pipelineId ?: "",
-                context = approvalMapper.toDomain(event.context),
-                timeoutSec = timeoutSec,
-                requestedAtMs = currentMs,
-            )
-        _uiState.update {
-            it.copy(
-                pendingApproval = approval,
-                remainingTimeSec = timeoutSec,
-            )
-        }
-        startCountdown(deadlineMs)
-    }
-
-    // Finding 1: deadline-based countdown so it stays accurate regardless of UI thread delays
-    private fun startCountdown(deadlineMs: Long) {
-        countdownJob?.cancel()
-        countdownJob =
-            viewModelScope.launch {
-                while (true) {
-                    delay(COUNTDOWN_INTERVAL_MS)
-                    val remaining = maxOf(0, ((deadlineMs - nowMs()) / 1000).toInt())
-                    _uiState.update { it.copy(remainingTimeSec = remaining) }
-                    if (remaining <= 0) break
-                }
-            }
     }
 
     private fun handleLaneEvent(
@@ -256,30 +207,6 @@ class PipelineMonitorViewModel(
         }
     }
 
-    fun respondToApproval(
-        decision: String,
-        comment: String = "",
-    ) {
-        val approvalId = _uiState.value.pendingApproval?.id ?: return
-        // Finding 2: ignore user action if the approval already timed out
-        if (_uiState.value.isApprovalTimedOut) return
-        viewModelScope.launch {
-            respondToApprovalUseCase?.invoke(approvalId, decision, comment)
-                ?.onSuccess {
-                    countdownJob?.cancel()
-                    _uiState.update { it.copy(pendingApproval = null, remainingTimeSec = null) }
-                }
-                ?.onFailure { e ->
-                    _uiState.update { it.copy(error = e.message) }
-                }
-        }
-    }
-
-    fun dismissApproval() {
-        countdownJob?.cancel()
-        _uiState.update { it.copy(pendingApproval = null, remainingTimeSec = null) }
-    }
-
     fun clearError() {
         _uiState.update { it.copy(error = null) }
     }
@@ -290,5 +217,6 @@ class PipelineMonitorViewModel(
 
     fun onCleared() {
         viewModelScope.cancel()
+        approvalModal.onCleared()
     }
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/PipelineMonitorScreen.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/PipelineMonitorScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.orchestradashboard.shared.domain.model.ConnectionStatus
+import com.orchestradashboard.shared.domain.model.GenericDecision
 import com.orchestradashboard.shared.ui.component.ApprovalDialog
 import com.orchestradashboard.shared.ui.component.ErrorBanner
 import com.orchestradashboard.shared.ui.component.LiveLogPanel
@@ -38,19 +39,22 @@ fun PipelineMonitorScreen(
     modifier: Modifier = Modifier,
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val approvalState by viewModel.approvalModal.uiState.collectAsState()
 
     LaunchedEffect(Unit) {
         viewModel.loadPipeline()
         viewModel.startObserving()
     }
 
-    uiState.pendingApproval?.let { approval ->
+    approvalState.pendingApproval?.let { approval ->
         ApprovalDialog(
             approval = approval,
-            remainingTimeSec = uiState.remainingTimeSec,
-            isTimedOut = uiState.isApprovalTimedOut,
-            onRespond = { decision -> viewModel.respondToApproval(decision) },
-            onDismiss = { viewModel.dismissApproval() },
+            remainingTimeSec = approvalState.remainingTimeSec,
+            isTimedOut = approvalState.isTimedOut,
+            onRespond = { decision ->
+                viewModel.approvalModal.respond(GenericDecision(decision))
+            },
+            onDismiss = { viewModel.approvalModal.dismiss() },
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/PipelineMonitorScreen.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/PipelineMonitorScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.orchestradashboard.shared.domain.model.ConnectionStatus
-import com.orchestradashboard.shared.domain.model.GenericDecision
 import com.orchestradashboard.shared.ui.component.ApprovalDialog
 import com.orchestradashboard.shared.ui.component.ErrorBanner
 import com.orchestradashboard.shared.ui.component.LiveLogPanel
@@ -39,22 +38,22 @@ fun PipelineMonitorScreen(
     modifier: Modifier = Modifier,
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val approvalState by viewModel.approvalModal.uiState.collectAsState()
 
     LaunchedEffect(Unit) {
         viewModel.loadPipeline()
         viewModel.startObserving()
     }
 
-    approvalState.pendingApproval?.let { approval ->
+    uiState.pendingApproval?.let { approval ->
         ApprovalDialog(
             approval = approval,
-            remainingTimeSec = approvalState.remainingTimeSec,
-            isTimedOut = approvalState.isTimedOut,
-            onRespond = { decision ->
-                viewModel.approvalModal.respond(GenericDecision(decision))
-            },
+            remainingTimeSec = uiState.approvalRemainingTimeSec,
+            isTimedOut = uiState.isApprovalTimedOut,
+            isSubmitting = uiState.isApprovalSubmitting,
+            error = uiState.approvalError,
+            onRespond = { decision -> viewModel.approvalModal.respond(decision) },
             onDismiss = { viewModel.approvalModal.dismiss() },
+            onClearError = { viewModel.approvalModal.clearError() },
         )
     }
 

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/approvalmodal/ApprovalModalViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/approvalmodal/ApprovalModalViewModelTest.kt
@@ -1,0 +1,461 @@
+package com.orchestradashboard.shared.ui.approvalmodal
+
+import com.orchestradashboard.shared.data.dto.orchestrator.ApprovalContextDto
+import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
+import com.orchestradashboard.shared.domain.model.GenericDecision
+import com.orchestradashboard.shared.domain.model.StrategyDecision
+import com.orchestradashboard.shared.domain.model.SupremeCourtDecision
+import com.orchestradashboard.shared.domain.usecase.RespondToApprovalUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ApprovalModalViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var fakeRepo: FakeApprovalRepository
+    private lateinit var viewModel: ApprovalModalViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        fakeRepo = FakeApprovalRepository()
+        viewModel =
+            ApprovalModalViewModel(
+                respondToApprovalUseCase = RespondToApprovalUseCase(fakeRepo),
+                nowMs = { testDispatcher.scheduler.currentTime },
+            )
+    }
+
+    @AfterTest
+    fun teardown() {
+        viewModel.onCleared()
+        Dispatchers.resetMain()
+    }
+
+    // --- Group 1: Initial State ---
+
+    @Test
+    fun `T1 initial state has no pending approval null remainingTimeSec not timed out not submitting`() {
+        val state = viewModel.uiState.value
+        assertNull(state.pendingApproval)
+        assertNull(state.remainingTimeSec)
+        assertFalse(state.isTimedOut)
+        assertFalse(state.isSubmitting)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `T2 initial state showDialog is false`() {
+        assertFalse(viewModel.uiState.value.showDialog)
+    }
+
+    // --- Group 2: Receiving Approval Events ---
+
+    @Test
+    fun `T3 onApprovalRequested with strategy type sets pendingApproval and showDialog true`() =
+        runTest {
+            viewModel.onApprovalRequested(strategyEvent())
+            runCurrent()
+
+            val state = viewModel.uiState.value
+            assertNotNull(state.pendingApproval)
+            assertEquals("strategy", state.pendingApproval?.approvalType)
+            assertTrue(state.showDialog)
+        }
+
+    @Test
+    fun `T4 onApprovalRequested with supreme court type sets correct approvalType`() =
+        runTest {
+            viewModel.onApprovalRequested(supremeCourtEvent())
+            runCurrent()
+
+            assertEquals("supreme_court", viewModel.uiState.value.pendingApproval?.approvalType)
+        }
+
+    @Test
+    fun `T5 onApprovalRequested sets remainingTimeSec to event timeoutSec`() =
+        runTest {
+            viewModel.onApprovalRequested(strategyEvent(timeoutSec = 60))
+            runCurrent()
+
+            assertEquals(60, viewModel.uiState.value.remainingTimeSec)
+        }
+
+    @Test
+    fun `T6 onApprovalRequested uses DEFAULT_TIMEOUT_SEC 300 when event has no timeout`() =
+        runTest {
+            viewModel.onApprovalRequested(strategyEvent(timeoutSec = null))
+            runCurrent()
+
+            assertEquals(300, viewModel.uiState.value.remainingTimeSec)
+        }
+
+    @Test
+    fun `T7 second onApprovalRequested is ignored while one is already pending`() =
+        runTest {
+            viewModel.onApprovalRequested(strategyEvent(approvalId = "first", timeoutSec = 60))
+            runCurrent()
+
+            viewModel.onApprovalRequested(supremeCourtEvent(approvalId = "second", timeoutSec = 60))
+            runCurrent()
+
+            assertEquals("first", viewModel.uiState.value.pendingApproval?.id)
+        }
+
+    // --- Group 3: Countdown ---
+
+    @Test
+    fun `T8 countdown decrements remainingTimeSec every second`() =
+        runTest {
+            viewModel.onApprovalRequested(strategyEvent(timeoutSec = 10))
+            runCurrent()
+
+            assertEquals(10, viewModel.uiState.value.remainingTimeSec)
+
+            advanceTimeBy(3001)
+            runCurrent()
+
+            assertEquals(7, viewModel.uiState.value.remainingTimeSec)
+        }
+
+    @Test
+    fun `T9 countdown reaching zero sets isTimedOut true`() =
+        runTest {
+            // No useCase: autoApprove() is a no-op, so the timed-out state persists for assertion
+            val vm = ApprovalModalViewModel(respondToApprovalUseCase = null, nowMs = { testDispatcher.scheduler.currentTime })
+            vm.onApprovalRequested(strategyEvent(timeoutSec = 3))
+            advanceUntilIdle()
+
+            assertEquals(0, vm.uiState.value.remainingTimeSec)
+            assertTrue(vm.uiState.value.isTimedOut)
+
+            vm.onCleared()
+        }
+
+    @Test
+    fun `T10 countdown is deadline-based advancing 3 seconds yields correct remaining`() =
+        runTest {
+            viewModel.onApprovalRequested(strategyEvent(timeoutSec = 30))
+            runCurrent()
+
+            advanceTimeBy(3000)
+            runCurrent()
+
+            val remaining = viewModel.uiState.value.remainingTimeSec ?: -1
+            assertTrue(remaining in 26..27, "Expected ~27 seconds remaining, got $remaining")
+        }
+
+    // --- Group 4: Auto-Approve on Timeout ---
+
+    @Test
+    fun `T11 when countdown reaches zero auto-approve response is sent via repository`() =
+        runTest {
+            viewModel.onApprovalRequested(strategyEvent(approvalId = "a1", timeoutSec = 3))
+            advanceUntilIdle()
+
+            assertEquals(1, fakeRepo.respondCallCount)
+            assertEquals("a1", fakeRepo.lastApprovalId)
+        }
+
+    @Test
+    fun `T12 auto-approve decision string is auto_approved`() =
+        runTest {
+            viewModel.onApprovalRequested(strategyEvent(timeoutSec = 3))
+            advanceUntilIdle()
+
+            assertEquals("auto_approved", fakeRepo.lastDecision)
+        }
+
+    @Test
+    fun `T13 after auto-approve pendingApproval is cleared and showDialog is false`() =
+        runTest {
+            viewModel.onApprovalRequested(strategyEvent(timeoutSec = 3))
+            advanceUntilIdle()
+
+            assertNull(viewModel.uiState.value.pendingApproval)
+            assertFalse(viewModel.uiState.value.showDialog)
+        }
+
+    @Test
+    fun `T13b auto-approve failure clears modal state and sets error`() =
+        runTest {
+            fakeRepo.respondResult = Result.failure(RuntimeException("Timeout network error"))
+            viewModel.onApprovalRequested(strategyEvent(timeoutSec = 3))
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertNull(state.pendingApproval)
+            assertFalse(state.showDialog)
+            assertEquals("Timeout network error", state.error)
+        }
+
+    // --- Group 5: User Response ---
+
+    @Test
+    fun `T14 respond with StrategyDecision SplitExecute sends split_execute to repository`() =
+        runTest {
+            viewModel.onApprovalRequested(strategyEvent(approvalId = "a1", timeoutSec = 60))
+            runCurrent()
+
+            viewModel.respond(StrategyDecision.SplitExecute)
+            advanceUntilIdle()
+
+            assertEquals("split_execute", fakeRepo.lastDecision)
+            assertEquals("a1", fakeRepo.lastApprovalId)
+        }
+
+    @Test
+    fun `T15 respond with StrategyDecision NoSplit sends no_split to repository`() =
+        runTest {
+            viewModel.onApprovalRequested(strategyEvent(timeoutSec = 60))
+            runCurrent()
+
+            viewModel.respond(StrategyDecision.NoSplit)
+            advanceUntilIdle()
+
+            assertEquals("no_split", fakeRepo.lastDecision)
+        }
+
+    @Test
+    fun `T16 respond with StrategyDecision Cancel sends cancel to repository`() =
+        runTest {
+            viewModel.onApprovalRequested(strategyEvent(timeoutSec = 60))
+            runCurrent()
+
+            viewModel.respond(StrategyDecision.Cancel)
+            advanceUntilIdle()
+
+            assertEquals("cancel", fakeRepo.lastDecision)
+        }
+
+    @Test
+    fun `T17 respond with SupremeCourtDecision Uphold sends uphold to repository`() =
+        runTest {
+            viewModel.onApprovalRequested(supremeCourtEvent(timeoutSec = 60))
+            runCurrent()
+
+            viewModel.respond(SupremeCourtDecision.Uphold)
+            advanceUntilIdle()
+
+            assertEquals("uphold", fakeRepo.lastDecision)
+        }
+
+    @Test
+    fun `T18 respond with SupremeCourtDecision Overturn sends overturn to repository`() =
+        runTest {
+            viewModel.onApprovalRequested(supremeCourtEvent(timeoutSec = 60))
+            runCurrent()
+
+            viewModel.respond(SupremeCourtDecision.Overturn)
+            advanceUntilIdle()
+
+            assertEquals("overturn", fakeRepo.lastDecision)
+        }
+
+    @Test
+    fun `T19 respond with SupremeCourtDecision Redesign sends redesign to repository`() =
+        runTest {
+            viewModel.onApprovalRequested(supremeCourtEvent(timeoutSec = 60))
+            runCurrent()
+
+            viewModel.respond(SupremeCourtDecision.Redesign)
+            advanceUntilIdle()
+
+            assertEquals("redesign", fakeRepo.lastDecision)
+        }
+
+    @Test
+    fun `T20 successful respond clears pendingApproval stops countdown showDialog false`() =
+        runTest {
+            viewModel.onApprovalRequested(strategyEvent(timeoutSec = 60))
+            runCurrent()
+
+            viewModel.respond(StrategyDecision.SplitExecute)
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertNull(state.pendingApproval)
+            assertNull(state.remainingTimeSec)
+            assertFalse(state.showDialog)
+        }
+
+    @Test
+    fun `T21 respond is ignored when isTimedOut is true`() =
+        runTest {
+            // No useCase: autoApprove() is a no-op, so isTimedOut stays true for the guard test
+            val vm = ApprovalModalViewModel(respondToApprovalUseCase = null, nowMs = { testDispatcher.scheduler.currentTime })
+            vm.onApprovalRequested(strategyEvent(timeoutSec = 3))
+            advanceUntilIdle()
+
+            assertTrue(vm.uiState.value.isTimedOut)
+            val approvalBefore = vm.uiState.value.pendingApproval
+
+            vm.respond(StrategyDecision.SplitExecute)
+            advanceUntilIdle()
+
+            // State is unchanged: respond() exited early due to isTimedOut guard
+            assertEquals(approvalBefore, vm.uiState.value.pendingApproval)
+
+            vm.onCleared()
+        }
+
+    @Test
+    fun `T22 respond failure sets error in state approval remains pending`() =
+        runTest {
+            fakeRepo.respondResult = Result.failure(RuntimeException("Network error"))
+            viewModel.onApprovalRequested(strategyEvent(timeoutSec = 60))
+            runCurrent()
+
+            viewModel.respond(StrategyDecision.SplitExecute)
+            runCurrent() // don't advance time past timeout — only run the launched coroutine
+
+            assertEquals("Network error", viewModel.uiState.value.error)
+            assertNotNull(viewModel.uiState.value.pendingApproval)
+        }
+
+    @Test
+    fun `T23 respond sets isSubmitting true during network call`() =
+        runTest {
+            viewModel.onApprovalRequested(strategyEvent(timeoutSec = 60))
+            runCurrent()
+
+            viewModel.respond(StrategyDecision.SplitExecute)
+            // isSubmitting is set synchronously before the coroutine launches — check before runCurrent
+            assertTrue(viewModel.uiState.value.isSubmitting)
+        }
+
+    // --- Group 6: Dismiss ---
+
+    @Test
+    fun `T24 dismiss clears pendingApproval and remainingTimeSec showDialog false`() =
+        runTest {
+            viewModel.onApprovalRequested(strategyEvent(timeoutSec = 60))
+            runCurrent()
+
+            assertNotNull(viewModel.uiState.value.pendingApproval)
+
+            viewModel.dismiss()
+
+            val state = viewModel.uiState.value
+            assertNull(state.pendingApproval)
+            assertNull(state.remainingTimeSec)
+            assertFalse(state.showDialog)
+        }
+
+    @Test
+    fun `T25 dismiss stops countdown job`() =
+        runTest {
+            viewModel.onApprovalRequested(strategyEvent(timeoutSec = 60))
+            runCurrent()
+
+            val remainingAfterStart = viewModel.uiState.value.remainingTimeSec
+
+            viewModel.dismiss()
+
+            advanceTimeBy(5000)
+            runCurrent()
+
+            assertNull(viewModel.uiState.value.remainingTimeSec)
+        }
+
+    // --- Group 7: Error Handling ---
+
+    @Test
+    fun `T26 clearError resets error to null`() =
+        runTest {
+            fakeRepo.respondResult = Result.failure(RuntimeException("err"))
+            viewModel.onApprovalRequested(strategyEvent(timeoutSec = 60))
+            runCurrent()
+
+            viewModel.respond(StrategyDecision.SplitExecute)
+            advanceUntilIdle()
+
+            assertNotNull(viewModel.uiState.value.error)
+
+            viewModel.clearError()
+
+            assertNull(viewModel.uiState.value.error)
+        }
+
+    // --- Additional: ApprovalContext mapping ---
+
+    @Test
+    fun `context from event is mapped into ApprovalRequest`() =
+        runTest {
+            viewModel.onApprovalRequested(
+                supremeCourtEvent(
+                    context = ApprovalContextDto(eta = "5m", detail = "Test ruling"),
+                ),
+            )
+            runCurrent()
+
+            val ctx = viewModel.uiState.value.pendingApproval?.context
+            assertNotNull(ctx)
+            assertEquals("5m", ctx.eta)
+            assertEquals("Test ruling", ctx.detail)
+        }
+
+    @Test
+    fun `GenericDecision sends its value string to repository`() =
+        runTest {
+            viewModel.onApprovalRequested(
+                PipelineEventDto(
+                    type = "approval.requested",
+                    pipelineId = "p1",
+                    approvalId = "g1",
+                    approvalType = "generic",
+                    options = listOf("approve", "reject"),
+                    timeoutSec = 60,
+                ),
+            )
+            runCurrent()
+
+            viewModel.respond(GenericDecision("approve"))
+            advanceUntilIdle()
+
+            assertEquals("approve", fakeRepo.lastDecision)
+        }
+
+    // --- Helpers ---
+
+    private fun strategyEvent(
+        approvalId: String = "a1",
+        timeoutSec: Int? = 60,
+    ) = PipelineEventDto(
+        type = "approval.requested",
+        pipelineId = "p1",
+        approvalId = approvalId,
+        approvalType = "strategy",
+        options = listOf("split_execute", "no_split", "cancel"),
+        timeoutSec = timeoutSec,
+    )
+
+    private fun supremeCourtEvent(
+        approvalId: String = "sc1",
+        timeoutSec: Int? = 120,
+        context: ApprovalContextDto? = null,
+    ) = PipelineEventDto(
+        type = "supreme_court.required",
+        pipelineId = "p1",
+        approvalId = approvalId,
+        approvalType = "supreme_court",
+        options = listOf("uphold", "overturn", "redesign"),
+        context = context,
+        timeoutSec = timeoutSec,
+    )
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/approvalmodal/FakeApprovalRepository.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/approvalmodal/FakeApprovalRepository.kt
@@ -1,0 +1,27 @@
+package com.orchestradashboard.shared.ui.approvalmodal
+
+import com.orchestradashboard.shared.domain.repository.ApprovalRepository
+
+class FakeApprovalRepository : ApprovalRepository {
+    var respondResult: Result<Unit> = Result.success(Unit)
+    var respondCallCount = 0
+        private set
+    var lastApprovalId: String? = null
+        private set
+    var lastDecision: String? = null
+        private set
+    var lastComment: String? = null
+        private set
+
+    override suspend fun respondToApproval(
+        approvalId: String,
+        decision: String,
+        comment: String,
+    ): Result<Unit> {
+        respondCallCount++
+        lastApprovalId = approvalId
+        lastDecision = decision
+        lastComment = comment
+        return respondResult
+    }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/component/ApprovalDialogStateTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/component/ApprovalDialogStateTest.kt
@@ -1,0 +1,204 @@
+package com.orchestradashboard.shared.ui.component
+
+import com.orchestradashboard.shared.domain.model.ApprovalContext
+import com.orchestradashboard.shared.domain.model.ApprovalRequest
+import com.orchestradashboard.shared.domain.model.GenericDecision
+import com.orchestradashboard.shared.domain.model.StrategyDecision
+import com.orchestradashboard.shared.domain.model.SupremeCourtDecision
+import com.orchestradashboard.shared.ui.approvalmodal.ApprovalModalState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ApprovalDialogStateTest {
+    private fun sampleApproval(approvalType: String = "strategy"): ApprovalRequest =
+        ApprovalRequest(
+            approvalType = approvalType,
+            options = emptyList(),
+            id = "approval-1",
+            context = null,
+            timeoutSec = 60,
+            requestedAtMs = 0L,
+        )
+
+    // ─── T-UI-1 ~ T-UI-3 : buildDialogTitle ────────────────────────────────────
+
+    @Test
+    fun `T-UI-1 buildDialogTitle returns strategy title`() {
+        assertEquals("Strategy Approval Required", buildDialogTitle("strategy"))
+    }
+
+    @Test
+    fun `T-UI-2 buildDialogTitle returns supreme court title`() {
+        assertEquals("Supreme Court Review Required", buildDialogTitle("supreme_court"))
+    }
+
+    @Test
+    fun `T-UI-3 buildDialogTitle returns generic title for unknown type`() {
+        assertEquals("Approval Required: custom_type", buildDialogTitle("custom_type"))
+    }
+
+    // ─── T-UI-4 ~ T-UI-6 : approvalDecisionsForType ───────────────────────────
+
+    @Test
+    fun `T-UI-4 approvalDecisionsForType strategy returns 3 decisions`() {
+        val decisions = approvalDecisionsForType("strategy")
+        assertEquals(3, decisions.size)
+        assertEquals(listOf("split_execute", "no_split", "cancel"), decisions.map { it.value })
+    }
+
+    @Test
+    fun `T-UI-5 approvalDecisionsForType supreme_court returns 3 decisions`() {
+        val decisions = approvalDecisionsForType("supreme_court")
+        assertEquals(3, decisions.size)
+        assertEquals(listOf("uphold", "overturn", "redesign"), decisions.map { it.value })
+    }
+
+    @Test
+    fun `T-UI-6 approvalDecisionsForType other returns 2 decisions`() {
+        val decisions = approvalDecisionsForType("other")
+        assertEquals(2, decisions.size)
+        assertEquals(listOf("approve", "reject"), decisions.map { it.value })
+    }
+
+    // ─── T-UI-7 ~ T-UI-9 : isTimedOut ──────────────────────────────────────────
+
+    @Test
+    fun `T-UI-7 isTimedOut is true when remainingTimeSec is 0`() {
+        val state =
+            ApprovalModalState(
+                pendingApproval = sampleApproval(),
+                remainingTimeSec = 0,
+            )
+        assertTrue(state.isTimedOut)
+    }
+
+    @Test
+    fun `T-UI-8 isTimedOut is false when remainingTimeSec is positive`() {
+        val state =
+            ApprovalModalState(
+                pendingApproval = sampleApproval(),
+                remainingTimeSec = 10,
+            )
+        assertFalse(state.isTimedOut)
+    }
+
+    @Test
+    fun `T-UI-9 isTimedOut is false when remainingTimeSec is null`() {
+        val state = ApprovalModalState(remainingTimeSec = null)
+        assertFalse(state.isTimedOut)
+    }
+
+    // ─── T-UI-10 ~ T-UI-11b : formatCountdownText and calculateProgress ───────
+
+    @Test
+    fun `T-UI-10 formatCountdownText formats remaining time as m-ss`() {
+        assertEquals("3:05 remaining", formatCountdownText(185, false))
+    }
+
+    @Test
+    fun `T-UI-11a formatCountdownText returns Timed out when isTimedOut is true`() {
+        assertEquals("Timed out", formatCountdownText(0, true))
+    }
+
+    @Test
+    fun `T-UI-11b calculateProgress returns 0f when remaining is 0`() {
+        assertEquals(0f, calculateProgress(0, 60))
+    }
+
+    @Test
+    fun `T-UI-12 calculateProgress returns half when halfway remaining`() {
+        assertEquals(0.5f, calculateProgress(30, 60))
+    }
+
+    // ─── T-UI-13 ~ T-UI-14 : isSubmitting ─────────────────────────────────────
+
+    @Test
+    fun `T-UI-13 isSubmitting reflects constructor value true`() {
+        val state = ApprovalModalState(isSubmitting = true)
+        assertTrue(state.isSubmitting)
+    }
+
+    @Test
+    fun `T-UI-14 isSubmitting defaults to false`() {
+        val state = ApprovalModalState()
+        assertFalse(state.isSubmitting)
+    }
+
+    // ─── T-UI-15 ~ T-UI-16 : error ────────────────────────────────────────────
+
+    @Test
+    fun `T-UI-15 error field preserves value`() {
+        val state = ApprovalModalState(error = "Network error")
+        assertEquals("Network error", state.error)
+    }
+
+    @Test
+    fun `T-UI-16 error defaults to null`() {
+        val state = ApprovalModalState()
+        assertNull(state.error)
+    }
+
+    // ─── T-UI-17 ~ T-UI-19 : ApprovalRequest.context ──────────────────────────
+
+    @Test
+    fun `T-UI-17 ApprovalRequest context exposes eta splitProposal detail`() {
+        val request =
+            ApprovalRequest(
+                approvalType = "strategy",
+                options = emptyList(),
+                context =
+                    ApprovalContext(
+                        eta = "5 min",
+                        splitProposal = "split into 2",
+                        detail = "extra detail",
+                    ),
+            )
+        val context = request.context
+        assertNotNull(context)
+        assertEquals("5 min", context.eta)
+        assertEquals("split into 2", context.splitProposal)
+        assertEquals("extra detail", context.detail)
+    }
+
+    @Test
+    fun `T-UI-18 ApprovalRequest context with only eta has other fields null`() {
+        val request =
+            ApprovalRequest(
+                approvalType = "strategy",
+                options = emptyList(),
+                context = ApprovalContext(eta = "3 min"),
+            )
+        val context = request.context
+        assertNotNull(context)
+        assertEquals("3 min", context.eta)
+        assertNull(context.splitProposal)
+        assertNull(context.detail)
+    }
+
+    @Test
+    fun `T-UI-19 ApprovalRequest with null context`() {
+        val request =
+            ApprovalRequest(
+                approvalType = "strategy",
+                options = emptyList(),
+                context = null,
+            )
+        assertNull(request.context)
+    }
+
+    // ─── Additional sanity checks referencing decision types (compile guard) ──
+
+    @Test
+    fun `sanity - decision sealed types are referenced`() {
+        val strategy: com.orchestradashboard.shared.domain.model.ApprovalDecision = StrategyDecision.SplitExecute
+        val court: com.orchestradashboard.shared.domain.model.ApprovalDecision = SupremeCourtDecision.Uphold
+        val generic: com.orchestradashboard.shared.domain.model.ApprovalDecision = GenericDecision("approve")
+        assertEquals("split_execute", strategy.value)
+        assertEquals("uphold", court.value)
+        assertEquals("approve", generic.value)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/ParallelPipelineViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/ParallelPipelineViewModelTest.kt
@@ -5,6 +5,7 @@ import com.orchestradashboard.shared.domain.model.DependencyType
 import com.orchestradashboard.shared.domain.model.MonitoredPipeline
 import com.orchestradashboard.shared.domain.model.PipelineRunStatus
 import com.orchestradashboard.shared.domain.model.StepStatus
+import com.orchestradashboard.shared.ui.approvalmodal.ApprovalModalViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -30,7 +31,7 @@ class ParallelPipelineViewModelTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         repository = FakePipelineMonitorRepository()
-        viewModel = PipelineMonitorViewModel("p1", repository)
+        viewModel = PipelineMonitorViewModel("p1", repository, ApprovalModalViewModel())
     }
 
     @AfterTest

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModelTest.kt
@@ -1,18 +1,15 @@
 package com.orchestradashboard.shared.ui.pipelinemonitor
 
-import com.orchestradashboard.shared.data.dto.orchestrator.ApprovalContextDto
 import com.orchestradashboard.shared.data.dto.orchestrator.PipelineEventDto
 import com.orchestradashboard.shared.domain.model.ConnectionStatus
 import com.orchestradashboard.shared.domain.model.PipelineRunStatus
 import com.orchestradashboard.shared.domain.model.StepStatus
-import com.orchestradashboard.shared.domain.usecase.RespondToApprovalUseCase
+import com.orchestradashboard.shared.ui.approvalmodal.ApprovalModalViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlin.test.AfterTest
@@ -34,7 +31,7 @@ class PipelineMonitorViewModelTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         repository = FakePipelineMonitorRepository()
-        viewModel = PipelineMonitorViewModel("p1", repository, nowMs = { testDispatcher.scheduler.currentTime })
+        viewModel = PipelineMonitorViewModel("p1", repository)
     }
 
     @AfterTest
@@ -186,12 +183,12 @@ class PipelineMonitorViewModelTest {
         }
 
     @Test
-    fun `approval requested event sets pendingApproval in state`() =
+    fun `approval requested event is forwarded to approvalModal`() =
         runTest {
-            viewModel.loadPipeline()
-            advanceUntilIdle()
+            val approvalModal = ApprovalModalViewModel(nowMs = { testDispatcher.scheduler.currentTime })
+            val vm = PipelineMonitorViewModel("p1", repository, approvalModal)
 
-            viewModel.startObserving()
+            vm.startObserving()
             advanceUntilIdle()
 
             repository.eventsFlow.emit(
@@ -200,27 +197,28 @@ class PipelineMonitorViewModelTest {
                     pipelineId = "p1",
                     approvalId = "approval-1",
                     approvalType = "strategy",
-                    options = listOf("approve", "reject"),
+                    options = listOf("split_execute", "no_split", "cancel"),
                     timeoutSec = 60,
                 ),
             )
             advanceUntilIdle()
 
-            val approval = viewModel.uiState.value.pendingApproval
+            val approval = approvalModal.uiState.value.pendingApproval
             assertNotNull(approval)
-            assertEquals("strategy", approval.approvalType)
-            assertEquals(listOf("approve", "reject"), approval.options)
             assertEquals("approval-1", approval.id)
-            assertEquals(60, approval.timeoutSec)
+            assertEquals("strategy", approval.approvalType)
+            assertTrue(approvalModal.uiState.value.showDialog)
+
+            vm.onCleared()
         }
 
     @Test
-    fun `supreme court required event sets pendingApproval in state`() =
+    fun `supreme court required event is forwarded to approvalModal`() =
         runTest {
-            viewModel.loadPipeline()
-            advanceUntilIdle()
+            val approvalModal = ApprovalModalViewModel(nowMs = { testDispatcher.scheduler.currentTime })
+            val vm = PipelineMonitorViewModel("p1", repository, approvalModal)
 
-            viewModel.startObserving()
+            vm.startObserving()
             advanceUntilIdle()
 
             repository.eventsFlow.emit(
@@ -230,192 +228,15 @@ class PipelineMonitorViewModelTest {
                     approvalId = "sc-1",
                     approvalType = "supreme_court",
                     options = listOf("uphold", "overturn", "redesign"),
-                    context = ApprovalContextDto(eta = "5m", detail = "Test ruling"),
                     timeoutSec = 120,
                 ),
             )
             advanceUntilIdle()
 
-            val approval = viewModel.uiState.value.pendingApproval
+            val approval = approvalModal.uiState.value.pendingApproval
             assertNotNull(approval)
-            assertEquals("supreme_court", approval.approvalType)
             assertEquals("sc-1", approval.id)
-            assertNotNull(approval.context)
-            assertEquals("5m", approval.context?.eta)
-            assertEquals("Test ruling", approval.context?.detail)
-        }
-
-    @Test
-    fun `approval event starts countdown and remainingTimeSec decreases`() =
-        runTest {
-            viewModel.loadPipeline()
-            advanceUntilIdle()
-
-            viewModel.startObserving()
-            advanceUntilIdle()
-
-            repository.eventsFlow.emit(
-                PipelineEventDto(
-                    type = "approval.requested",
-                    pipelineId = "p1",
-                    approvalId = "a1",
-                    approvalType = "strategy",
-                    options = listOf("approve"),
-                    timeoutSec = 10,
-                ),
-            )
-            runCurrent()
-
-            assertEquals(10, viewModel.uiState.value.remainingTimeSec)
-
-            advanceTimeBy(3001)
-            runCurrent()
-
-            assertEquals(7, viewModel.uiState.value.remainingTimeSec)
-            assertFalse(viewModel.uiState.value.isApprovalTimedOut)
-        }
-
-    @Test
-    fun `countdown reaching zero sets isApprovalTimedOut`() =
-        runTest {
-            viewModel.loadPipeline()
-            advanceUntilIdle()
-
-            viewModel.startObserving()
-            advanceUntilIdle()
-
-            repository.eventsFlow.emit(
-                PipelineEventDto(
-                    type = "approval.requested",
-                    pipelineId = "p1",
-                    approvalId = "a1",
-                    approvalType = "strategy",
-                    options = listOf("approve"),
-                    timeoutSec = 3,
-                ),
-            )
-            advanceUntilIdle()
-
-            advanceTimeBy(4000)
-
-            assertEquals(0, viewModel.uiState.value.remainingTimeSec)
-            assertTrue(viewModel.uiState.value.isApprovalTimedOut)
-        }
-
-    @Test
-    fun `respondToApproval calls use case and clears approval`() =
-        runTest {
-            val fakeApprovalRepo = FakeApprovalRepository()
-            val useCase = RespondToApprovalUseCase(fakeApprovalRepo)
-            val vm = PipelineMonitorViewModel("p1", repository, useCase, nowMs = { testDispatcher.scheduler.currentTime })
-
-            vm.loadPipeline()
-            advanceUntilIdle()
-
-            vm.startObserving()
-            advanceUntilIdle()
-
-            repository.eventsFlow.emit(
-                PipelineEventDto(
-                    type = "approval.requested",
-                    pipelineId = "p1",
-                    approvalId = "a1",
-                    approvalType = "strategy",
-                    options = listOf("approve"),
-                    timeoutSec = 60,
-                ),
-            )
-            // runCurrent instead of advanceUntilIdle to avoid exhausting the countdown before responding
-            runCurrent()
-
-            assertNotNull(vm.uiState.value.pendingApproval)
-
-            vm.respondToApproval("split_execute")
-            advanceUntilIdle()
-
-            assertEquals(1, fakeApprovalRepo.respondCallCount)
-            assertEquals("a1", fakeApprovalRepo.lastApprovalId)
-            assertEquals("split_execute", fakeApprovalRepo.lastDecision)
-            // Finding 4: verify comment is sent as empty string, not null
-            assertEquals("", fakeApprovalRepo.lastComment)
-            assertNull(vm.uiState.value.pendingApproval)
-            assertNull(vm.uiState.value.remainingTimeSec)
-
-            vm.onCleared()
-        }
-
-    @Test
-    fun `respondToApproval failure sets error`() =
-        runTest {
-            val fakeApprovalRepo = FakeApprovalRepository()
-            fakeApprovalRepo.respondResult = Result.failure(RuntimeException("Network error"))
-            val useCase = RespondToApprovalUseCase(fakeApprovalRepo)
-            val vm = PipelineMonitorViewModel("p1", repository, useCase, nowMs = { testDispatcher.scheduler.currentTime })
-
-            vm.loadPipeline()
-            advanceUntilIdle()
-
-            vm.startObserving()
-            advanceUntilIdle()
-
-            repository.eventsFlow.emit(
-                PipelineEventDto(
-                    type = "approval.requested",
-                    pipelineId = "p1",
-                    approvalId = "a1",
-                    approvalType = "strategy",
-                    options = listOf("approve"),
-                    timeoutSec = 60,
-                ),
-            )
-            // runCurrent instead of advanceUntilIdle to avoid exhausting the countdown before responding
-            runCurrent()
-
-            vm.respondToApproval("approve")
-            advanceUntilIdle()
-
-            assertEquals("Network error", vm.uiState.value.error)
-            // Approval should remain since the call failed
-            assertNotNull(vm.uiState.value.pendingApproval)
-
-            vm.onCleared()
-        }
-
-    @Test
-    fun `respondToApproval is ignored when approval is already timed out`() =
-        runTest {
-            val fakeApprovalRepo = FakeApprovalRepository()
-            val useCase = RespondToApprovalUseCase(fakeApprovalRepo)
-            val vm = PipelineMonitorViewModel("p1", repository, useCase, nowMs = { testDispatcher.scheduler.currentTime })
-
-            vm.loadPipeline()
-            advanceUntilIdle()
-
-            vm.startObserving()
-            advanceUntilIdle()
-
-            repository.eventsFlow.emit(
-                PipelineEventDto(
-                    type = "approval.requested",
-                    pipelineId = "p1",
-                    approvalId = "a1",
-                    approvalType = "strategy",
-                    options = listOf("approve"),
-                    timeoutSec = 3,
-                ),
-            )
-            // Let the countdown run to completion
-            advanceUntilIdle()
-
-            assertTrue(vm.uiState.value.isApprovalTimedOut)
-
-            // Simulate user clicking a button at the exact moment the timer expires
-            vm.respondToApproval("split_execute")
-            advanceUntilIdle()
-
-            // Should be ignored — no API call made, timed-out state preserved
-            assertEquals(0, fakeApprovalRepo.respondCallCount)
-            assertTrue(vm.uiState.value.isApprovalTimedOut)
+            assertEquals("supreme_court", approval.approvalType)
 
             vm.onCleared()
         }
@@ -466,35 +287,6 @@ class PipelineMonitorViewModelTest {
             viewModel.refresh()
             advanceUntilIdle()
             assertEquals(2, repository.getPipelineDetailCallCount)
-        }
-
-    @Test
-    fun `dismissApproval clears pendingApproval and remainingTimeSec`() =
-        runTest {
-            viewModel.loadPipeline()
-            advanceUntilIdle()
-
-            viewModel.startObserving()
-            advanceUntilIdle()
-
-            repository.eventsFlow.emit(
-                PipelineEventDto(
-                    type = "approval.requested",
-                    pipelineId = "p1",
-                    approvalType = "supreme_court",
-                    options = listOf("approve"),
-                    timeoutSec = 60,
-                ),
-            )
-            advanceUntilIdle()
-
-            assertNotNull(viewModel.uiState.value.pendingApproval)
-            assertNotNull(viewModel.uiState.value.remainingTimeSec)
-
-            viewModel.dismissApproval()
-
-            assertNull(viewModel.uiState.value.pendingApproval)
-            assertNull(viewModel.uiState.value.remainingTimeSec)
         }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModelTest.kt
@@ -31,7 +31,7 @@ class PipelineMonitorViewModelTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         repository = FakePipelineMonitorRepository()
-        viewModel = PipelineMonitorViewModel("p1", repository)
+        viewModel = PipelineMonitorViewModel("p1", repository, ApprovalModalViewModel())
     }
 
     @AfterTest
@@ -273,6 +273,7 @@ class PipelineMonitorViewModelTest {
             assertNotNull(viewModel.uiState.value.error)
 
             viewModel.clearError()
+            advanceUntilIdle()
 
             assertNull(viewModel.uiState.value.error)
         }

--- a/shared/src/desktopMain/kotlin/com/orchestradashboard/shared/ui/component/ApprovalDialogPreview.kt
+++ b/shared/src/desktopMain/kotlin/com/orchestradashboard/shared/ui/component/ApprovalDialogPreview.kt
@@ -1,0 +1,80 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.runtime.Composable
+import com.orchestradashboard.shared.domain.model.ApprovalContext
+import com.orchestradashboard.shared.domain.model.ApprovalRequest
+
+@Preview
+@Composable
+fun ApprovalDialogStrategyModePreview() {
+    val request =
+        ApprovalRequest(
+            id = "req-1",
+            approvalType = "strategy",
+            options = listOf("split_execute", "no_split", "cancel"),
+            context = ApprovalContext(eta = "5m", detail = "Deploy to production"),
+            timeoutSec = 300,
+        )
+    ApprovalDialog(
+        approval = request,
+        remainingTimeSec = 250,
+        isTimedOut = false,
+        isSubmitting = false,
+        error = null,
+        onRespond = {},
+        onDismiss = {},
+        onClearError = {},
+    )
+}
+
+@Preview
+@Composable
+fun ApprovalDialogSupremeCourtModePreview() {
+    val request =
+        ApprovalRequest(
+            id = "req-2",
+            approvalType = "supreme_court",
+            options = listOf("uphold", "overturn", "redesign"),
+            context =
+                ApprovalContext(
+                    eta = "10m",
+                    splitProposal = "Split into 3 sub-tasks",
+                    detail = "Review pipeline strategy",
+                ),
+            timeoutSec = 300,
+        )
+    ApprovalDialog(
+        approval = request,
+        remainingTimeSec = 180,
+        isTimedOut = false,
+        isSubmitting = false,
+        error = null,
+        onRespond = {},
+        onDismiss = {},
+        onClearError = {},
+    )
+}
+
+@Preview
+@Composable
+fun ApprovalDialogTimedOutPreview() {
+    val request =
+        ApprovalRequest(
+            id = "req-3",
+            approvalType = "strategy",
+            options = listOf("split_execute", "no_split", "cancel"),
+            context = ApprovalContext(eta = "5m", detail = "Deploy to production"),
+            timeoutSec = 300,
+        )
+    ApprovalDialog(
+        approval = request,
+        remainingTimeSec = 0,
+        isTimedOut = true,
+        isSubmitting = false,
+        error = null,
+        onRespond = {},
+        onDismiss = {},
+        onClearError = {},
+    )
+}


### PR DESCRIPTION
Closes #109

## Design
Now I have a complete picture. Here's the design document:

---

# Design Document: Approval Modal — Shared Module (Issue #109)

## Current State Analysis

Significant approval infrastructure already exists, embedded within PipelineMonitor:
- **Models**: `ApprovalRequest`, `ApprovalContext`, `ApprovalResponse` (raw `String` decision) in `domain/model/MonitoredPipeline.kt`
- **Repository**: `ApprovalRepository` interface + `ApprovalRepositoryImpl` calling `POST /api/approvals/{id}/respond`
- **UseCase**: `RespondToApprovalUseCase` wrapping the repository
- **ViewModel logic**: Countdown, timeout, auto-approve, event handling — all inside `PipelineMonitorViewModel`
- **UI**: `ApprovalDialog.kt` with strategy/supreme_court button sets
- **Tests**: Approval-related tests inside `PipelineMonitorViewModelTest`

**What's missing** (the actual scope of this issue):
1. **Typed response models** — `ApprovalResponse` is just `data class(decision: String)`, no type-safe sealed hierarchy for Strategy vs SupremeCourt decisions
2. **Dedicated ApprovalViewModel** — approval logic is tightly coupled to PipelineMonitorViewModel; needs extraction for reuse
3. **Dedicated ApprovalUiState** — currently mixed into `PipelineMonitorUiState`
4. **Dedicated unit tests** for the extracted ApprovalViewModel
5. **Auto-approve on timeout** — current code only *detects* timeout, doesn't send auto-approve response

---

## SECTION A: Design Document

### 1. Files to Create/Modify

**New files:**

| # | File

_(truncated)_

## Changed Files (10)
- `_workspace/03_ci_report.md`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/ApprovalDecision.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/approvalmodal/ApprovalModalState.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/approvalmodal/ApprovalModalViewModel.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorUiState.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModel.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/PipelineMonitorScreen.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/approvalmodal/ApprovalModalViewModelTest.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/approvalmodal/FakeApprovalRepository.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModelTest.kt`

## Review
Here are the findings from the review:

### Finding 1: `autoApprove` failure causes a stuck UI state

-   **File:** `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/approvalmodal/ApprovalModalViewModel.kt`
-   **Lines:** 140-142
-   **What is wrong:** When the `autoApprove` function is triggered by a timeout, if the underlying network call fails, the `onFailure` block only updates the state with an error message. It does not hide the dialog (`showDialog = false`) or clear the `pendingApproval` state. This results in the modal remaining on-screen in a timed-out state (`isTimedOut == true`), where the user cannot interact with it besides dismissing it.
-   **How to fix it:** The `onFailure` block within `autoApprove` should fully reset the approval state to hide the modal, simi

_(truncated)_

## AI Audit: PASS
[AUDIT: FAIL]

### Acceptance Criteria Status:

1. **ApprovalDecision sealed interface**: [PASS]  
2. **ApprovalModalState fields**: [PASS]  
3. **onApprovalRequested creates ApprovalRequest**: [PASS]  
4. **Concurrent approval guard**: [PASS]  
5. **Deadline-based countdown**: [PASS]  
6. **Auto-approve on timeout**: [PASS]  
7. **respond() clears state on success**: [PASS]  
8. **respond() no-op when timed out**: [PASS]  
9. **respond() sets error on failure**: [PASS]  
10. **PipelineMonitorViewModel delegates approval**: [PASS]  
11. **PipelineMonitorUiState fields removed**: [PASS]  
12. **26 test cases pass**: [PASS]  
13. **FakeApprovalRepository exists**: [PASS]  
14. **Tests migrated**: [PASS]  

### Critical Findings:

1. **Logic Flaw: Auto-approve Failure Leaves UI Stuck**  
   - **Severity**: [CRITICAL]  
   - **Details**: When `autoApprove()` fails, the modal remains visible with `isTimedOut == true`, preventing user interaction.  

2. **Redundant State Reset Logic**  
   -

_(truncated)_