### PR TITLE
feat: Live Log 스트리밍 — UI (Compose + SwiftUI)

### DIFF
--- a/_workspace/02_developer_log.md
+++ b/_workspace/02_developer_log.md
@@ -1,61 +1,109 @@
-# Developer Log — Issue #128 (LogStream feature — Model, Repository, ViewModel + tests)
+# Developer Log — Issue #129 (Live Log Streaming UI — Compose + SwiftUI)
 
 ## Implementation Order
 
-Domain models -> Repository interface -> UseCase -> DTO -> Mapper -> Repository impl ->
-OrchestratorApi / OrchestratorApiClient modification -> UI state -> ViewModel -> Tests -> DI wiring.
+Tests (pure functions) -> StepNode/StepTimeline selection -> LogStreamPanel (Compose)
+-> PipelineMonitorScreen integration -> AppNavigation wiring -> desktopApp/androidApp
+DI wiring -> iOS StepTimelineView selection -> IOSLogStreamViewModel + IOSAppContainer
+-> LogStreamPanelView (SwiftUI) -> PipelineMonitorView integration -> build/lint/test
+verification.
 
 ## Production files created
 
-### Domain layer
-- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/LogEntry.kt`
-- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/model/LogStreamState.kt`
-- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/repository/LogStreamRepository.kt`
-- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/domain/usecase/ObserveLogStreamUseCase.kt` (required by CLAUDE.md)
+### Shared (Compose)
+- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/LogStreamPanel.kt`
 
-### Data layer
-- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/dto/orchestrator/LogEntryDto.kt`
-- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/mapper/LogEntryMapper.kt`
-- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/repository/LogStreamRepositoryImpl.kt`
-
-### UI layer (shared)
-- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/logstream/LogStreamUiState.kt`
-- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/logstream/LogStreamViewModel.kt`
+### iOS (SwiftUI)
+- [x] `iosApp/iosApp/components/LogStreamPanelView.swift`
+- [x] `iosApp/iosApp/IOSLogStreamViewModel.swift`
 
 ## Production files modified
-- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/api/OrchestratorApi.kt` (added `connectLogStream` method)
-- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/data/api/OrchestratorApiClient.kt` (implemented `connectLogStream` via WebSocket)
-- [x] `androidApp/src/main/kotlin/com/orchestradashboard/android/di/AppContainer.kt` (mapper + repository + usecase + `createLogStreamViewModel()`)
-- [x] `desktopApp/src/main/kotlin/com/orchestradashboard/desktop/di/AppContainer.kt` (mapper + repository + usecase + `createLogStreamViewModel()`)
-- [x] `config/detekt/detekt.yml` (added `thresholdInObjects: 15` — fixes underlying issue per CLAUDE.md rule 4, avoids `@Suppress`)
+
+### Shared (Compose)
+- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/StepNode.kt`
+      — added `isSelected` + `onClick`; ring overlay via `.border(..., CircleShape)` when selected.
+- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/StepTimeline.kt`
+      — added `selectedStepName` + `onStepClick` parameters, wired into each `StepNode`.
+- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/PipelineMonitorScreen.kt`
+      — now takes `logStreamViewModel: LogStreamViewModel`; shows `LogStreamPanel`
+        (with `AnimatedVisibility`) when a step is selected, otherwise the pre-existing
+        `LiveLogPanel`. Step clicks toggle start/stop on the log stream VM.
+- [x] `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/AppNavigation.kt`
+      — added `logStreamViewModelFactory: () -> LogStreamViewModel`; new LogStreamVM
+        instance created per `Screen.PipelineMonitor` and disposed with the pipeline VM.
+
+### desktopApp / androidApp (DI wiring)
+- [x] `desktopApp/src/main/kotlin/com/orchestradashboard/desktop/Main.kt`
+      — passes `AppContainer.createLogStreamViewModel` to `AppNavigation`.
+- [x] `androidApp/src/main/kotlin/com/orchestradashboard/android/App.kt`
+      — passes `AppContainer.createLogStreamViewModel` to `AppNavigation`.
+
+(`createLogStreamViewModel()` already existed on both `AppContainer`s from issue #128
+— no DI container changes required.)
+
+### iOS
+- [x] `iosApp/iosApp/components/StepTimelineView.swift`
+      — added `selectedStepName` + `onStepTap`; selection ring via a `.stroke` overlay
+        on the circle, tap handler via `.onTapGesture` on each step node.
+- [x] `iosApp/iosApp/IOSAppContainer.swift`
+      — added `createLogStreamViewModel()` factory stub (fatalError until KMP framework
+        is linked, matching the other factory stubs in this container).
+- [x] `iosApp/iosApp/PipelineMonitorView.swift`
+      — wires `@StateObject IOSLogStreamViewModel`, threads selection state through
+        `StepTimelineView`, swaps in `LogStreamPanelView` when a step is selected,
+        disposes the log VM in `.onDisappear`.
 
 ## Test files created
-- [x] `shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/logstream/FakeLogStreamRepository.kt`
-- [x] `shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/logstream/LogStreamViewModelTest.kt` — 13 tests
-- [x] `shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/repository/LogStreamRepositoryImplTest.kt` — 4 tests (+ private `FakeOrchestratorApiForLogStream`)
-
-## Test files modified
-- [x] `shared/src/commonTest/kotlin/com/orchestradashboard/shared/data/api/FakeOrchestratorEventsApi.kt` (added `connectLogStream` throwing `NotImplementedError` to satisfy the expanded interface)
+- [x] `shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/component/LogStreamPanelStateTest.kt`
+      — 10 tests covering:
+        - `formatLogEntry` for INFO/WARN/ERROR/DEBUG
+        - `formatLogEntry` with blank and malformed timestamps (no crash)
+        - `logLevelColor` returning `Color.Unspecified` for INFO and semantic hues
+          for WARN (orange), ERROR (red), DEBUG (gray)
+      — All 10 tests pass.
 
 ## Verification
 
 | Job | Status |
 |---|---|
-| `./gradlew :shared:desktopTest` | PASS (677 tests) |
+| `./gradlew :shared:desktopTest` (incl. new tests) | PASS — 10/10 new tests green, no regressions |
 | `./gradlew ktlintFormat` + `ktlintCheck` | PASS |
-| `./gradlew detekt --rerun-tasks` | PASS |
-
-All 17 newly added LogStream tests pass. No regressions.
+| `./gradlew detekt` | PASS |
+| `./gradlew :shared:compileKotlinDesktop` | PASS |
+| `./gradlew :desktopApp:compileKotlin` | PASS |
+| `./gradlew :androidApp:compileDebugKotlin` | skipped locally — no Android SDK on dev machine; CI will validate |
 
 ## Design decisions
 
-- **UseCase added**: CLAUDE.md rule 2 mandates UseCases for every feature, even single-repo delegation. `ObserveLogStreamUseCase` wraps `LogStreamRepository.observeLogStream`.
-- **WebSocket endpoint**: `$baseUrl/ws/logs/$stepId` mirrors the existing `/ws/events/$pipelineId` convention from `OrchestratorApiClient.connectEvents(pipelineId)`.
-- **Fallback stepId in mapper**: when the server omits `stepId` in the DTO, the mapper uses the subscription stepId. Ensures domain `LogEntry.stepId` is always non-null.
-- **`shouldThrow` split into `setErrorFlow` / `resetToNormalFlow`**: the plan called out that throwing inside `observeLogStream` (the subscription point) differs from throwing inside the collected Flow. The fake supports both patterns; we use the flow-throws pattern for the error test so `.catch { }` in the ViewModel can observe it.
-- **detekt `thresholdInObjects: 15`**: Desktop `AppContainer` now has 11 functions after adding `createLogStreamViewModel()`, which tripped the default detekt threshold of 11. Instead of adding `@Suppress("TooManyFunctions")` (forbidden by CLAUDE.md rule 4), I raised the threshold to 15 in `config/detekt/detekt.yml`, matching the existing `thresholdInClasses` value. Android `AppContainer` already had an existing `@Suppress("TooManyFunctions")` annotation — left unchanged to avoid scope creep.
-- **`take(1)` pattern**: the repository test uses `.take(1).toList()` to eagerly trigger collection (so the fake's `lastStepId` counter fires) while still terminating the Flow. `take(0)` throws `IllegalArgumentException` so it cannot be used.
-- **Test 7 verification strategy**: `startStream with new stepId cancels previous stream` is verified indirectly via `observeCallCount == 2` and `lastStepId == "step-2"`, since the previous job's cancellation semantics inside a `MutableSharedFlow` are hard to assert directly without racing.
+- **Pure state logic in Compose file**: `formatLogEntry` and `logLevelColor` live as
+  `internal` functions inside `LogStreamPanel.kt` so they can be unit-tested without
+  a Compose runtime. `Color.Unspecified` is returned for INFO (caller falls back to
+  the Material3 `onSurfaceVariant` token via `Color.takeOrElse`).
+- **Timestamp parsing**: kept allocation-free and defensive — no `kotlinx.datetime`
+  parser is required because the only information needed for display is the
+  `HH:mm:ss` substring of an ISO-8601 value. Returns empty on malformed input so the
+  UI still shows the message.
+- **No `@Suppress`**: `AppNavigation` already exceeded `LongParameterList`'s threshold
+  (11 parameters before, 12 after adding `logStreamViewModelFactory`). The existing
+  signature did not need a suppression, so the new parameter does not either. detekt
+  passes clean.
+- **Auto-scroll behaviour**: `derivedStateOf` over `listState.layoutInfo` decides
+  whether the user is at the bottom (within 2 rows of the tail). `LaunchedEffect(logs.size)`
+  only animates to the bottom when that condition is met, so manual scrolling up
+  pauses auto-scroll. A `FloatingActionButton` appears at the bottom-right to let the
+  user resume tailing with a single tap.
+- **AnimatedVisibility for panel swap**: replacing the existing `LiveLogPanel` with
+  the step-scoped `LogStreamPanel` uses `AnimatedVisibility` so the transition is
+  smooth when a step is (de)selected, and the fallback `LiveLogPanel` remains the
+  default surface when no step is selected.
+- **iOS selection ring via overlay**: SwiftUI `Circle().stroke(...).padding(-3)` gives
+  a 3-pt outer ring that doesn't affect the layout of neighboring steps (so the
+  timeline spacing stays consistent whether or not a step is selected).
+- **iOS panel hot-reload via `ScrollViewReader`**: `onChange(of: viewModel.logs.count)`
+  drives an automatic `scrollTo(_, anchor: .bottom)`. For now this always scrolls on
+  new entries (mirrors the existing `LiveLogPanel` behaviour); SwiftUI does not expose
+  scroll position cleanly in older OS targets, so the "pause auto-scroll when user
+  scrolls up" behaviour is Compose-only for this PR.
 
 ## Unresolved issues
 

--- a/_workspace/03_ci_report.md
+++ b/_workspace/03_ci_report.md
@@ -1,50 +1,57 @@
-## CI Parity 결과 — Issue #123 (iOS SwiftUI Analytics — 3 charts + period filter)
+## CI Parity 결과 — Issue #129 (Live Log Streaming UI — Compose + SwiftUI)
 
 | # | 잡 | 명령 | 상태 | 비고 |
 |---|----|------|------|------|
-| 1 | Shared (KMP) Tests | `./gradlew :shared:desktopTest --parallel` + `--rerun-tasks` verify | PASS | All tests PASS (fresh execution, compileKotlinDesktop + compileTestKotlinDesktop + desktopTest + jacocoTestReport executed). No regressions from Issue #122 test suite (AnalyticsScreenStateTest 15/15 et al.) |
-| 2 | Server (Spring Boot) Build & Test | `:server:assemble --parallel` + `:server:test` + `:server:jacocoTestReport` + `:server:jacocoTestCoverageVerification` + `:server:bootJar` | PASS | All steps BUILD SUCCESSFUL (UP-TO-DATE cache valid — no server source changes) |
-| 3 | Desktop App Build | `./gradlew :desktopApp:build --parallel` | PASS | `desktopApp:jar`/`assemble`/`build` executed, ktlint + detekt green inline |
-| 4 | Android App Build | `ANDROID_HOME=$HOME/Library/Android/sdk ./gradlew :androidApp:assembleDebug --parallel` | PASS | Full pipeline: shared:compileDebugKotlinAndroid + androidApp:compileDebugKotlin + dexBuilderDebug + packageDebug + assembleDebug (31 executed, 27 from cache, 3 up-to-date). APK generated. |
-| 5 | Code Quality — Detekt | `./gradlew detekt --continue` | PASS | server/android/desktop clean, shared NO-SOURCE |
-| 5 | Code Quality — ktlint (root) | `./gradlew ktlintCheck` | PASS | All Kotlin source sets clean (commonMain/commonTest/desktopMain/desktopTest/iosMain + android/desktop/server main+test + kotlin scripts) |
+| 1 | Shared (KMP) Tests | `./gradlew :shared:desktopTest --parallel` (+ `--rerun-tasks` verify) | PASS | compileKotlinDesktop + compileTestKotlinDesktop + desktopTest + jacocoTestReport all executed fresh. New `LogStreamPanelStateTest` 10/10 PASS (formatLogEntry INFO/WARN/ERROR/DEBUG + blank/malformed timestamp + logLevelColor Unspecified/WARN/ERROR/DEBUG hues). No regressions. |
+| 2 | Server (Spring Boot) Build & Test | `:server:assemble --parallel` + `:server:test` | PASS | `:server:assemble` BUILD SUCCESSFUL; `:server:test` + `:server:jacocoTestReport` FROM-CACHE (no server source changes in this issue). |
+| 3 | ktlintCheck (root, all source sets) | `./gradlew ktlintCheck --rerun-tasks` | PASS | All 41 ktlint tasks executed fresh: shared (commonMain/commonTest/desktopMain/desktopTest/iosMain) + androidApp (main) + desktopApp (main) + server (main/test) + kotlin scripts — all green. |
+| 4 | `:shared:ktlintDesktopTestSourceSetCheck` (historical failure point) | `./gradlew :shared:ktlintDesktopTestSourceSetCheck --rerun-tasks` | PASS | Called out specifically in the task. Fresh execution of `runKtlintCheckOverDesktopTestSourceSet` + `ktlintDesktopTestSourceSetCheck` — both green. New `LogStreamPanelStateTest.kt` under `commonTest` conforms. |
+| 5 | Code Quality — Detekt | `./gradlew detekt --continue --rerun-tasks` | PASS | `:shared:detekt` NO-SOURCE (KMP source sets lint via ktlint; shared module has no JVM-target detekt source), `:server:detekt` + `:desktopApp:detekt` + `:androidApp:detekt` all fresh-executed BUILD SUCCESSFUL, `:detektReportMergeSarif` merged. No `@Suppress` added, no baseline changes. |
+| 6 | Shared build check | `./gradlew :shared:compileKotlinDesktop` | PASS | compileKotlinDesktop BUILD SUCCESSFUL. Deprecation warnings in unrelated pre-existing files (DesignPanel/DiscussPanel/PlanIssuesPanel `menuAnchor`, CommandCenterScreen `ArrowBack`) — not introduced by this issue. |
 
-## 변경 범위 (Issue #123)
+## Additional verification
 
-**iOS-only changes** — Swift files in `iosApp/iosApp/` and `iosApp/iosAppTests/`. These files live outside all Gradle source sets, so every Gradle job correctly observes cache hits for inputs unrelated to iOS Swift code.
+| 확인 | 상태 |
+|------|------|
+| `:desktopApp:build --parallel` | PASS (executes :desktopApp:{ktlintMainSourceSetCheck,compileKotlin,jar,assemble,build}) |
+| `:androidApp:assembleDebug --parallel` (ANDROID_HOME set) | PASS (compileDebugKotlin fresh → dex/merge/package → APK emitted) |
 
-### New Swift production files
-- `iosApp/iosApp/IOSAnalyticsViewModel.swift` (Combine/ObservableObject bridge over KMP `AnalyticsViewModel`)
-- `iosApp/iosApp/AnalyticsView.swift` (NavigationView + period filter chip bar + 3 chart sections + loading/empty + refresh toolbar)
-- `iosApp/iosApp/components/SuccessRateChartView.swift` (Canvas donut: green success arc + red failure arc from -90°)
-- `iosApp/iosApp/components/DurationTrendsChartView.swift` (SwiftUI Charts `LineMark` + `PointMark` + axis labels)
-- `iosApp/iosApp/components/StepFailureHeatmapView.swift` (5-bucket heatmap identical to Compose thresholds)
+## 변경 범위 (Issue #129)
 
-### New Swift test files (XCTest)
-- `iosApp/iosAppTests/AnalyticsViewTests.swift` (periodLabel 3 + hasAnyData 3)
-- `iosApp/iosAppTests/components/SuccessRateChartViewTests.swift` (successRateLabel 4 + donutAngles 4)
-- `iosApp/iosAppTests/components/DurationTrendsChartViewTests.swift` (axisLabels 5 + normalizeY 2)
-- `iosApp/iosAppTests/components/StepFailureHeatmapViewTests.swift` (failureBucketColor 5 + failurePercentLabel 1)
+### Shared (Compose — KMP)
+- **NEW** `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/LogStreamPanel.kt`
+- **NEW** `shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/component/LogStreamPanelStateTest.kt` (10 tests)
+- **MOD** `StepNode.kt` (+ `isSelected`, `onClick`, ring overlay)
+- **MOD** `StepTimeline.kt` (+ `selectedStepName`, `onStepClick` wiring)
+- **MOD** `PipelineMonitorScreen.kt` (+ `LogStreamViewModel` integration, AnimatedVisibility panel swap)
+- **MOD** `AppNavigation.kt` (+ `logStreamViewModelFactory`, per-screen VM lifecycle)
 
-### Modified Swift files
-- `iosApp/iosApp/IOSAppContainer.swift` (added `createAnalyticsViewModel(project:)` factory, matching existing KMP-gated pattern)
-- `iosApp/iosApp/HistoryView.swift` (added `.navigationBarLeading` toolbar with NavigationLink → `AnalyticsView`)
+### Platform (DI wiring)
+- **MOD** `desktopApp/src/main/kotlin/com/orchestradashboard/desktop/Main.kt`
+- **MOD** `androidApp/src/main/kotlin/com/orchestradashboard/android/App.kt`
 
-### Gradle/Kotlin changes
-None. Zero impact on Gradle CI parity surface.
+### iOS (SwiftUI — outside Gradle source sets)
+- **NEW** `iosApp/iosApp/IOSLogStreamViewModel.swift`
+- **NEW** `iosApp/iosApp/components/LogStreamPanelView.swift`
+- **MOD** `iosApp/iosApp/IOSAppContainer.swift`
+- **MOD** `iosApp/iosApp/PipelineMonitorView.swift`
+- **MOD** `iosApp/iosApp/components/StepTimelineView.swift`
 
 ## 수정 이력
 
-- **1회차**: 모든 5개 CI 잡 PASS (kmp-developer 단계에서 `ktlintFormat` + detekt 선행 완료; iOS Swift 변경이 Gradle source sets 외부이기 때문에 구조적으로 Gradle 영향 없음)
-- 추가 재실행 검증:
-  - `:shared:desktopTest --rerun-tasks` → PASS (compileKotlinDesktop + compileTestKotlinDesktop + desktopTest 전부 fresh 실행)
-  - `:server:assemble/:server:test/:server:jacocoTestReport/:server:jacocoTestCoverageVerification/:server:bootJar` → PASS
-  - `:androidApp:assembleDebug --parallel` → PASS (shared:compileDebugKotlinAndroid fresh + androidApp dex/merge/package 실행)
-  - `:desktopApp:build --parallel` → PASS
-  - `ktlintCheck` + `detekt --continue` → PASS
+- **1회차**: 모든 6개 CI 잡 PASS (kmp-developer 단계에서 `ktlintFormat` 선행 완료).
+  - `ktlintFormat` → UP-TO-DATE (no additional changes needed)
+  - `ktlintCheck --rerun-tasks` → all 41 tasks fresh-executed, green
+  - `:shared:desktopTest --rerun-tasks` → 12 tasks executed; LogStreamPanelStateTest 10/10 PASS
+  - `:shared:ktlintDesktopTestSourceSetCheck --rerun-tasks` → fresh PASS (historical failure point clean)
+  - `detekt --continue --rerun-tasks` → server/android/desktop all fresh BUILD SUCCESSFUL; shared NO-SOURCE as expected
+  - `:shared:compileKotlinDesktop` → PASS
+  - `:server:assemble` + `:server:test` → PASS (server source unchanged, cache valid)
+  - `:desktopApp:build` → PASS
+  - `:androidApp:assembleDebug` → PASS (APK emitted)
 
-## Swift 컴파일 관련 주석
+## iOS 컴파일 주석
 
-iOS Swift 컴파일은 KMP framework(`:shared:iosArm64Binaries`)가 Xcode로 링크된 환경에서만 가능 — 기존 `IOSHistoryViewModel` / `HistoryView` 와 동일한 프로젝트 전반 게이트. Swift 파일은 생성 시 구문적으로 정확하며, 검증된 `IOSHistoryViewModel` collector 패턴을 그대로 미러링함. 이는 CI YAML의 5개 잡 범위 바깥이므로 본 리포트 PASS 기준에 해당하지 않음.
+iOS Swift 컴파일은 KMP framework(`:shared:iosArm64Binaries`)가 Xcode로 링크된 환경에서만 가능 — 기존 `IOSHistoryViewModel` / `HistoryView` 등과 동일한 프로젝트 전반 게이트. Swift 파일(`IOSLogStreamViewModel.swift`, `LogStreamPanelView.swift`)은 검증된 iOS VM collector 패턴을 그대로 미러링. CI YAML 5개 잡 범위 바깥이므로 본 리포트 PASS 기준에 해당하지 않음.
 
 ## 최종 상태: ALL GREEN (PR 생성 가능)

--- a/androidApp/src/main/kotlin/com/orchestradashboard/android/App.kt
+++ b/androidApp/src/main/kotlin/com/orchestradashboard/android/App.kt
@@ -54,6 +54,9 @@ class MainActivity : ComponentActivity() {
                     pipelineMonitorViewModelFactory = { pipelineId ->
                         AppContainer.createPipelineMonitorViewModel(pipelineId)
                     },
+                    logStreamViewModelFactory = {
+                        AppContainer.createLogStreamViewModel()
+                    },
                     commandCenterViewModelFactory = {
                         AppContainer.createCommandCenterViewModel()
                     },

--- a/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/com/orchestradashboard/desktop/Main.kt
@@ -51,6 +51,9 @@ fun main() =
                     pipelineMonitorViewModelFactory = { pipelineId ->
                         AppContainer.createPipelineMonitorViewModel(pipelineId)
                     },
+                    logStreamViewModelFactory = {
+                        AppContainer.createLogStreamViewModel()
+                    },
                     commandCenterViewModelFactory = {
                         AppContainer.createCommandCenterViewModel()
                     },

--- a/iosApp/iosApp/IOSAppContainer.swift
+++ b/iosApp/iosApp/IOSAppContainer.swift
@@ -103,4 +103,8 @@ final class IOSAppContainer {
     func createAnalyticsViewModel(project: String) -> AnalyticsViewModel {
         fatalError("KMP framework must be linked via Gradle :shared:iosArm64Binaries")
     }
+
+    func createLogStreamViewModel() -> LogStreamViewModel {
+        fatalError("KMP framework must be linked via Gradle :shared:iosArm64Binaries")
+    }
 }

--- a/iosApp/iosApp/IOSLogStreamViewModel.swift
+++ b/iosApp/iosApp/IOSLogStreamViewModel.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Shared
+
+/// iOS-specific wrapper around the KMP LogStreamViewModel.
+/// Bridges Kotlin coroutine StateFlow to Swift's ObservableObject/Combine.
+@MainActor
+final class IOSLogStreamViewModel: ObservableObject {
+    @Published var streamState: LogStreamState = LogStreamStateIdle()
+    @Published var logs: [LogEntry] = []
+    @Published var selectedStepId: String? = nil
+
+    private let viewModel: LogStreamViewModel
+    private var collectTask: Task<Void, Never>?
+
+    init() {
+        self.viewModel = IOSAppContainer.shared.createLogStreamViewModel()
+        startCollecting()
+    }
+
+    func startStream(stepId: String) {
+        viewModel.startStream(stepId: stepId)
+    }
+
+    func stopStream() {
+        viewModel.stopStream()
+    }
+
+    func onCleared() {
+        collectTask?.cancel()
+        viewModel.onCleared()
+    }
+
+    private func startCollecting() {
+        collectTask?.cancel()
+        collectTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let collector = LogStreamUiStateCollector { [weak self] state in
+                self?.updateFromState(state)
+            }
+            try? await self.viewModel.uiState.collect(collector: collector)
+        }
+    }
+
+    private func updateFromState(_ state: LogStreamUiState) {
+        self.streamState = state.streamState
+        self.logs = state.logs as? [LogEntry] ?? []
+        self.selectedStepId = state.selectedStepId
+    }
+}
+
+private final class LogStreamUiStateCollector: Kotlinx_coroutines_coreFlowCollector {
+    let onValue: (LogStreamUiState) -> Void
+
+    init(onValue: @escaping (LogStreamUiState) -> Void) {
+        self.onValue = onValue
+    }
+
+    func emit(value: Any?, completionHandler: @escaping (Error?) -> Void) {
+        if let state = value as? LogStreamUiState {
+            onValue(state)
+        }
+        completionHandler(nil)
+    }
+}

--- a/iosApp/iosApp/PipelineMonitorView.swift
+++ b/iosApp/iosApp/PipelineMonitorView.swift
@@ -4,6 +4,7 @@ import Shared
 /// Pipeline Monitor screen — displays step timeline, live logs, and approval dialogs.
 struct PipelineMonitorView: View {
     @StateObject private var viewModel: IOSPipelineMonitorViewModel
+    @StateObject private var logStreamViewModel = IOSLogStreamViewModel()
 
     init(pipelineId: String) {
         _viewModel = StateObject(wrappedValue: IOSPipelineMonitorViewModel(pipelineId: pipelineId))
@@ -22,10 +23,24 @@ struct PipelineMonitorView: View {
                                 dependencies: viewModel.dependencies
                             )
                         } else if let pipeline = viewModel.pipeline {
-                            StepTimelineView(steps: pipeline.steps)
+                            StepTimelineView(
+                                steps: pipeline.steps,
+                                selectedStepName: logStreamViewModel.selectedStepId,
+                                onStepTap: { stepName in
+                                    if logStreamViewModel.selectedStepId == stepName {
+                                        logStreamViewModel.stopStream()
+                                    } else {
+                                        logStreamViewModel.startStream(stepId: stepName)
+                                    }
+                                }
+                            )
                         }
 
-                        logPanel
+                        if logStreamViewModel.selectedStepId != nil {
+                            LogStreamPanelView(viewModel: logStreamViewModel)
+                        } else {
+                            logPanel
+                        }
                     }
                     .padding()
                 }
@@ -45,7 +60,10 @@ struct PipelineMonitorView: View {
             viewModel.loadPipeline()
             viewModel.startObserving()
         }
-        .onDisappear { viewModel.onCleared() }
+        .onDisappear {
+            viewModel.onCleared()
+            logStreamViewModel.onCleared()
+        }
         .alert("Error", isPresented: .constant(viewModel.error != nil)) {
             Button("OK") { viewModel.clearError() }
         } message: {

--- a/iosApp/iosApp/components/LogStreamPanelView.swift
+++ b/iosApp/iosApp/components/LogStreamPanelView.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+import Shared
+
+/// Panel that displays streaming logs for the currently selected pipeline step.
+struct LogStreamPanelView: View {
+    @ObservedObject var viewModel: IOSLogStreamViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            header
+
+            content
+        }
+        .padding(8)
+        .background(Color(.systemGray6))
+        .cornerRadius(8)
+    }
+
+    private var header: some View {
+        HStack {
+            Text(headerTitle)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Spacer()
+            Button(action: { viewModel.stopStream() }) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityLabel("Stop streaming")
+        }
+        .padding(.horizontal, 4)
+    }
+
+    private var headerTitle: String {
+        if let stepId = viewModel.selectedStepId {
+            return "Logs: \(stepId)"
+        }
+        return "Logs"
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if viewModel.streamState is LogStreamStateLoading {
+            loadingView
+        } else if let error = viewModel.streamState as? LogStreamStateError {
+            errorView(message: error.message)
+        } else {
+            logListView
+        }
+    }
+
+    private var loadingView: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+            Text("Connecting...")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(8)
+    }
+
+    private func errorView(message: String) -> some View {
+        Text("Stream error: \(message)")
+            .font(.caption)
+            .foregroundStyle(.red)
+            .padding(8)
+    }
+
+    @ViewBuilder
+    private var logListView: some View {
+        if viewModel.logs.isEmpty {
+            Text("No logs yet")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(8)
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 2) {
+                        ForEach(Array(viewModel.logs.enumerated()), id: \.offset) { index, entry in
+                            Text(LogStreamPanelView.formatLogEntry(entry))
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundStyle(LogStreamPanelView.logLevelColor(entry.level))
+                                .id(index)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                    .padding(.horizontal, 4)
+                }
+                .frame(maxHeight: 300)
+                .onChange(of: viewModel.logs.count) { _, newCount in
+                    if newCount > 0 {
+                        withAnimation {
+                            proxy.scrollTo(newCount - 1, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Formatting helpers (mirror Kotlin `formatLogEntry` / `logLevelColor`)
+
+    static func formatLogEntry(_ entry: LogEntry) -> String {
+        let timePart = extractHms(from: entry.timestamp)
+        let levelMarker: String
+        switch entry.level {
+        case .info: levelMarker = ""
+        case .warn: levelMarker = " WARN"
+        case .error: levelMarker = " ERROR"
+        case .debug: levelMarker = " DEBUG"
+        default: levelMarker = ""
+        }
+
+        let prefix: String
+        if timePart.isEmpty && levelMarker.isEmpty {
+            prefix = ""
+        } else if timePart.isEmpty {
+            prefix = "[\(levelMarker.trimmingCharacters(in: .whitespaces))] "
+        } else {
+            prefix = "[\(timePart)\(levelMarker)] "
+        }
+        return "\(prefix)\(entry.message)"
+    }
+
+    static func logLevelColor(_ level: LogLevel) -> Color {
+        switch level {
+        case .info: return .primary
+        case .warn: return Color(red: 0.88, green: 0.55, blue: 0.06)
+        case .error: return Color(red: 0.83, green: 0.18, blue: 0.18)
+        case .debug: return .gray
+        default: return .primary
+        }
+    }
+
+    private static func extractHms(from timestamp: String) -> String {
+        guard !timestamp.isEmpty else { return "" }
+        let timeSection: String
+        if let tRange = timestamp.range(of: "T") {
+            timeSection = String(timestamp[tRange.upperBound...])
+        } else {
+            timeSection = timestamp
+        }
+        let candidate = String(timeSection.prefix(8))
+        guard candidate.count == 8 else { return "" }
+        let chars = Array(candidate)
+        if chars[2] == ":" && chars[5] == ":" {
+            return candidate
+        }
+        return ""
+    }
+}

--- a/iosApp/iosApp/components/StepTimelineView.swift
+++ b/iosApp/iosApp/components/StepTimelineView.swift
@@ -4,6 +4,8 @@ import Shared
 /// Horizontal step timeline displaying pipeline steps with status colors.
 struct StepTimelineView: View {
     let steps: [MonitoredStep]
+    var selectedStepName: String? = nil
+    var onStepTap: ((String) -> Void)? = nil
 
     var body: some View {
         if steps.isEmpty {
@@ -31,8 +33,9 @@ struct StepTimelineView: View {
     }
 
     private func stepNode(_ step: MonitoredStep) -> some View {
-        VStack(spacing: 4) {
-            StepCircleView(status: step.status)
+        let isSelected = step.name == selectedStepName
+        return VStack(spacing: 4) {
+            StepCircleView(status: step.status, isSelected: isSelected)
 
             Text(step.name)
                 .font(.caption2)
@@ -46,6 +49,11 @@ struct StepTimelineView: View {
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
+        }
+        .padding(2)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            onStepTap?(step.name)
         }
     }
 
@@ -78,6 +86,7 @@ struct StepTimelineView: View {
 
 struct StepCircleView: View {
     let status: StepStatus
+    var isSelected: Bool = false
     @State private var isPulsing: Bool = false
 
     var body: some View {
@@ -90,6 +99,11 @@ struct StepCircleView: View {
                     ? .easeInOut(duration: 0.8).repeatForever(autoreverses: true)
                     : .default,
                 value: isPulsing
+            )
+            .overlay(
+                Circle()
+                    .stroke(Color.accentColor, lineWidth: isSelected ? 2 : 0)
+                    .padding(-3)
             )
             .onAppear {
                 if status == .running { isPulsing = true }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/LogStreamPanel.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/LogStreamPanel.kt
@@ -1,0 +1,238 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.orchestradashboard.shared.domain.model.LogEntry
+import com.orchestradashboard.shared.domain.model.LogLevel
+import com.orchestradashboard.shared.domain.model.LogStreamState
+import com.orchestradashboard.shared.ui.logstream.LogStreamUiState
+import kotlinx.coroutines.launch
+
+private const val MAX_LOG_PANEL_HEIGHT = 320
+private const val BOTTOM_THRESHOLD = 2
+private val WARN_COLOR = Color(0xFFE08B0F)
+private val ERROR_COLOR = Color(0xFFD32F2F)
+private val DEBUG_COLOR = Color(0xFF9E9E9E)
+
+@Composable
+fun LogStreamPanel(
+    uiState: LogStreamUiState,
+    onStopStream: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth().heightIn(max = MAX_LOG_PANEL_HEIGHT.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        LogStreamPanelContent(uiState = uiState, onStopStream = onStopStream)
+    }
+}
+
+@Composable
+private fun LogStreamPanelContent(
+    uiState: LogStreamUiState,
+    onStopStream: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxSize().padding(8.dp)) {
+        LogStreamPanelHeader(
+            stepId = uiState.selectedStepId,
+            onStopStream = onStopStream,
+        )
+
+        when (val state = uiState.streamState) {
+            is LogStreamState.Loading -> LoadingContent()
+            is LogStreamState.Error -> ErrorContent(message = state.message)
+            else -> LogListContent(logs = uiState.logs)
+        }
+    }
+}
+
+@Composable
+private fun LogStreamPanelHeader(
+    stepId: String?,
+    onStopStream: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stepId?.let { "Logs: $it" } ?: "Logs",
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        IconButton(onClick = onStopStream) {
+            Icon(Icons.Default.Close, contentDescription = "Stop streaming")
+        }
+    }
+}
+
+@Composable
+private fun LoadingContent() {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        CircularProgressIndicator(modifier = Modifier.padding(end = 4.dp))
+        Text(
+            text = "Connecting...",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun ErrorContent(message: String) {
+    Text(
+        text = "Stream error: $message",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.error,
+        modifier = Modifier.padding(16.dp),
+    )
+}
+
+@Composable
+private fun LogListContent(logs: List<LogEntry>) {
+    if (logs.isEmpty()) {
+        Text(
+            text = "No logs yet",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(16.dp),
+        )
+        return
+    }
+
+    val listState = rememberLazyListState()
+    val coroutineScope = rememberCoroutineScope()
+    val isAtBottom by remember {
+        derivedStateOf {
+            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            val total = listState.layoutInfo.totalItemsCount
+            total == 0 || lastVisible >= total - BOTTOM_THRESHOLD
+        }
+    }
+
+    LaunchedEffect(logs.size) {
+        if (isAtBottom && logs.isNotEmpty()) {
+            listState.animateScrollToItem(logs.lastIndex)
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        val fallback = MaterialTheme.colorScheme.onSurfaceVariant
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize().padding(horizontal = 8.dp),
+        ) {
+            items(logs) { entry ->
+                Text(
+                    text = formatLogEntry(entry),
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = logLevelColor(entry.level).takeOrElse { fallback },
+                )
+            }
+        }
+
+        if (!isAtBottom && logs.isNotEmpty()) {
+            FloatingActionButton(
+                onClick = {
+                    coroutineScope.launch { listState.animateScrollToItem(logs.lastIndex) }
+                },
+                modifier = Modifier.align(Alignment.BottomEnd).padding(8.dp),
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+            ) {
+                Icon(Icons.Default.KeyboardArrowDown, contentDescription = "Scroll to bottom")
+            }
+        }
+    }
+}
+
+/**
+ * Formats a [LogEntry] for display as a single line. The output contains the extracted
+ * HH:mm:ss timestamp (when parseable from an ISO-8601 string), an optional level marker,
+ * and the message.
+ */
+internal fun formatLogEntry(entry: LogEntry): String {
+    val timePart = extractHmsOrEmpty(entry.timestamp)
+    val levelMarker =
+        when (entry.level) {
+            LogLevel.INFO -> ""
+            LogLevel.WARN -> " WARN"
+            LogLevel.ERROR -> " ERROR"
+            LogLevel.DEBUG -> " DEBUG"
+        }
+    val prefix =
+        when {
+            timePart.isEmpty() && levelMarker.isEmpty() -> ""
+            timePart.isEmpty() -> "[${levelMarker.trim()}] "
+            else -> "[$timePart$levelMarker] "
+        }
+    return "$prefix${entry.message}"
+}
+
+/**
+ * Extracts the HH:mm:ss component from an ISO-8601 timestamp string. Returns an empty
+ * string when the input does not contain a recognizable time component.
+ */
+private fun extractHmsOrEmpty(timestamp: String): String {
+    if (timestamp.isBlank()) return ""
+    val tIndex = timestamp.indexOf('T')
+    val timeSection =
+        if (tIndex >= 0 && tIndex + 1 < timestamp.length) {
+            timestamp.substring(tIndex + 1)
+        } else {
+            timestamp
+        }
+    val hms = timeSection.take(8)
+    val looksLikeHms = hms.length == 8 && hms[2] == ':' && hms[5] == ':'
+    return if (looksLikeHms) hms else ""
+}
+
+/**
+ * Returns a semantic color for a log level. [Color.Unspecified] means the caller should
+ * fall back to the default on-surface text color (used for INFO).
+ */
+internal fun logLevelColor(level: LogLevel): Color =
+    when (level) {
+        LogLevel.INFO -> Color.Unspecified
+        LogLevel.WARN -> WARN_COLOR
+        LogLevel.ERROR -> ERROR_COLOR
+        LogLevel.DEBUG -> DEBUG_COLOR
+    }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/StepNode.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/StepNode.kt
@@ -6,9 +6,12 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
@@ -37,15 +40,30 @@ private const val TIMER_INTERVAL_MS = 1000L
 fun StepNode(
     step: MonitoredStep,
     modifier: Modifier = Modifier,
+    isSelected: Boolean = false,
+    onClick: (() -> Unit)? = null,
 ) {
     val color = stepStatusColor(step.status)
+    val ringColor = MaterialTheme.colorScheme.primary
+
+    val clickableModifier =
+        if (onClick != null) {
+            Modifier.clickable { onClick() }
+        } else {
+            Modifier
+        }
 
     Column(
-        modifier = modifier,
+        modifier = modifier.then(clickableModifier).padding(2.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        StepCircle(step.status, color)
+        StepCircle(
+            status = step.status,
+            color = color,
+            isSelected = isSelected,
+            ringColor = ringColor,
+        )
 
         Text(
             text = step.name,
@@ -63,8 +81,21 @@ fun StepNode(
 private fun StepCircle(
     status: StepStatus,
     color: Color,
+    isSelected: Boolean,
+    ringColor: Color,
     modifier: Modifier = Modifier,
 ) {
+    // Always reserve the 2dp ring space so selecting/deselecting a step does not
+    // shift the layout of neighboring steps. The border is only painted when
+    // `isSelected` is true; the padding always consumes the 2dp.
+    val borderModifier =
+        if (isSelected) {
+            Modifier.border(width = 2.dp, color = ringColor, shape = CircleShape)
+        } else {
+            Modifier
+        }
+    val ringSpacing = Modifier.padding(2.dp)
+
     if (status == StepStatus.RUNNING) {
         val infiniteTransition = rememberInfiniteTransition()
         val alpha by infiniteTransition.animateFloat(
@@ -73,11 +104,22 @@ private fun StepCircle(
             animationSpec = infiniteRepeatable(tween(800), RepeatMode.Reverse),
         )
         Box(
-            modifier = modifier.size(24.dp).alpha(alpha).background(color, CircleShape),
+            modifier =
+                modifier
+                    .then(borderModifier)
+                    .then(ringSpacing)
+                    .size(24.dp)
+                    .alpha(alpha)
+                    .background(color, CircleShape),
         )
     } else {
         Box(
-            modifier = modifier.size(24.dp).background(color, CircleShape),
+            modifier =
+                modifier
+                    .then(borderModifier)
+                    .then(ringSpacing)
+                    .size(24.dp)
+                    .background(color, CircleShape),
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/StepTimeline.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/StepTimeline.kt
@@ -22,6 +22,8 @@ import com.orchestradashboard.shared.domain.model.StepStatus
 fun StepTimeline(
     steps: List<MonitoredStep>,
     modifier: Modifier = Modifier,
+    selectedStepName: String? = null,
+    onStepClick: ((String) -> Unit)? = null,
 ) {
     if (steps.isEmpty()) {
         Text(
@@ -40,7 +42,12 @@ fun StepTimeline(
     ) {
         itemsIndexed(steps) { index, step ->
             Row(verticalAlignment = Alignment.CenterVertically) {
-                StepNode(step = step, modifier = Modifier.width(72.dp))
+                StepNode(
+                    step = step,
+                    modifier = Modifier.width(72.dp),
+                    isSelected = step.name == selectedStepName,
+                    onClick = onStepClick?.let { handler -> { handler(step.name) } },
+                )
 
                 if (index < steps.lastIndex) {
                     StepConnector(step.status)

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/AppNavigation.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/AppNavigation.kt
@@ -14,6 +14,7 @@ import com.orchestradashboard.shared.ui.analytics.AnalyticsViewModel
 import com.orchestradashboard.shared.ui.commandcenter.CommandCenterViewModel
 import com.orchestradashboard.shared.ui.dashboardhome.DashboardHomeViewModel
 import com.orchestradashboard.shared.ui.history.HistoryViewModel
+import com.orchestradashboard.shared.ui.logstream.LogStreamViewModel
 import com.orchestradashboard.shared.ui.pipelinemonitor.PipelineMonitorViewModel
 import com.orchestradashboard.shared.ui.projectexplorer.ProjectExplorerViewModel
 import com.orchestradashboard.shared.ui.settings.SettingsViewModel
@@ -49,6 +50,7 @@ fun AppNavigation(
     projectExplorerViewModelFactory: () -> ProjectExplorerViewModel,
     solveDialogViewModelFactory: () -> SolveDialogViewModel,
     pipelineMonitorViewModelFactory: (String) -> PipelineMonitorViewModel,
+    logStreamViewModelFactory: () -> LogStreamViewModel,
     commandCenterViewModelFactory: () -> CommandCenterViewModel,
     settingsViewModelFactory: () -> SettingsViewModel,
     historyViewModelFactory: () -> HistoryViewModel,
@@ -131,11 +133,19 @@ fun AppNavigation(
                 remember(screen.pipelineId) {
                     pipelineMonitorViewModelFactory(screen.pipelineId)
                 }
+            val logVm =
+                remember(screen.pipelineId) {
+                    logStreamViewModelFactory()
+                }
             DisposableEffect(screen.pipelineId) {
-                onDispose { vm.onCleared() }
+                onDispose {
+                    vm.onCleared()
+                    logVm.onCleared()
+                }
             }
             PipelineMonitorScreen(
                 viewModel = vm,
+                logStreamViewModel = logVm,
                 onBackClick = { currentScreen = Screen.DashboardHome },
                 modifier = modifier,
             )

--- a/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/PipelineMonitorScreen.kt
+++ b/shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/PipelineMonitorScreen.kt
@@ -1,5 +1,6 @@
 package com.orchestradashboard.shared.ui.screen
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -26,18 +27,22 @@ import com.orchestradashboard.shared.ui.component.ApprovalDialog
 import com.orchestradashboard.shared.ui.component.ErrorBanner
 import com.orchestradashboard.shared.ui.component.LiveLogPanel
 import com.orchestradashboard.shared.ui.component.LoadingOverlay
+import com.orchestradashboard.shared.ui.component.LogStreamPanel
 import com.orchestradashboard.shared.ui.component.ParallelPipelineView
 import com.orchestradashboard.shared.ui.component.StepTimeline
+import com.orchestradashboard.shared.ui.logstream.LogStreamViewModel
 import com.orchestradashboard.shared.ui.pipelinemonitor.PipelineMonitorViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PipelineMonitorScreen(
     viewModel: PipelineMonitorViewModel,
+    logStreamViewModel: LogStreamViewModel,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val logStreamState by logStreamViewModel.uiState.collectAsState()
 
     LaunchedEffect(Unit) {
         viewModel.loadPipeline()
@@ -120,14 +125,33 @@ fun PipelineMonitorScreen(
                     StepTimeline(
                         steps = uiState.pipeline!!.steps,
                         modifier = Modifier.fillMaxWidth(),
+                        selectedStepName = logStreamState.selectedStepId,
+                        onStepClick = { stepName ->
+                            if (logStreamState.selectedStepId == stepName) {
+                                logStreamViewModel.stopStream()
+                            } else {
+                                logStreamViewModel.startStream(stepName)
+                            }
+                        },
                     )
                 }
             }
 
-            LiveLogPanel(
-                logLines = uiState.logLines,
-                modifier = Modifier.fillMaxWidth().weight(1f).padding(horizontal = 16.dp),
-            )
+            val hasSelectedStep = logStreamState.selectedStepId != null
+            AnimatedVisibility(visible = hasSelectedStep) {
+                LogStreamPanel(
+                    uiState = logStreamState,
+                    onStopStream = { logStreamViewModel.stopStream() },
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                )
+            }
+
+            if (!hasSelectedStep) {
+                LiveLogPanel(
+                    logLines = uiState.logLines,
+                    modifier = Modifier.fillMaxWidth().weight(1f).padding(horizontal = 16.dp),
+                )
+            }
         }
     }
 }

--- a/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/component/LogStreamPanelStateTest.kt
+++ b/shared/src/commonTest/kotlin/com/orchestradashboard/shared/ui/component/LogStreamPanelStateTest.kt
@@ -1,0 +1,105 @@
+package com.orchestradashboard.shared.ui.component
+
+import androidx.compose.ui.graphics.Color
+import com.orchestradashboard.shared.domain.model.LogEntry
+import com.orchestradashboard.shared.domain.model.LogLevel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class LogStreamPanelStateTest {
+    private fun entry(
+        timestamp: String = "2026-04-23T10:15:30Z",
+        level: LogLevel = LogLevel.INFO,
+        message: String = "hello world",
+        stepId: String = "step-1",
+    ): LogEntry =
+        LogEntry(
+            timestamp = timestamp,
+            level = level,
+            message = message,
+            stepId = stepId,
+        )
+
+    // ─── formatLogEntry ───────────────────────────────────────────────────────
+
+    @Test
+    fun `formatLogEntry formats INFO entry with HH-mm-ss prefix`() {
+        val result = formatLogEntry(entry(timestamp = "2026-04-23T10:15:30Z", level = LogLevel.INFO, message = "ok"))
+        assertEquals("[10:15:30] ok", result)
+    }
+
+    @Test
+    fun `formatLogEntry formats ERROR entry with ERROR marker`() {
+        val result =
+            formatLogEntry(entry(timestamp = "2026-04-23T01:02:03Z", level = LogLevel.ERROR, message = "boom"))
+        assertTrue(result.contains("ERROR"), "expected ERROR marker but was '$result'")
+        assertTrue(result.contains("boom"))
+        assertTrue(result.contains("01:02:03"))
+    }
+
+    @Test
+    fun `formatLogEntry formats WARN entry with WARN marker`() {
+        val result =
+            formatLogEntry(entry(timestamp = "2026-04-23T23:59:59Z", level = LogLevel.WARN, message = "careful"))
+        assertTrue(result.contains("WARN"), "expected WARN marker but was '$result'")
+        assertTrue(result.contains("careful"))
+        assertTrue(result.contains("23:59:59"))
+    }
+
+    @Test
+    fun `formatLogEntry formats DEBUG entry with DEBUG marker`() {
+        val result =
+            formatLogEntry(entry(timestamp = "2026-04-23T00:00:00Z", level = LogLevel.DEBUG, message = "trace"))
+        assertTrue(result.contains("DEBUG"), "expected DEBUG marker but was '$result'")
+        assertTrue(result.contains("trace"))
+    }
+
+    @Test
+    fun `formatLogEntry handles blank timestamp gracefully`() {
+        val result = formatLogEntry(entry(timestamp = "", level = LogLevel.INFO, message = "hi"))
+        assertNotNull(result)
+        assertTrue(result.contains("hi"), "message should still be preserved but was '$result'")
+    }
+
+    @Test
+    fun `formatLogEntry handles malformed timestamp gracefully`() {
+        val result = formatLogEntry(entry(timestamp = "not-a-timestamp", level = LogLevel.INFO, message = "hi"))
+        assertNotNull(result)
+        assertTrue(result.contains("hi"))
+    }
+
+    // ─── logLevelColor ────────────────────────────────────────────────────────
+
+    @Test
+    fun `logLevelColor returns Unspecified for INFO`() {
+        assertEquals(Color.Unspecified, logLevelColor(LogLevel.INFO))
+    }
+
+    @Test
+    fun `logLevelColor returns a warning hued color for WARN`() {
+        val color = logLevelColor(LogLevel.WARN)
+        // Orange-ish: red and green high, blue low
+        assertTrue(color.red > 0.6f, "expected high red channel but was ${color.red}")
+        assertTrue(color.green > 0.3f, "expected moderate green channel but was ${color.green}")
+        assertTrue(color.blue < 0.3f, "expected low blue channel but was ${color.blue}")
+    }
+
+    @Test
+    fun `logLevelColor returns a red hued color for ERROR`() {
+        val color = logLevelColor(LogLevel.ERROR)
+        assertTrue(color.red > 0.7f, "expected high red channel but was ${color.red}")
+        assertTrue(color.green < 0.4f, "expected low green channel but was ${color.green}")
+        assertTrue(color.blue < 0.4f, "expected low blue channel but was ${color.blue}")
+    }
+
+    @Test
+    fun `logLevelColor returns a gray hued color for DEBUG`() {
+        val color = logLevelColor(LogLevel.DEBUG)
+        // Gray: all channels roughly equal and moderate
+        val max = maxOf(color.red, color.green, color.blue)
+        val min = minOf(color.red, color.green, color.blue)
+        assertTrue(max - min < 0.2f, "expected near-gray channels but was r=${color.red} g=${color.green} b=${color.blue}")
+    }
+}


### PR DESCRIPTION
Closes #129

## Design
I now have complete understanding of the codebase. Here's the design document.

---

# Design Document: Live Log Streaming UI (Compose + SwiftUI)

## SECTION A: Design Document

### 1. Files to Create/Modify

**New Files:**

| # | Path | Purpose |
|---|------|---------|
| 1 | `shared/src/commonMain/.../ui/component/LogStreamPanel.kt` | Compose log panel with auto-scroll, scroll lock, level coloring |
| 2 | `shared/src/commonTest/.../ui/component/LogStreamPanelStateTest.kt` | Unit tests for auto-scroll logic & state helpers |
| 3 | `iosApp/iosApp/components/LogStreamPanelView.swift` | SwiftUI log panel |
| 4 | `iosApp/iosApp/IOSLogStreamViewModel.swift` | iOS ObservableObject wrapping KMP `LogStreamViewModel` |

**Modified Files:**

| # | Path | Change |
|---|------|--------|
| 5 | `shared/.../ui/component/StepTimeline.kt` | Add `onStepClick: (String) -> Unit` + `selectedStepName` params |
| 6 | `shared/.../ui/component/StepNode.kt` | Add `isSelected` + `onClick` params, visual selection ring |
| 7 | `shared/.../ui/screen/PipelineMonitorScreen.kt` | Wire `LogStreamViewModel`, replace `LiveLogPanel` with `LogStreamPanel`, pass step selection callbacks |
| 8 | `shared/.../ui/screen/AppNavigation.kt` | Add `logStreamViewModelFactory` param, create/dispose `LogStreamViewModel` in `PipelineMonitor` case |
| 9 | `iosApp/iosApp/components/StepTimelineView.swift` | Add `onStepTap` + `selectedStepName` params |
| 10 | `iosApp/iosApp/PipelineMonitorView.swift` | Wire `IOSLogStreamViewMo

_(truncated)_

## Changed Files (13)
- `_workspace/02_developer_log.md`
- `_workspace/03_ci_report.md`
- `androidApp/src/main/kotlin/com/orchestradashboard/android/App.kt`
- `desktopApp/src/main/kotlin/com/orchestradashboard/desktop/Main.kt`
- `iosApp/iosApp/IOSAppContainer.swift`
- `iosApp/iosApp/IOSLogStreamViewModel.swift`
- `iosApp/iosApp/PipelineMonitorView.swift`
- `iosApp/iosApp/components/LogStreamPanelView.swift`
- `iosApp/iosApp/components/StepTimelineView.swift`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/LogStreamPanel.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/StepNode.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/component/StepTimeline.kt`
- `shared/src/commonMain/kotlin/com/orchestradashboard/shared/ui/screen/AppNavigation.kt`

## Review
All acceptance criteria are satisfied and all CI checks pass cleanly:

- `AppNavigation.kt` — the `DisposableEffect` block is complete (`logVm.onCleared()` is present; the diff was just truncated in the review prompt)
- All 10 tests in `LogStreamPanelStateTest` pass
- `./gradlew :shared:desktopTest`, `ktlintCheck`, `detekt`, and `:shared:compileKotlinDesktop` all build successfully with no new failures

No changes were needed — the implementation is complete and correct.


## AI Audit: PASS
### Acceptance Criteria Evaluation:

#### **Compose (Desktop/Android)**  
- [PASS] `StepTimeline` accepts `onStepClick: ((String) -> Unit)?` and `selectedStepName: String?` parameters with null defaults (backward compatible).  
- [PASS] `StepNode` renders a visual selection indicator (border/ring) when `isSelected = true`.  
- [PASS] Clicking a step node in StepTimeline calls `onStepClick` with the step's `name`.  
- [PASS] `LogStreamPanel` composable exists and accepts `LogStreamUiState` + `onStopStream` callback.  
- [PASS] `LogStreamPanel` renders `CircularProgressIndicator` when `streamState` is `Loading`.  
- [PASS] `LogStreamPanel` renders error message when `streamState` is `Error`.  
- [PASS] `LogStreamPanel` renders `LazyColumn` of log entries with monospace font when `streamState` is `Streaming` and logs are non-empty.  
- [PASS] `LogStreamPanel` shows "No logs yet" placeholder when `streamState` is `Streaming` and `logs` is empty.  
- [PASS] Each log entry row displays times

_(truncated)_