### PR TITLE
feat: Approval Modal — Compose UI (commonMain)

### DIFF
--- a/_workspace/02_developer_log.md
+++ b/_workspace/02_developer_log.md
@@ -1,64 +1,51 @@
-# Developer Log — Issue #110 (Approval Modal UI)
+# Developer Log — Issue #114 (Approval Modal — SwiftUI iosApp)
 
 ## 구현 완료 파일
 
-### shared/commonTest (TDD — test-first)
-- [x] `shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/component/ApprovalDialogStateTest.kt` — 19개의 T-UI-N 테스트 + sanity 1개 = 총 20 tests (실제 JUnit report 기준 21 testcases, T-UI-11a/11b 분리 영향)
+### iosApp (신규)
+- [x] `iosApp/iosApp/IOSApprovalModalViewModel.swift`
+  - `@MainActor final class` — `ObservableObject` 래퍼
+  - `@Published` 6개: `showDialog`, `pendingApproval`, `remainingTimeSec`, `isTimedOut`, `isSubmitting`, `approvalError`
+  - `ApprovalModalStateCollector: Kotlinx_coroutines_coreFlowCollector` (IOSPipelineMonitorViewModel 패턴 동일)
+  - `respond(decision:comment:)` — `ApprovalDecisionValue` → `ApprovalDecision` sealed 매핑
+    - strategy 3개: `StrategyDecision.splitExecute/.noSplit/.cancel`
+    - supreme court 3개: `SupremeCourtDecision.uphold/.overturn/.redesign`
+    - generic 2개: `GenericDecision(value: "approve"|"reject")`
+    - fallback: `GenericDecision(value: decision.value)`
+  - `dismiss()`, `clearError()`, `onCleared()` — KMP ViewModel 메서드 위임
+  - `remainingTimeSec`: `KotlinInt?` → `Int32?`를 `.int32Value`로 변환 (기존 패턴)
 
-### shared/commonMain
-- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/ApprovalDialog.kt`
-  - `onRespond: (decision: String) -> Unit` → `onRespond: (ApprovalDecision) -> Unit`
-  - `isSubmitting`, `error`, `onClearError` 파라미터 추가
-  - 에러 메시지 표시 + `CircularProgressIndicator` 로딩 표시
-  - 모든 액션 버튼에 `enabled = !isSubmitting` 전달
-  - `buildTitle` → `internal buildDialogTitle`로 rename + 공개
-  - 새 internal 함수 추가: `formatCountdownText`, `calculateProgress`, `approvalDecisionsForType`
-  - StrategyButtons/SupremeCourtButtons/GenericButtons가 타입-세이프한 `ApprovalDecision` sealed 인스턴스 전달
-- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/PipelineMonitorScreen.kt`
-  - 사용하지 않는 `GenericDecision` import 제거
-  - `ApprovalDialog`에 `isSubmitting`, `error`, `onClearError` 전달
-- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModel.kt`
-  - `GenericDecision` import 추가
-  - iOS bridge용 메서드 3개 추가: `respondToApproval(decision, comment)`, `dismissApproval()`, `clearApprovalError()`
+- [x] `iosApp/iosApp/ApprovalModalView.swift`
+  - `@ObservedObject var viewModel: IOSApprovalModalViewModel`
+  - `.sheet(isPresented: Binding)` — 양방향 바인딩, 사용자 dismiss 제스처도 `viewModel.dismiss()` 호출
+  - sheet 안에서 `ApprovalDialogView` 렌더링 (기존 stateless 컴포넌트 재사용)
+  - `#Preview` 매크로 4종: Strategy active / Supreme Court active / Timed out / Submitting
 
-### iosApp
-- [x] `iosApp/iosApp/components/ApprovalDialogView.swift`
-  - `isSubmitting`, `error`, `onClearError` 프로퍼티 추가
-  - toolbar에 로딩 `ProgressView` 추가, `.alert` 바인딩으로 에러 표시
-  - 모든 액션 버튼에 `.disabled(isSubmitting)` 적용
-- [x] `iosApp/iosApp/IOSPipelineMonitorViewModel.swift`
-  - `isApprovalSubmitting`, `approvalError` @Published 속성 추가
-  - `approvalCollectTask`로 `approvalModal.uiState` 별도 수집
-  - `updateFromState`에서 approval 필드(`pendingApproval`, `remainingTimeSec`, `isApprovalTimedOut`) 제거 — 더 이상 PipelineMonitorUiState에 존재하지 않음
-  - 신규 `updateFromApprovalState(ApprovalModalState)` 추가
-  - `respondToApproval`을 KMP bridge 메서드로 라우팅
-  - `clearApprovalError()` 추가
-  - `onCleared()`에서 `approvalCollectTask` 함께 취소
-  - 파일 하단에 `ApprovalUiStateCollector` private 클래스 추가
+### iosApp (수정)
+- [x] `iosApp/iosApp/IOSAppContainer.swift`
+  - `createApprovalModalViewModel() -> ApprovalModalViewModel` 팩토리 추가
+  - 기존 다른 ViewModel 팩토리와 동일한 `fatalError("KMP framework must be linked via Gradle :shared:iosArm64Binaries")` 스텁 패턴
+
 - [x] `iosApp/iosApp/PipelineMonitorView.swift`
-  - `.sheet` 블록에 `isSubmitting`, `error`, `onClearError` 전달
+  - 기존 inline `.sheet` 블록에 유지 사유 NOTE 주석 추가
+  - 의도적으로 교체하지 않음: `PipelineMonitorView`는 `IOSPipelineMonitorViewModel` → KMP `PipelineMonitorViewModel.approvalModal`을 사용하고 있으며, 신규 `IOSApprovalModalViewModel`로 교체 시 별도 `ApprovalModalViewModel` 인스턴스가 생성되어 pipeline events를 받지 못함
+  - 주석으로 `ApprovalModalView`는 `PipelineMonitorViewModel`을 소유하지 않는 화면에서만 사용할 것을 명시
 
-### desktopApp / androidApp (AppContainer 수정 — 기존 compile-break 동반 수정)
-- [x] `desktopApp/src/main/kotlin/com/orchestradashboard/desktop/di/AppContainer.kt`
-  - `ApprovalModalViewModel` import 추가
-  - `createPipelineMonitorViewModel`: 구 시그니처 `(pipelineId, repo, useCase, mapper)` → 신 시그니처 `(pipelineId, repository, approvalModal=ApprovalModalViewModel(useCase, mapper))`
-- [x] `androidApp/src/main/kotlin/com/orchestradashboard/android/di/AppContainer.kt`
-  - 동일 패턴 수정 (desktop과 동일하게 `ApprovalModalViewModel` 주입)
+## 검증 결과 (정적)
 
-## 검증 결과
-
-- `:shared:compileCommonMainKotlinMetadata` — BUILD SUCCESSFUL
-- `:shared:desktopTest` — BUILD SUCCESSFUL, **78 suites / 552 tests / 0 failures / 0 errors / 0 skipped**
-  - `ApprovalDialogStateTest`: 21/21 pass (19 T-UI-N + T-UI-11a/11b split + sanity)
-  - `ApprovalModalViewModelTest`: 29/29 pass (회귀 없음)
-  - `PipelineMonitorViewModelTest`: 17/17 pass (회귀 없음)
-  - `ParallelPipelineViewModelTest`: 13/13 pass
-- `:desktopApp:assemble` — BUILD SUCCESSFUL
-- `:androidApp:assembleDebug` — BUILD SUCCESSFUL
-- `ktlintCheck` (root, 전체 모듈) — BUILD SUCCESSFUL
-- `:shared:detekt` — BUILD SUCCESSFUL (NO-SOURCE)
+- iOS CI는 본 저장소 `.github/workflows/ci.yml` 6-job 구성에서 미포함 (Issue #110 기준 동일)
+- Swift 문법은 기존 `IOSPipelineMonitorViewModel` / `PipelineMonitorView` / `ApprovalDialogView` 패턴과 정합:
+  - `Kotlinx_coroutines_coreFlowCollector` 심볼 사용 동일
+  - `@MainActor` + `Task { @MainActor [weak self] in ... }` 수집 패턴 동일
+  - `.int32Value` 언래핑 동일
+  - `ApprovalDecisionValue` switch는 기존 `StepTimelineView`의 `switch status { case .pending: ... default: ... }` 컨벤션 준수
+- KMP bridge 타입 확인:
+  - `ApprovalModalState.showDialog: Bool` ✓
+  - `ApprovalModalState.remainingTimeSec: Int?` → Swift `KotlinInt?` ✓
+  - `ApprovalModalState.isTimedOut: Bool` (computed property) ✓
+  - `ApprovalDecision` sealed interface, `StrategyDecision`/`SupremeCourtDecision`/`GenericDecision(value:)` 구현 ✓
+  - `ApprovalModalViewModel.respond(decision:comment:)` 시그니처 확인 ✓
 
 ## 미해결 이슈
 
-- 없음 (iOS CI는 현 워크플로우에 미포함 — `.github/workflows/ci.yml` 6-job. iOS Swift 변경은 문법적으로 정합하나 xcodebuild 미실행. KMP bridge 시그니처는 shared 테스트로 검증됨)
-- Compose Material 3 deprecation 경고 4건 (DesignPanel/DiscussPanel/PlanIssuesPanel/CommandCenterScreen) — 이슈 #110 범위 밖, 기존 경고 그대로 유지
+- 없음

--- a/_workspace/03_ci_report.md
+++ b/_workspace/03_ci_report.md
@@ -1,41 +1,30 @@
-## CI Parity 결과 — issue #113 (Approval Modal Compose UI)
+## CI Parity 결과 — issue #114 (Approval Modal — SwiftUI iosApp, #Preview refactor)
 
 | 잡 | 명령 | 상태 | 비고 |
 |----|------|------|------|
-| 1. ktlintCommonMainSourceSetCheck | `./gradlew :shared:ktlintCommonMainSourceSetCheck` | PASS | 1회차 실패 후 수정 → 2회차 PASS. |
-| 2. ktlintCommonTestSourceSetCheck | `./gradlew :shared:ktlintCommonTestSourceSetCheck` | PASS | FROM-CACHE. |
-| 3. ktlintDesktopTestSourceSetCheck | `./gradlew :shared:ktlintDesktopTestSourceSetCheck` | PASS | FROM-CACHE. |
-| 4. detekt | `./gradlew detekt` | PASS | shared=NO-SOURCE, desktopApp/androidApp/server PASS. |
-| 5. shared:desktopTest | `./gradlew :shared:desktopTest` | PASS | **552 tests / 0 failed / 0 skipped / 0 error**. (1회차 1건 실패 → 테스트 수정 후 2회차 PASS) |
-| 6. server:test | `./gradlew :server:test` | PASS | **209 tests / 0 failed**. FROM-CACHE. |
+| 1. Shared (KMP) Tests | `./gradlew :shared:desktopTest --parallel` | PASS | UP-TO-DATE (cache hit) |
+| 2. Server (Spring Boot) Build & Test | `./gradlew :server:assemble --parallel && :server:test && :server:bootJar` | PASS | UP-TO-DATE (cache hit) |
+| 3. Desktop App Build | `./gradlew :desktopApp:build --parallel` | PASS | UP-TO-DATE (cache hit) |
+| 4. Android App Build | `./gradlew :androidApp:assembleDebug --parallel` | PASS | UP-TO-DATE (cache hit) |
+| 5. Code Quality — Detekt | `./gradlew detekt --continue` | PASS | UP-TO-DATE (cache hit) |
+| 6. Code Quality — ktlint (root) | `./gradlew ktlintCheck` | PASS | UP-TO-DATE (cache hit) |
 
-## 총 테스트 카운트
+## 변경 범위
 
-- **shared:desktopTest: 552 tests pass, 0 fail, 0 skipped, 0 error** (79 suites)
-  - `ApprovalDialogStateTest`: 21 tests (issue #113 Compose UI 상태)
-  - `ApprovalModalViewModelTest`: 29 tests (issue #113 ViewModel 로직)
-  - `PipelineMonitorViewModelTest`: 17 tests (통합 회귀)
-  - 기타 repository/mapper/api 등: 485 tests
-- **server:test: 209 tests pass, 0 fail** (Controller/Service/Config 등 전 범위)
+- 수정 파일: `iosApp/iosApp/ApprovalModalView.swift` (SwiftUI `#Preview` 매크로 2종)
+- 변경 내용: `#Preview` 블록을 `ApprovalDialogView` 직접 인스턴스화 → `ApprovalModalView` + `PreviewHost` 래퍼 구조로 전환
+- 프로덕션 로직 변경 없음 (Preview-only)
+
+## CI Parity 분석
+
+- `.github/workflows/ci.yml` 6-job 구성은 전부 JVM/Android 기반 Gradle 태스크
+- iOS/SwiftUI 소스는 Gradle 빌드 그래프에 없음 → 본 수정이 CI 6개 잡에 미치는 영향 = 0
+- 6개 잡 모두 UP-TO-DATE (`--parallel` 상태에서도 캐시 히트)로 통과 확인
 
 ## 수정 이력
 
-### 1회차 (초기 실행)
-- `:shared:ktlintCommonMainSourceSetCheck` FAILED:
-  - `PipelineMonitorViewModel.kt:34` — `standard:property-naming` 위반. `_pipelineState` 네이밍이 백킹 프로퍼티 규칙에 부적합 (public property `uiState`가 있는데 이름 불일치).
-  - 조치: 전 파일에서 `_pipelineState` → `_uiState` 리네임 (13곳). 백킹 프로퍼티 규칙(`_uiState` ↔ `val uiState`) 준수.
-- `:shared:desktopTest` FAILED:
-  - `PipelineMonitorViewModelTest.clearError sets error to null` — `uiState`가 `combine(_uiState, approvalModal.uiState).stateIn(...)` 파이프라인을 거치므로, `clearError()` 호출 직후 동기적으로 `uiState.value`가 갱신되지 않음 (TestDispatcher에서 combine 파이프가 한 스텝 필요).
-  - 조치: `clearError()` 호출 뒤 `advanceUntilIdle()` 1회 추가. 다른 error-관련 테스트(`loadPipeline sets error on failure`)가 이미 `advanceUntilIdle()`을 쓰는 것과 동일한 패턴.
+- 1회차 실행에서 6개 잡 전체 PASS. 수정 불필요.
 
-### 2회차 (재실행)
-- 6개 잡 전체 PASS. 변경 없음.
+## 최종 상태: ALL GREEN (PR 생성 가능)
 
-## 경고 (비-블로킹)
-
-- Compose Material 3 deprecation 경고 4건 (DesignPanel/DiscussPanel/PlanIssuesPanel L52~57, CommandCenterScreen L50) — 이슈 #113 범위 밖, 기존 경고 유지.
-- Gradle 8.7의 Gradle 9.0 deprecation 경고 — 인프라 범위.
-
-## 최종 상태: ALL GREEN
-
-커밋: `443a907 feat(shared): Approval Modal — Compose UI + ViewModel + Tests (#113)`
+참고: iOS SwiftUI 코드는 리포지토리 CI 파이프라인에 포함되지 않으므로 (Issue #110/#113/#114 공통), iOS 프리뷰 렌더링 검증은 Xcode 로컬에서만 가능하다. 본 에이전트는 CI Parity (6개 잡) 게이트만 커버한다.

--- a/_workspace/03_ci_report.md
+++ b/_workspace/03_ci_report.md
@@ -1,33 +1,41 @@
-## CI Parity 결과 (6개 잡) — issue #110 (Approval Modal UI)
+## CI Parity 결과 — issue #113 (Approval Modal Compose UI)
 
 | 잡 | 명령 | 상태 | 비고 |
 |----|------|------|------|
-| 1. ktlintCheck (루트) | `./gradlew ktlintCheck` | PASS | 41 tasks, 모두 UP-TO-DATE. commonMain/commonTest/desktopMain/desktopTest/androidMain/kotlinScripts 전부 통과. |
-| 2. detekt (shared) | `./gradlew :shared:detekt` | PASS | NO-SOURCE (shared는 Kotlin Multiplatform 구성으로 detekt 태스크가 소스 없음 보고). 루트 `detekt` 구성은 CI 워크플로우에서 별도 처리. |
-| 3. shared allTests | `./gradlew :shared:allTests` | PASS | 4 target × 합계 **1,788 tests / 0 failure / 0 error / 0 skip**. 상세: desktopTest 552, iosSimulatorArm64Test 412, testDebugUnitTest 412, testReleaseUnitTest 412. iosX64Test는 SKIPPED (unlinked `kotlin.uuid` 심볼 — kotlinx-serialization 1.7 + Kotlin 2.0 호환 이슈로 iosX64 링크 스킵, CI의 macOS 러너 동작과 동일). |
-| 4. shared compileCommonMainKotlinMetadata | `./gradlew :shared:compileCommonMainKotlinMetadata` | PASS | 4 tasks UP-TO-DATE. |
-| 5. desktopApp assemble | `./gradlew :desktopApp:assemble` | PASS | 13 tasks UP-TO-DATE. desktopJar 산출물 확인. |
-| 6. androidApp assembleDebug | `./gradlew :androidApp:assembleDebug` | PASS | 61 tasks UP-TO-DATE. Debug APK 산출물 확인. |
+| 1. ktlintCommonMainSourceSetCheck | `./gradlew :shared:ktlintCommonMainSourceSetCheck` | PASS | 1회차 실패 후 수정 → 2회차 PASS. |
+| 2. ktlintCommonTestSourceSetCheck | `./gradlew :shared:ktlintCommonTestSourceSetCheck` | PASS | FROM-CACHE. |
+| 3. ktlintDesktopTestSourceSetCheck | `./gradlew :shared:ktlintDesktopTestSourceSetCheck` | PASS | FROM-CACHE. |
+| 4. detekt | `./gradlew detekt` | PASS | shared=NO-SOURCE, desktopApp/androidApp/server PASS. |
+| 5. shared:desktopTest | `./gradlew :shared:desktopTest` | PASS | **552 tests / 0 failed / 0 skipped / 0 error**. (1회차 1건 실패 → 테스트 수정 후 2회차 PASS) |
+| 6. server:test | `./gradlew :server:test` | PASS | **209 tests / 0 failed**. FROM-CACHE. |
 
 ## 총 테스트 카운트
 
-- **shared 합계: 1,788 tests pass, 0 fail, 0 error, 0 skipped** (4 타겟 합산)
-- desktopTest 기준 단일 타겟: 78 suites / 552 tests
-  - `ApprovalDialogStateTest`: 21 tests (issue #110 신규 UI 상태 검증)
-  - `ApprovalModalViewModelTest`: 29 tests (issue #109 회귀 검증)
-  - `PipelineMonitorViewModelTest`: 17 tests (delegation 패턴 회귀 검증)
-  - `ParallelPipelineViewModelTest`: 13 tests
-  - 기타 repository/mapper/api 테스트: 472 tests
+- **shared:desktopTest: 552 tests pass, 0 fail, 0 skipped, 0 error** (79 suites)
+  - `ApprovalDialogStateTest`: 21 tests (issue #113 Compose UI 상태)
+  - `ApprovalModalViewModelTest`: 29 tests (issue #113 ViewModel 로직)
+  - `PipelineMonitorViewModelTest`: 17 tests (통합 회귀)
+  - 기타 repository/mapper/api 등: 485 tests
+- **server:test: 209 tests pass, 0 fail** (Controller/Service/Config 등 전 범위)
 
 ## 수정 이력
 
-- 1회차: 6개 잡 모두 PASS, 코드 수정 없음.
+### 1회차 (초기 실행)
+- `:shared:ktlintCommonMainSourceSetCheck` FAILED:
+  - `PipelineMonitorViewModel.kt:34` — `standard:property-naming` 위반. `_pipelineState` 네이밍이 백킹 프로퍼티 규칙에 부적합 (public property `uiState`가 있는데 이름 불일치).
+  - 조치: 전 파일에서 `_pipelineState` → `_uiState` 리네임 (13곳). 백킹 프로퍼티 규칙(`_uiState` ↔ `val uiState`) 준수.
+- `:shared:desktopTest` FAILED:
+  - `PipelineMonitorViewModelTest.clearError sets error to null` — `uiState`가 `combine(_uiState, approvalModal.uiState).stateIn(...)` 파이프라인을 거치므로, `clearError()` 호출 직후 동기적으로 `uiState.value`가 갱신되지 않음 (TestDispatcher에서 combine 파이프가 한 스텝 필요).
+  - 조치: `clearError()` 호출 뒤 `advanceUntilIdle()` 1회 추가. 다른 error-관련 테스트(`loadPipeline sets error on failure`)가 이미 `advanceUntilIdle()`을 쓰는 것과 동일한 패턴.
+
+### 2회차 (재실행)
+- 6개 잡 전체 PASS. 변경 없음.
 
 ## 경고 (비-블로킹)
 
-- Compose Material 3 deprecation 경고 4건 (DesignPanel.kt:52, DiscussPanel.kt:55, PlanIssuesPanel.kt:57, CommandCenterScreen.kt:50) — 이슈 #110 범위 밖, 기존 코드 그대로.
-- Gradle 8.7의 Gradle 9.0 deprecation 경고 — 인프라 범위, 이슈 범위 밖.
-- kotlinx-serialization-core의 `kotlin.uuid/Uuid` unlinked symbol 경고 — iosX64Test SKIPPED 원인. iosSimulatorArm64Test는 정상 실행되어 iOS 로직 커버됨.
-- iOS `IOSPipelineMonitorViewModel.swift` / `PipelineMonitorView.swift` / `ApprovalDialogView.swift` 변경은 KMP bridge 시그니처에 정합하며 shared 테스트로 간접 검증됨. iOS xcodebuild는 현 CI 워크플로우 미포함 (`.github/workflows/ci.yml` 6-job).
+- Compose Material 3 deprecation 경고 4건 (DesignPanel/DiscussPanel/PlanIssuesPanel L52~57, CommandCenterScreen L50) — 이슈 #113 범위 밖, 기존 경고 유지.
+- Gradle 8.7의 Gradle 9.0 deprecation 경고 — 인프라 범위.
 
-## 최종 상태: ALL GREEN (PR 생성 가능)
+## 최종 상태: ALL GREEN
+
+커밋: `443a907 feat(shared): Approval Modal — Compose UI + ViewModel + Tests (#113)`

--- a/iosApp/iosApp/ApprovalModalView.swift
+++ b/iosApp/iosApp/ApprovalModalView.swift
@@ -1,0 +1,170 @@
+import SwiftUI
+import Shared
+
+/// Coordinator view that binds `IOSApprovalModalViewModel` to the stateless
+/// `ApprovalDialogView` component and presents it as a modal sheet.
+///
+/// Use this from any screen that needs to react to pipeline approval requests
+/// — it listens to the KMP `ApprovalModalViewModel.uiState` (via the iOS
+/// wrapper) and drives sheet presentation, button enablement, timeout, and
+/// error alerts automatically.
+struct ApprovalModalView: View {
+    @ObservedObject var viewModel: IOSApprovalModalViewModel
+
+    var body: some View {
+        EmptyView()
+            .sheet(isPresented: Binding(
+                get: { viewModel.showDialog },
+                set: { newValue in
+                    if !newValue { viewModel.dismiss() }
+                }
+            )) {
+                if let approval = viewModel.pendingApproval {
+                    ApprovalDialogView(
+                        approval: approval,
+                        remainingTimeSec: viewModel.remainingTimeSec,
+                        isTimedOut: viewModel.isTimedOut,
+                        isSubmitting: viewModel.isSubmitting,
+                        error: viewModel.approvalError,
+                        onRespond: { decision in viewModel.respond(decision: decision) },
+                        onDismiss: { viewModel.dismiss() },
+                        onClearError: { viewModel.clearError() }
+                    )
+                }
+            }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Strategy — active") {
+    struct PreviewHost: View {
+        @StateObject var vm: IOSApprovalModalViewModel
+
+        init() {
+            let approvalVM = IOSApprovalModalViewModel()
+            approvalVM.showDialog = true
+            approvalVM.pendingApproval = ApprovalRequest(
+                approvalType: "strategy",
+                options: ["split_execute", "no_split", "cancel"],
+                id: "preview-strategy-1",
+                context: ApprovalContext(
+                    eta: "~18 min",
+                    splitProposal: "Split into 3 checkpoints",
+                    detail: "Issue spans multiple modules"
+                ),
+                timeoutSec: 300,
+                requestedAtMs: 0
+            )
+            approvalVM.remainingTimeSec = 240
+            approvalVM.isTimedOut = false
+            approvalVM.isSubmitting = false
+            _vm = StateObject(wrappedValue: approvalVM)
+        }
+
+        var body: some View {
+            ZStack {
+                Text("Parent View Content")
+                ApprovalModalView(viewModel: vm)
+            }
+        }
+    }
+    return PreviewHost()
+}
+
+#Preview("Supreme Court — active") {
+    struct PreviewHost: View {
+        @StateObject var vm: IOSApprovalModalViewModel
+
+        init() {
+            let approvalVM = IOSApprovalModalViewModel()
+            approvalVM.showDialog = true
+            approvalVM.pendingApproval = ApprovalRequest(
+                approvalType: "supreme_court",
+                options: ["uphold", "overturn", "redesign"],
+                id: "preview-sc-1",
+                context: ApprovalContext(
+                    eta: nil,
+                    splitProposal: nil,
+                    detail: "Design review after 2 failed checkpoints"
+                ),
+                timeoutSec: 600,
+                requestedAtMs: 0
+            )
+            approvalVM.remainingTimeSec = 480
+            approvalVM.isTimedOut = false
+            approvalVM.isSubmitting = false
+            _vm = StateObject(wrappedValue: approvalVM)
+        }
+
+        var body: some View {
+            ZStack {
+                Text("Parent View Content")
+                ApprovalModalView(viewModel: vm)
+            }
+        }
+    }
+    return PreviewHost()
+}
+
+#Preview("Timed out") {
+    struct PreviewHost: View {
+        @StateObject var vm: IOSApprovalModalViewModel
+
+        init() {
+            let approvalVM = IOSApprovalModalViewModel()
+            approvalVM.showDialog = true
+            approvalVM.pendingApproval = ApprovalRequest(
+                approvalType: "strategy",
+                options: ["split_execute", "no_split", "cancel"],
+                id: "preview-timeout",
+                context: nil,
+                timeoutSec: 300,
+                requestedAtMs: 0
+            )
+            approvalVM.remainingTimeSec = 0
+            approvalVM.isTimedOut = true
+            approvalVM.isSubmitting = false
+            _vm = StateObject(wrappedValue: approvalVM)
+        }
+
+        var body: some View {
+            ZStack {
+                Text("Parent View Content")
+                ApprovalModalView(viewModel: vm)
+            }
+        }
+    }
+    return PreviewHost()
+}
+
+#Preview("Submitting") {
+    struct PreviewHost: View {
+        @StateObject var vm: IOSApprovalModalViewModel
+
+        init() {
+            let approvalVM = IOSApprovalModalViewModel()
+            approvalVM.showDialog = true
+            approvalVM.pendingApproval = ApprovalRequest(
+                approvalType: "strategy",
+                options: ["split_execute", "no_split", "cancel"],
+                id: "preview-submitting",
+                context: nil,
+                timeoutSec: 300,
+                requestedAtMs: 0
+            )
+            approvalVM.remainingTimeSec = 200
+            approvalVM.isTimedOut = false
+            approvalVM.isSubmitting = true
+            _vm = StateObject(wrappedValue: approvalVM)
+        }
+
+        var body: some View {
+            ZStack {
+                Text("Parent View Content")
+                ApprovalModalView(viewModel: vm)
+            }
+        }
+    }
+    return PreviewHost()
+}

--- a/iosApp/iosApp/IOSAppContainer.swift
+++ b/iosApp/iosApp/IOSAppContainer.swift
@@ -61,6 +61,10 @@ final class IOSAppContainer {
         fatalError("KMP framework must be linked via Gradle :shared:iosArm64Binaries")
     }
 
+    func createApprovalModalViewModel() -> ApprovalModalViewModel {
+        fatalError("KMP framework must be linked via Gradle :shared:iosArm64Binaries")
+    }
+
     func createCommandCenterViewModel() -> CommandCenterViewModel {
         fatalError("KMP framework must be linked via Gradle :shared:iosArm64Binaries")
     }

--- a/iosApp/iosApp/IOSApprovalModalViewModel.swift
+++ b/iosApp/iosApp/IOSApprovalModalViewModel.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Shared
+
+/// iOS-specific wrapper around the KMP ApprovalModalViewModel.
+/// Bridges Kotlin coroutine StateFlow to Swift's ObservableObject/Combine.
+///
+/// The KMP `ApprovalModalViewModel` owns the canonical approval state
+/// (pending request, countdown, timeout, submission, error). This class
+/// surfaces those fields as `@Published` properties for SwiftUI.
+@MainActor
+final class IOSApprovalModalViewModel: ObservableObject {
+    @Published var showDialog: Bool = false
+    @Published var pendingApproval: ApprovalRequest? = nil
+    @Published var remainingTimeSec: Int32? = nil
+    @Published var isTimedOut: Bool = false
+    @Published var isSubmitting: Bool = false
+    @Published var approvalError: String? = nil
+
+    private let viewModel: ApprovalModalViewModel
+    private var collectTask: Task<Void, Never>?
+
+    init(viewModel: ApprovalModalViewModel? = nil) {
+        self.viewModel = viewModel ?? IOSAppContainer.shared.createApprovalModalViewModel()
+        startCollecting()
+    }
+
+    private func startCollecting() {
+        collectTask?.cancel()
+        collectTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let collector = ApprovalModalStateCollector { [weak self] state in
+                self?.updateFromState(state)
+            }
+            try? await self.viewModel.uiState.collect(collector: collector)
+        }
+    }
+
+    private func updateFromState(_ state: ApprovalModalState) {
+        self.showDialog = state.showDialog
+        self.pendingApproval = state.pendingApproval
+        if let remaining = state.remainingTimeSec {
+            self.remainingTimeSec = remaining.int32Value
+        } else {
+            self.remainingTimeSec = nil
+        }
+        self.isTimedOut = state.isTimedOut
+        self.isSubmitting = state.isSubmitting
+        self.approvalError = state.error
+    }
+
+    /// Submits a user decision. Maps the `ApprovalDecisionValue` enum (exposed
+    /// to SwiftUI callers) to the matching KMP `ApprovalDecision` sealed-interface
+    /// variant — `StrategyDecision`, `SupremeCourtDecision`, or `GenericDecision`.
+    func respond(decision: ApprovalDecisionValue, comment: String = "") {
+        let kmpDecision: ApprovalDecision = mapDecision(decision)
+        viewModel.respond(decision: kmpDecision, comment: comment)
+    }
+
+    func dismiss() {
+        viewModel.dismiss()
+    }
+
+    func clearError() {
+        viewModel.clearError()
+    }
+
+    func onCleared() {
+        collectTask?.cancel()
+        viewModel.onCleared()
+    }
+
+    // MARK: - Decision Mapping
+
+    private func mapDecision(_ decision: ApprovalDecisionValue) -> ApprovalDecision {
+        switch decision {
+        case .splitExecute:
+            return StrategyDecision.splitExecute
+        case .noSplit:
+            return StrategyDecision.noSplit
+        case .cancel:
+            return StrategyDecision.cancel
+        case .uphold:
+            return SupremeCourtDecision.uphold
+        case .overturn:
+            return SupremeCourtDecision.overturn
+        case .redesign:
+            return SupremeCourtDecision.redesign
+        case .approve:
+            return GenericDecision(value: "approve")
+        case .reject:
+            return GenericDecision(value: "reject")
+        default:
+            return GenericDecision(value: decision.value)
+        }
+    }
+}
+
+private final class ApprovalModalStateCollector: Kotlinx_coroutines_coreFlowCollector {
+    let onValue: (ApprovalModalState) -> Void
+
+    init(onValue: @escaping (ApprovalModalState) -> Void) {
+        self.onValue = onValue
+    }
+
+    func emit(value: Any?, completionHandler: @escaping (Error?) -> Void) {
+        if let state = value as? ApprovalModalState {
+            onValue(state)
+        }
+        completionHandler(nil)
+    }
+}

--- a/iosApp/iosApp/PipelineMonitorView.swift
+++ b/iosApp/iosApp/PipelineMonitorView.swift
@@ -51,6 +51,13 @@ struct PipelineMonitorView: View {
         } message: {
             Text(viewModel.error ?? "")
         }
+        // NOTE: This sheet is intentionally inline and bound to the
+        // pipeline-owned approval modal (via `IOSPipelineMonitorViewModel`
+        // → KMP `PipelineMonitorViewModel.approvalModal`). Do NOT replace
+        // it with `ApprovalModalView(viewModel: IOSApprovalModalViewModel())`
+        // — that would create a second, disconnected approval modal that
+        // never receives pipeline events. Use `ApprovalModalView` only on
+        // screens that do NOT already own a `PipelineMonitorViewModel`.
         .sheet(isPresented: .constant(viewModel.pendingApproval != nil)) {
             if let approval = viewModel.pendingApproval {
                 ApprovalDialogView(

--- a/iosApp/iosApp/components/ApprovalDialogView.swift
+++ b/iosApp/iosApp/components/ApprovalDialogView.swift
@@ -215,6 +215,6 @@ struct ApprovalDialogView: View {
     private func formatTime(_ totalSeconds: Int) -> String {
         let minutes = totalSeconds / 60
         let seconds = totalSeconds % 60
-        return "\(minutes):\(String(format: "%02d", seconds)) remaining"
+        return "\(String(format: "%02d", minutes)):\(String(format: "%02d", seconds)) remaining"
     }
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -70,6 +70,7 @@ kotlin {
             dependencies {
                 implementation(libs.coroutines.swing)
                 implementation(libs.ktor.client.cio)
+                implementation(compose.desktop.currentOs)
             }
         }
 

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModel.kt
@@ -28,12 +28,12 @@ private const val MAX_LOG_LINES = 500
 class PipelineMonitorViewModel(
     private val pipelineId: String,
     private val repository: PipelineMonitorRepository,
-    val approvalModal: ApprovalModalViewModel = ApprovalModalViewModel(),
+    val approvalModal: ApprovalModalViewModel,
 ) {
     private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
-    private val _pipelineState = MutableStateFlow(PipelineMonitorUiState())
+    private val _uiState = MutableStateFlow(PipelineMonitorUiState())
     val uiState: StateFlow<PipelineMonitorUiState> =
-        combine(_pipelineState, approvalModal.uiState) { pipelineState, approvalState ->
+        combine(_uiState, approvalModal.uiState) { pipelineState, approvalState ->
             pipelineState.copy(
                 pendingApproval = approvalState.pendingApproval,
                 approvalRemainingTimeSec = approvalState.remainingTimeSec,
@@ -49,10 +49,10 @@ class PipelineMonitorViewModel(
 
     fun loadPipeline() {
         viewModelScope.launch {
-            _pipelineState.update { it.copy(isLoading = true, error = null) }
+            _uiState.update { it.copy(isLoading = true, error = null) }
             repository.getPipelineDetail(pipelineId)
                 .onSuccess { newPipeline ->
-                    val oldSteps = _pipelineState.value.pipeline?.steps
+                    val oldSteps = _uiState.value.pipeline?.steps
                     val mergedSteps =
                         if (oldSteps != null) {
                             newPipeline.steps.map { newStep ->
@@ -69,13 +69,13 @@ class PipelineMonitorViewModel(
                         } else {
                             newPipeline.steps
                         }
-                    _pipelineState.update { it.copy(pipeline = newPipeline.copy(steps = mergedSteps), isLoading = false) }
+                    _uiState.update { it.copy(pipeline = newPipeline.copy(steps = mergedSteps), isLoading = false) }
                     if (newPipeline.isParallel) {
                         loadParallelPipelines()
                     }
                 }
                 .onFailure { e ->
-                    _pipelineState.update { it.copy(error = e.message, isLoading = false) }
+                    _uiState.update { it.copy(error = e.message, isLoading = false) }
                 }
         }
     }
@@ -84,7 +84,7 @@ class PipelineMonitorViewModel(
         viewModelScope.launch {
             repository.getParallelPipelines(pipelineId)
                 .onSuccess { group ->
-                    _pipelineState.update {
+                    _uiState.update {
                         it.copy(
                             parallelGroup = group,
                             parallelPipelines = group.pipelines,
@@ -92,17 +92,17 @@ class PipelineMonitorViewModel(
                     }
                 }
                 .onFailure { e ->
-                    _pipelineState.update { it.copy(error = e.message) }
+                    _uiState.update { it.copy(error = e.message) }
                 }
         }
     }
 
     fun startObserving() {
         viewModelScope.launch {
-            _pipelineState.update { it.copy(connectionStatus = ConnectionStatus.CONNECTED) }
+            _uiState.update { it.copy(connectionStatus = ConnectionStatus.CONNECTED) }
             repository.observePipelineEvents(pipelineId)
                 .catch { e ->
-                    _pipelineState.update {
+                    _uiState.update {
                         it.copy(connectionStatus = ConnectionStatus.DISCONNECTED, error = e.message)
                     }
                 }
@@ -125,7 +125,7 @@ class PipelineMonitorViewModel(
             "approval.requested", "supreme_court.required" -> approvalModal.onApprovalRequested(event)
             "log" -> {
                 event.detail?.let { line ->
-                    _pipelineState.update { state ->
+                    _uiState.update { state ->
                         val updated = state.logLines.toMutableList().apply { add(line) }
                         state.copy(logLines = if (updated.size > MAX_LOG_LINES) updated.takeLast(MAX_LOG_LINES) else updated)
                     }
@@ -138,7 +138,7 @@ class PipelineMonitorViewModel(
         laneId: String,
         event: PipelineEventDto,
     ) {
-        _pipelineState.update { state ->
+        _uiState.update { state ->
             val group = state.parallelGroup ?: return@update state
             val updatedPipelines =
                 group.pipelines.map { lane ->
@@ -195,7 +195,7 @@ class PipelineMonitorViewModel(
         elapsedSec: Double?,
     ) {
         if (stepName == null) return
-        _pipelineState.update { state ->
+        _uiState.update { state ->
             val pipeline = state.pipeline ?: return@update state
             val updatedSteps =
                 pipeline.steps.map { step ->
@@ -219,13 +219,13 @@ class PipelineMonitorViewModel(
     }
 
     private fun updatePipelineStatus(status: PipelineRunStatus) {
-        _pipelineState.update { state ->
+        _uiState.update { state ->
             state.copy(pipeline = state.pipeline?.copy(status = status))
         }
     }
 
     fun clearError() {
-        _pipelineState.update { it.copy(error = null) }
+        _uiState.update { it.copy(error = null) }
     }
 
     fun respondToApproval(

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/ParallelPipelineViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/ParallelPipelineViewModelTest.kt
@@ -5,6 +5,7 @@ import com.orchestradashboard.shared.domain.model.DependencyType
 import com.orchestradashboard.shared.domain.model.MonitoredPipeline
 import com.orchestradashboard.shared.domain.model.PipelineRunStatus
 import com.orchestradashboard.shared.domain.model.StepStatus
+import com.orchestradashboard.shared.ui.approvalmodal.ApprovalModalViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -30,7 +31,7 @@ class ParallelPipelineViewModelTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         repository = FakePipelineMonitorRepository()
-        viewModel = PipelineMonitorViewModel("p1", repository)
+        viewModel = PipelineMonitorViewModel("p1", repository, ApprovalModalViewModel())
     }
 
     @AfterTest

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModelTest.kt
@@ -31,7 +31,7 @@ class PipelineMonitorViewModelTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         repository = FakePipelineMonitorRepository()
-        viewModel = PipelineMonitorViewModel("p1", repository)
+        viewModel = PipelineMonitorViewModel("p1", repository, ApprovalModalViewModel())
     }
 
     @AfterTest
@@ -273,6 +273,7 @@ class PipelineMonitorViewModelTest {
             assertNotNull(viewModel.uiState.value.error)
 
             viewModel.clearError()
+            advanceUntilIdle()
 
             assertNull(viewModel.uiState.value.error)
         }

--- a/shared/src/desktopMain/kotlin/com/orchestradashboard/shared/ui/component/ApprovalDialogPreview.kt
+++ b/shared/src/desktopMain/kotlin/com/orchestradashboard/shared/ui/component/ApprovalDialogPreview.kt
@@ -1,0 +1,76 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.runtime.Composable
+import com.orchestradashboard.shared.domain.model.ApprovalContext
+import com.orchestradashboard.shared.domain.model.ApprovalRequest
+
+@Preview
+@Composable
+fun ApprovalDialogStrategyModePreview() {
+    val request = ApprovalRequest(
+        id = "req-1",
+        approvalType = "strategy",
+        options = listOf("split_execute", "no_split", "cancel"),
+        context = ApprovalContext(eta = "5m", detail = "Deploy to production"),
+        timeoutSec = 300,
+    )
+    ApprovalDialog(
+        approval = request,
+        remainingTimeSec = 250,
+        isTimedOut = false,
+        isSubmitting = false,
+        error = null,
+        onRespond = {},
+        onDismiss = {},
+        onClearError = {},
+    )
+}
+
+@Preview
+@Composable
+fun ApprovalDialogSupremeCourtModePreview() {
+    val request = ApprovalRequest(
+        id = "req-2",
+        approvalType = "supreme_court",
+        options = listOf("uphold", "overturn", "redesign"),
+        context = ApprovalContext(
+            eta = "10m",
+            splitProposal = "Split into 3 sub-tasks",
+            detail = "Review pipeline strategy",
+        ),
+        timeoutSec = 300,
+    )
+    ApprovalDialog(
+        approval = request,
+        remainingTimeSec = 180,
+        isTimedOut = false,
+        isSubmitting = false,
+        error = null,
+        onRespond = {},
+        onDismiss = {},
+        onClearError = {},
+    )
+}
+
+@Preview
+@Composable
+fun ApprovalDialogTimedOutPreview() {
+    val request = ApprovalRequest(
+        id = "req-3",
+        approvalType = "strategy",
+        options = listOf("split_execute", "no_split", "cancel"),
+        context = ApprovalContext(eta = "5m", detail = "Deploy to production"),
+        timeoutSec = 300,
+    )
+    ApprovalDialog(
+        approval = request,
+        remainingTimeSec = 0,
+        isTimedOut = true,
+        isSubmitting = false,
+        error = null,
+        onRespond = {},
+        onDismiss = {},
+        onClearError = {},
+    )
+}

--- a/shared/src/desktopMain/kotlin/com/orchestradashboard/shared/ui/component/ApprovalDialogPreview.kt
+++ b/shared/src/desktopMain/kotlin/com/orchestradashboard/shared/ui/component/ApprovalDialogPreview.kt
@@ -8,13 +8,14 @@ import com.orchestradashboard.shared.domain.model.ApprovalRequest
 @Preview
 @Composable
 fun ApprovalDialogStrategyModePreview() {
-    val request = ApprovalRequest(
-        id = "req-1",
-        approvalType = "strategy",
-        options = listOf("split_execute", "no_split", "cancel"),
-        context = ApprovalContext(eta = "5m", detail = "Deploy to production"),
-        timeoutSec = 300,
-    )
+    val request =
+        ApprovalRequest(
+            id = "req-1",
+            approvalType = "strategy",
+            options = listOf("split_execute", "no_split", "cancel"),
+            context = ApprovalContext(eta = "5m", detail = "Deploy to production"),
+            timeoutSec = 300,
+        )
     ApprovalDialog(
         approval = request,
         remainingTimeSec = 250,
@@ -30,17 +31,19 @@ fun ApprovalDialogStrategyModePreview() {
 @Preview
 @Composable
 fun ApprovalDialogSupremeCourtModePreview() {
-    val request = ApprovalRequest(
-        id = "req-2",
-        approvalType = "supreme_court",
-        options = listOf("uphold", "overturn", "redesign"),
-        context = ApprovalContext(
-            eta = "10m",
-            splitProposal = "Split into 3 sub-tasks",
-            detail = "Review pipeline strategy",
-        ),
-        timeoutSec = 300,
-    )
+    val request =
+        ApprovalRequest(
+            id = "req-2",
+            approvalType = "supreme_court",
+            options = listOf("uphold", "overturn", "redesign"),
+            context =
+                ApprovalContext(
+                    eta = "10m",
+                    splitProposal = "Split into 3 sub-tasks",
+                    detail = "Review pipeline strategy",
+                ),
+            timeoutSec = 300,
+        )
     ApprovalDialog(
         approval = request,
         remainingTimeSec = 180,
@@ -56,13 +59,14 @@ fun ApprovalDialogSupremeCourtModePreview() {
 @Preview
 @Composable
 fun ApprovalDialogTimedOutPreview() {
-    val request = ApprovalRequest(
-        id = "req-3",
-        approvalType = "strategy",
-        options = listOf("split_execute", "no_split", "cancel"),
-        context = ApprovalContext(eta = "5m", detail = "Deploy to production"),
-        timeoutSec = 300,
-    )
+    val request =
+        ApprovalRequest(
+            id = "req-3",
+            approvalType = "strategy",
+            options = listOf("split_execute", "no_split", "cancel"),
+            context = ApprovalContext(eta = "5m", detail = "Deploy to production"),
+            timeoutSec = 300,
+        )
     ApprovalDialog(
         approval = request,
         remainingTimeSec = 0,


### PR DESCRIPTION
Closes #113

## Design
The implementation is already complete (commit `06bccbe`). I'll now produce the design document and acceptance criteria based on what's been implemented and what still needs verification.

---

## SECTION A: Design Document

### 1. Files Created/Modified

| Path | Action | Purpose |
|------|--------|---------|
| `shared/src/commonMain/.../ui/component/ApprovalDialog.kt` | **Created** | Main composable: `ApprovalDialog` with context section, countdown, error display, and type-specific action buttons |
| `shared/src/commonMain/.../ui/approvalmodal/ApprovalModalState.kt` | **Created** | State data class with `showDialog`, `pendingApproval`, `remainingTimeSec`, `isSubmitting`, `error`, computed `isTimedOut` |
| `shared/src/commonMain/.../ui/approvalmodal/ApprovalModalViewModel.kt` | **Created** | ViewModel with countdown, auto-approve, respond, dismiss, clearError |
| `shared/src/commonMain/.../ui/screen/PipelineMonitorScreen.kt` | **Modified** | Integrates `ApprovalDialog` composable, binds to ViewModel state via `collectAsState` |
| `shared/src/commonTest/.../ui/component/ApprovalDialogStateTest.kt` | **Created** | Unit tests for pure functions and state logic (19 tests) |
| `shared/src/commonTest/.../ui/approvalmodal/ApprovalModalViewModelTest.kt` | **Created** | ViewModel behavior tests (26+ tests) |

### 2. TDD Test Plan (Tests Written First)

**Group A — Pure UI Logic (`ApprovalDialogStateTest.kt`)**:
1. `buildDialogTitle("strategy")` → "Strategy Approval Required"
2. `buil

_(truncated)_

## Changed Files (6)
- `_workspace/03_ci_report.md`
- `shared/build.gradle.kts`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModel.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/ParallelPipelineViewModelTest.kt`
- `shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/pipelinemonitor/PipelineMonitorViewModelTest.kt`
- `shared/src/desktopMain/kotlin/com/orchestradashboard/shared/ui/component/ApprovalDialogPreview.kt`

## Review
### Finding 1: Missing Compose Previews

-   **File and line reference**: `shared/src/desktopMain/kotlin/com/orchestradashboard/shared/ui/component/ApprovalDialogPreview.kt` (This file should be created).
-   **What is wrong**: The acceptance criteria mandate the creation of Compose `@Preview` functions for the `ApprovalDialog` component to cover its various states (strategy, supreme court, timed-out). These previews are missing from the implementation. Previews cannot be in `commonMain` because they rely on platform-specific tooling dependencies, so they must be placed in a platform-specific source set like `desktopMain` or `androidMain`.
-   **How to fix it**: Create a new file in `shared/src/desktopMain/kotlin/com/orchestradashboard/shared/ui/component/` (or a similar location in `andro

_(truncated)_

## AI Audit: PASS
# Audit Verdict

## Acceptance Criteria Status

1. **ApprovalDialog Composable**  
   [PASS] - Exists and accepts required parameters.

2. **Strategy Mode Buttons**  
   [PASS] - Renders 3 buttons with correct decisions.

3. **Supreme Court Mode Buttons**  
   [PASS] - Renders 3 buttons with correct decisions.

4. **Context Section Display**  
   [PASS] - Shows eta, splitProposal, detail when non-null.

5. **Countdown Section**  
   [PASS] - Shows LinearProgressIndicator and formatted text.

6. **Timed-Out State**  
   [PASS] - Replaces buttons with "Auto-approved" message.

7. **Submitting State**  
   [PASS] - Shows CircularProgressIndicator and disables buttons.

8. **Error Message Display**  
   [PASS] - Shows error in red with Dismiss button.

9. **PipelineMonitorScreen Binding**  
   [PASS] - Binds uiState and conditionally renders dialog.

10. **buildDialogTitle Unit Tested**  
    [PASS] - Correct titles for all types.

11. **formatCountdownText Unit Tested**  
    [PASS] - Bou

_(truncated)_